### PR TITLE
Added redirect_history property to HTTPResponse instances

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -121,6 +121,17 @@ class TestingApp(WSGIHandler):
         headers = [('Location', target)]
         return Response(status='303 See Other', headers=headers)
 
+    def multi_redirect(self, request):
+        "Performs a redirect chain based on ``redirect_codes``"
+        codes = request.params.get('redirect_codes', '200')
+        codes = codes.split(',')
+        head, tail = codes[0], codes[1:]
+        if not tail:
+            return Response("Done redirecting", status=head)
+
+        headers = [('Location', '/multi_redirect?redirect_codes=%s' % ','.join(tail))]
+        return Response(status=head, headers=headers)
+
     def keepalive(self, request):
         if request.params.get('close', b'0') == b'1':
             headers = [('Connection', 'close')]

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -123,7 +123,7 @@ class TestingApp(WSGIHandler):
 
     def multi_redirect(self, request):
         "Performs a redirect chain based on ``redirect_codes``"
-        codes = request.params.get('redirect_codes', '200')
+        codes = request.params.get('redirect_codes', '200').decode('utf-8')
         codes = codes.split(',')
         head, tail = codes[0], codes[1:]
         if not tail:

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -28,6 +28,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         self.assertEqual(r.status, 200)
         self.assertEqual(r.data, b'Dummy server!')
+        self.assertEqual(r.redirect_history, [(303, '%s/' % self.base_url)])
 
     def test_redirect_twice(self):
         http = PoolManager()
@@ -43,6 +44,10 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         self.assertEqual(r.status, 200)
         self.assertEqual(r.data, b'Dummy server!')
+        self.assertEqual(r.redirect_history, [
+            (303, '%s/redirect?target=%s/' % (self.base_url, self.base_url)),
+            (303, '%s/' % (self.base_url))
+        ])
 
     def test_redirect_to_relative_url(self):
         http = PoolManager()
@@ -58,6 +63,10 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         self.assertEqual(r.status, 200)
         self.assertEqual(r.data, b'Dummy server!')
+        self.assertEqual(r.redirect_history, [
+            (303, '%s/redirect' % self.base_url),
+            (303, '%s/' % self.base_url)
+        ])
 
     def test_cross_host_redirect(self):
         http = PoolManager()

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -160,6 +160,9 @@ class PoolManager(RequestMethods):
 
         # Support relative URLs for redirecting.
         redirect_location = urljoin(url, redirect_location)
+        redirect_history = kw.get('redirect_history', [])
+        redirect_history.append((response.status, redirect_location))
+        kw['redirect_history'] = redirect_history
 
         # RFC 2616, Section 10.3.4
         if response.status == 303:

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -79,7 +79,8 @@ class HTTPResponse(io.IOBase):
 
     def __init__(self, body='', headers=None, status=0, version=0, reason=None,
                  strict=0, preload_content=True, decode_content=True,
-                 original_response=None, pool=None, connection=None):
+                 original_response=None, pool=None, connection=None,
+                 redirect_history=None):
 
         self.headers = HTTPHeaderDict()
         if headers:
@@ -89,6 +90,7 @@ class HTTPResponse(io.IOBase):
         self.reason = reason
         self.strict = strict
         self.decode_content = decode_content
+        self.redirect_history = redirect_history
 
         self._decoder = None
         self._body = body if body and isinstance(body, basestring) else None


### PR DESCRIPTION
Hey guys, first of all, thank you for your awesome work on urllib3.

One thing I missed though was being able to figure out what were the redirects my request had to jump through before arriving at the final destination, and what was this final destination.

To solve this problem I added a new property to instances of HTTPResponse called `redirect_history`. It contains a list of tuples with each status code and redirect location sent by the servers before the request was completed. I also added some test cases to illustrate this behavior.

Please let me know if you think this useful. I'm open to any changes you might require, just let me know and I'll work on it.
