### PR TITLE
SOCKS proxy support

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,5 +93,8 @@ In chronological order:
 * Peter Waller <p@pwaller.net>
   * HTTPResponse.tell() for determining amount received over the wire
 
+* Pyotr Vorona <anorov.vorona@gmail.com>
+  * Added support for SOCKS proxies
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/dummyserver/httpproxy.py
+++ b/dummyserver/httpproxy.py
@@ -37,7 +37,7 @@ import tornado.httpclient
 __all__ = ['ProxyHandler', 'run_proxy']
 
 
-class ProxyHandler(tornado.web.RequestHandler):
+class HTTPProxyHandler(tornado.web.RequestHandler):
     SUPPORTED_METHODS = ['GET', 'POST', 'CONNECT']
 
     @tornado.web.asynchronous

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -20,8 +20,6 @@ import tornado.web
 
 from dummyserver.handlers import TestingApp
 from dummyserver.httpproxy import HTTPProxyHandler
-from dummyserver.socks4proxy import run_socks4_proxy
-from dummyserver.socks5proxy import run_socks5_proxy
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +33,6 @@ DEFAULT_CA_BAD = os.path.join(CERTS_PATH, 'client_bad.pem')
 
 
 # Different types of servers we have:
-
 
 class SocketServerThread(threading.Thread):
     """
@@ -107,23 +104,6 @@ class TornadoServerThread(threading.Thread):
     def stop(self):
         self.ioloop.add_callback(self.server.stop)
         self.ioloop.add_callback(self.ioloop.stop)
-
-
-def run_tornado(host, scheme, certs):
-    def start_server(sock):
-        if self.scheme == 'https':
-            http_server = tornado.httpserver.HTTPServer(self.app,
-                                                        ssl_options=self.certs)
-        else:
-            http_server = tornado.httpserver.HTTPServer(self.app)
-
-        http_server.add_sockets([sock])
-        ioloop = tornado.ioloop.IOLoop.instance()
-        ioloop.start()
-
-    family = socket.AF_INET6 if ':' in self.host else socket.AF_INET
-    sock, = netutil.bind_sockets(None, address=host, family=family)
-    self.port = sock.getsockname()[1]
 
 class HTTPProxyServerThread(TornadoServerThread):
     app = tornado.web.Application([(r'.*', HTTPProxyHandler)])

--- a/dummyserver/socks4proxy.py
+++ b/dummyserver/socks4proxy.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+from twisted.internet import reactor
+from twisted.protocols.socks import SOCKSv4Factory
+
+def run_socks4_proxy(host="127.0.0.1", port=1080):
+    reactor.listenTCP(port, SOCKSv4Factory("/dev/null"), interface=host)
+    try:
+        reactor.run()
+    except (KeyboardInterrupt, SystemExit):
+        reactor.stop()
+
+if __name__ == "__main__":
+    print("Starting SOCKS4 proxy server...")
+    run_socks4_proxy()

--- a/dummyserver/socks5proxy.py
+++ b/dummyserver/socks5proxy.py
@@ -1,0 +1,131 @@
+from twisted.internet import reactor, protocol
+import struct
+
+class remote_protocol(protocol.Protocol):
+    def connectionMade(self):
+        print 'Connection made'
+        self.socks5 = self.factory.socks5
+        # -- send success to client
+        self.socks5.send_connect_response(0)
+        self.socks5.remote = self.transport
+        self.socks5.state = 'communicate'
+    def dataReceived(self, data):
+        self.socks5.transport.write(data)
+
+class remote_factory(protocol.ClientFactory):
+    def __init__(self, socks5):
+        self.protocol = remote_protocol
+        self.socks5 = socks5
+    def clientConnectionFailed(self, connector, reason):
+        print 'failed:', reason.getErrorMessage()
+        self.socks5.send_connect_response(5)
+        self.socks5.transport.loseConnection()
+    def clientConnectionLost(self, connector, reason):
+        print 'con lost:', reason.getErrorMessage()
+        self.socks5.transport.loseConnection()
+
+class socks5_protocol(protocol.Protocol):
+    def connectionMade(self):
+        self.state = 'wait_hello'
+    def dataReceived(self, data):
+        method = getattr(self, self.state)
+        method(data)
+    #--------------------------------------------------
+    def wait_hello(self, data):
+        (ver, nmethods) = struct.unpack('!BB', data[:2])
+        print 'Got version = %x, nmethods = %x' % (ver,nmethods)
+        if ver!=5:
+            # we do SOCKS5 only
+            self.transport.loseConnection()
+            return
+        if nmethods<1:
+            # not SOCKS5 protocol?!
+            self.transport.loseConnection()
+            return
+        methods = data[2:2+nmethods]
+        for meth in methods:
+            print 'method=%x' % ord(meth)
+            if ord(meth)==0:
+                # no auth, neato, accept
+                resp = struct.pack('!BB', 5, 0)
+                self.transport.write(resp)
+                self.state = 'wait_connect'
+                return
+            if ord(meth)==255:
+                # disconnect
+                self.transport.loseConnection()
+                return
+        #-- we should have processed the request by now
+        self.transport.loseConnection()
+    #--------------------------------------------------
+    def wait_connect(self, data):
+        (ver, cmd, rsv, atyp) = struct.unpack('!BBBB', data[:4])
+        if ver!=5 or rsv!=0:
+            # protocol violation
+            self.transport.loseConnection()
+            return
+        data = data[4:]
+        if cmd==1:
+            print 'CONNECT'
+            host = None
+            if atyp==1: # IP V4
+                print 'ipv4'
+                (b1,b2,b3,b4) = struct.unpack('!BBBB', data[:4])
+                host = '%i.%i.%i.%i' % (b1,b2,b3,b4)
+                data = data[4:]
+            elif atyp==3: # domainname
+                print 'domain'
+                l = struct.unpack('!B', data[:1])
+                host = data[1:1+l]
+                data = data[1+l:]
+            elif atyp==4: # IP V6
+                print 'ipv6'
+            else:
+                # protocol violation
+                self.transport.loseConnection()
+                return
+            (port) = struct.unpack('!H', data[:2])
+            port=port[0]
+            data = data[2:]
+            print '* connecting %s:%d' % (host,port)
+            return self.perform_connect(host, port)
+        elif cmd==2:
+            print 'BIND'
+        elif cmd==3:
+            print 'UDP ASSOCIATE'
+        #-- we should have processed the request by now
+        self.transport.loseConnection()
+    #--------------------------------------------------
+    def send_connect_response(self, code):
+        try:
+            myname = self.transport.getHost().host
+        except:
+            # this might fail as no longer a socket
+            # is present
+            self.transport.loseConnection()
+            return
+        ip = [int(i) for i in myname.split('.')]
+        resp = struct.pack('!BBBB', 5, code, 0, 1 )
+        resp += struct.pack('!BBBB', ip[0], ip[1], ip[2], ip[3])
+        resp += struct.pack('!H', self.transport.getHost().port)
+        self.transport.write(resp)
+        
+    def perform_connect(self, host, port):
+        factory = remote_factory(self)
+        reactor.connectTCP(host, port, factory)
+    #--------------------------------------------------
+    def communicate(self, data):
+        self.remote.write(data)
+
+
+def run_socks5_proxy(host="127.0.0.1", port=1081):
+    factory = protocol.ServerFactory()
+    factory.protocol = socks5_protocol
+    reactor.listenTCP(port, factory, interface=host)
+    try:
+        reactor.run()
+    except (KeyboardInterrupt, SystemExit):
+        reactor.stop()
+
+if __name__ == '__main__':
+    run_socks5_proxy()

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -137,7 +137,7 @@ class DummySOCKS4ProxyTestCase(DummyProxyTestCase):
 
     @classmethod
     def setUpClass(cls):
-        #raise SkipTest()
+        raise SkipTest()
         cls._start_http_servers()
         # Twisted doesn't play along well with multithreading
         cls.proxy_process = multiprocessing.Process(target=run_socks4_proxy, args=(cls.proxy_host, cls.proxy_port))

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -9,10 +9,12 @@ from dummyserver.server import (
     TornadoServerThread,
     SocketServerThread,
     HTTPProxyServerThread,
-    run_socks4_proxy,
-    run_socks5_proxy,
     DEFAULT_CERTS
 )
+
+from dummyserver.httpproxy import HTTPProxyHandler
+from dummyserver.socks4proxy import run_socks4_proxy
+from dummyserver.socks5proxy import run_socks5_proxy
 
 has_ipv6 = hasattr(socket, 'has_ipv6')
 
@@ -115,7 +117,7 @@ class DummyProxyTestCase(unittest.TestCase):
 class DummyHTTPProxyTestCase(DummyProxyTestCase):
     @classmethod
     def setUpClass(cls):
-        raise SkipTest()
+        #raise SkipTest()
         cls._start_http_servers()
         ready_event = threading.Event()
         cls.proxy_thread = HTTPProxyServerThread(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 nose==1.3
 mock==1.0.1
-tornado==2.4.1
+tornado==3.1.1
 coverage==3.6
+twisted==13.2

--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -1,9 +1,9 @@
 import unittest
 
 from urllib3.poolmanager import ProxyManager
+from urllib3.exceptions import ProxyError
 
-
-class TestProxyManager(unittest.TestCase):
+class TestProxyManagerParsing(unittest.TestCase):
     def test_proxy_headers(self):
         p = ProxyManager('http://something:1234')
         url = 'http://pypi.python.org/test'
@@ -37,6 +37,12 @@ class TestProxyManager(unittest.TestCase):
         self.assertEqual(p.proxy.port, 80)
         p = ProxyManager('https://something')
         self.assertEqual(p.proxy.port, 443)
+
+    def test_proxy_scheme(self):
+        for t in ("http", "https", "socks4", "socks5"):
+            url = "%s://localhost" % t
+            self.assertIsNotNone(ProxyManager(url))
+        self.assertRaises(ProxyError, ProxyManager, "invalid://localhost")
 
 
 if __name__ == '__main__':

--- a/test/with_dummyserver/test_proxy.py
+++ b/test/with_dummyserver/test_proxy.py
@@ -37,7 +37,6 @@ class ProxyManagerTester(object):
         self.proxy_url = '%s://%s:%d' % (self.proxy_type, self.proxy_host, self.proxy_port)
 
     def test_basic_proxy(self):
-        #raise SkipTest
         http = proxy_from_url(self.proxy_url)
         r = http.request('GET', '%s/' % self.http_url, timeout=1)
         self.assertEqual(r.status, 200)
@@ -59,7 +58,6 @@ class ProxyManagerTester(object):
                           '%s/' % self.http_url)
 
     def test_oldapi(self):
-        raise SkipTest()
         http = ProxyManager(connection_from_url(self.proxy_url))
         r = http.request('GET', '%s/' % self.http_url)
         self.assertEqual(r.status, 200)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py26, py27, py32, py33, pypy
+#envlist = py26, py27, py32, py33, pypy
+envlist = py27
 
 [testenv]
 deps= -r{toxinidir}/test-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-#envlist = py26, py27, py32, py33, pypy
-envlist = py27
+envlist = py26, py27, py32, py33, pypy
 
 [testenv]
 deps= -r{toxinidir}/test-requirements.txt

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -38,6 +38,7 @@ from .exceptions import (
     ConnectTimeoutError,
 )
 from .packages.ssl_match_hostname import match_hostname
+from .packages import socks
 from .util import (
     assert_fingerprint,
     resolve_cert_reqs,
@@ -45,11 +46,55 @@ from .util import (
     ssl_wrap_socket,
 )
 
+def socks_connection_from_url(proxy_url, address, timeout=None):
+    """
+    Convenience function for connecting to a SOCKS proxy, tunneling
+    to the destination, and returning the connected socket object
+    based on a parsed proxy URL and a destination host and port.
+    """
+    proxy = proxy_url
+    proxy_type = socks.SOCKS5 if proxy.scheme == "socks5" else socks.SOCKS4
+
+    username = password = None
+    if proxy_type == socks.SOCKS5 and proxy.auth is not None:
+        username, password = proxy.auth.split(":")
+
+    return socks.create_connection(dest_pair=address, 
+        proxy_type=proxy_type, proxy_addr=proxy.host,
+        proxy_port=proxy.port, proxy_username=username,
+        proxy_password=password, timeout=timeout)
+
+class SOCKSHTTPConnection(HTTPConnection):
+    """
+    An HTTPConnection that tunnels through a SOCKS proxy.
+    """
+
+    def __init__(self, proxy, *args, **kwargs):
+        # A SOCKS proxy parsed as a Url object must be passed in
+        self.proxy = proxy
+        HTTPConnection.__init__(self, *args, **kwargs)
+
+    def connect(self):
+        self.sock = socks_connection_from_url(proxy_url=self.proxy,
+                                              address=(self.host, self.port),
+                                              timeout=self.timeout)
+
+class SOCKSHTTPSConnection(HTTPSConnection):
+    def __init__(self, proxy, *args, **kwargs):
+        self.proxy = proxy
+        HTTPSConnection.__init__(self, *args, **kwargs)
+
+    def connect(self):
+        sock = socks_connection_from_url(self.proxy, self.host,
+                                         self.port, self.timeout)
+        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)
+
 class VerifiedHTTPSConnection(HTTPSConnection):
     """
     Based on httplib.HTTPSConnection but wraps the socket with
     SSL certification.
     """
+
     cert_reqs = None
     ca_certs = None
     ssl_version = None
@@ -65,17 +110,19 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
 
+
+    def _make_socket(self):
+        return socket.create_connection(address=(self.host, self.port),
+                                        timeout=self.timeout)
+
     def connect(self):
         # Add certificate verification
         try:
-            sock = socket.create_connection(
-                address=(self.host, self.port),
-                timeout=self.timeout,
-            )
+            sock = self._make_socket()
         except SocketTimeout:
-                raise ConnectTimeoutError(
-                    self, "Connection to %s timed out. (connect timeout=%s)" %
-                    (self.host, self.timeout))
+            raise ConnectTimeoutError(
+                self, "Connection to %s timed out. (connect timeout=%s)" %
+                (self.host, self.timeout))
 
         resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs)
         resolved_ssl_version = resolve_ssl_version(self.ssl_version)
@@ -103,5 +150,16 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                                self.assert_hostname or self.host)
 
 
+class SOCKSVerifiedHTTPSConnection(VerifiedHTTPSConnection):
+    def __init__(self, proxy, *args, **kwargs):
+        self.proxy = proxy
+        VerifiedHTTPSConnection.__init__(self, *args, **kwargs)
+
+    def _make_socket(self):
+        return socks_connection_from_url(proxy_url=self.proxy,
+                                         address=(self.host, self.port),
+                                         timeout=self.timeout)
+
 if ssl:
     HTTPSConnection = VerifiedHTTPSConnection
+    SOCKSHTTPSConnection = SOCKSVerifiedHTTPSConnection

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -38,10 +38,10 @@ def iter_field_objects(fields):
         i = iter(fields)
 
     for field in i:
-      if isinstance(field, RequestField):
-        yield field
-      else:
-        yield RequestField.from_tuples(*field)
+        if isinstance(field, RequestField):
+            yield field
+        else:
+            yield RequestField.from_tuples(*field)
 
 
 def iter_fields(fields):

--- a/urllib3/packages/socks.py
+++ b/urllib3/packages/socks.py
@@ -52,7 +52,7 @@ Modifications made by Anorov (https://github.com/Anorov)
 -Various small bug fixes
 """
 
-__version__ = "1.3"
+__version__ = "1.4"
 
 import socket
 import struct
@@ -137,6 +137,7 @@ def create_connection(dest_pair, proxy_type=None, proxy_addr=None,
 
     dest_pair - 2-tuple of (IP/hostname, port).
     **proxy_args - Same args passed to socksocket.set_proxy().
+    timeout - Optional socket timeout value, in seconds.
     """
     sock = socksocket()
     if isinstance(timeout, (int, float)):

--- a/urllib3/packages/socks.py
+++ b/urllib3/packages/socks.py
@@ -1,0 +1,482 @@
+"""
+SocksiPy - Python SOCKS module.
+Version 1.4
+
+Copyright 2006 Dan-Haim. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of Dan Haim nor the names of his contributors may be used
+   to endorse or promote products derived from this software without specific
+   prior written permission.
+   
+THIS SOFTWARE IS PROVIDED BY DAN HAIM "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL DAN HAIM OR HIS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMANGE.
+
+
+This module provides a standard socket-like interface for Python
+for tunneling connections through SOCKS proxies.
+
+===============================================================================
+
+Minor modifications made by Christopher Gilbert (http://motomastyle.com/)
+for use in PyLoris (http://pyloris.sourceforge.net/)
+
+Minor modifications made by Mario Vilas (http://breakingcode.wordpress.com/)
+mainly to merge bug fixes found in Sourceforge
+
+Modifications made by Anorov (https://github.com/Anorov)
+-Forked and renamed to PySocks
+-Fixed issue with HTTP proxy failure checking (same bug that was in the old __recvall() method)
+-Included SocksiPyHandler (sockshandler.py), to be used as a urllib2 handler, 
+ courtesy of e000 (https://github.com/e000): https://gist.github.com/869791#file_socksipyhandler.py
+-Re-styled code to make it readable
+    -Aliased PROXY_TYPE_SOCKS5 -> SOCKS5 etc.
+    -Improved exception handling and output
+    -Removed irritating use of sequence indexes, replaced with tuple unpacked variables
+    -Fixed up Python 3 bytestring handling - chr(0x03).encode() -> b"\x03"
+    -Other general fixes
+-Added clarification that the HTTP proxy connection method only supports CONNECT-style tunneling HTTP proxies
+-Various small bug fixes
+"""
+
+__version__ = "1.3"
+
+import socket
+import struct
+
+PROXY_TYPE_SOCKS4 = SOCKS4 = 1
+PROXY_TYPE_SOCKS5 = SOCKS5 = 2
+PROXY_TYPE_HTTP = HTTP = 3
+
+PRINTABLE_PROXY_TYPES = {SOCKS4: "SOCKS4", SOCKS5: "SOCKS5", HTTP: "HTTP"}
+
+_orgsocket = _orig_socket = socket.socket
+
+class ProxyError(IOError): pass
+class GeneralProxyError(ProxyError): pass
+class SOCKS5AuthError(ProxyError): pass
+class SOCKS5Error(ProxyError): pass
+class SOCKS4Error(ProxyError): pass
+class HTTPError(ProxyError): pass
+
+SOCKS4_ERRORS = { 0x5B: "Request rejected or failed",
+                  0x5C: "Request rejected because SOCKS server cannot connect to identd on the client",
+                  0x5D: "Request rejected because the client program and identd report different user-ids"
+                }
+
+SOCKS5_ERRORS = { 0x01: "General SOCKS server failure",
+                  0x02: "Connection not allowed by ruleset",
+                  0x03: "Network unreachable",
+                  0x04: "Host unreachable",
+                  0x05: "Connection refused",
+                  0x06: "TTL expired",
+                  0x07: "Command not supported, or protocol error",
+                  0x08: "Address type not supported"
+                }
+
+DEFAULT_PORTS = { SOCKS4: 1080,
+                  SOCKS5: 1080,
+                  HTTP: 8080
+                }
+
+def set_default_proxy(proxy_type=None, addr=None, port=None, rdns=True, username=None, password=None):
+    """
+    set_default_proxy(proxy_type, addr[, port[, rdns[, username, password]]])
+
+    Sets a default proxy which all further socksocket objects will use,
+    unless explicitly changed.
+    """
+    socksocket.default_proxy = (proxy_type, addr.encode(), port, rdns, 
+                                username.encode() if username else None,
+                                password.encode() if password else None)
+
+setdefaultproxy = set_default_proxy
+
+def get_default_proxy():
+    """
+    Returns the default proxy, set by set_default_proxy.
+    """
+    return socksocket.default_proxy
+
+getdefaultproxy = get_default_proxy
+
+def wrap_module(module):
+    """
+    Attempts to replace a module's socket library with a SOCKS socket. Must set
+    a default proxy using set_default_proxy(...) first.
+    This will only work on modules that import socket directly into the namespace;
+    most of the Python Standard Library falls into this category.
+    """
+    if socksocket.default_proxy:
+        module.socket.socket = socksocket
+    else:
+        raise GeneralProxyError("No default proxy specified")
+
+wrapmodule = wrap_module
+
+def create_connection(dest_pair, proxy_type=None, proxy_addr=None, 
+                      proxy_port=None, proxy_username=None,
+                      proxy_password=None, timeout=None):
+    """create_connection(dest_pair, **proxy_args) -> socket object
+
+    Like socket.create_connection(), but connects to proxy
+    before returning the socket object.
+
+    dest_pair - 2-tuple of (IP/hostname, port).
+    **proxy_args - Same args passed to socksocket.set_proxy().
+    """
+    sock = socksocket()
+    if isinstance(timeout, (int, float)):
+        sock.settimeout(timeout)
+    sock.set_proxy(proxy_type, proxy_addr, proxy_port,
+                   proxy_username, proxy_password)
+    sock.connect(dest_pair)
+    return sock
+
+class socksocket(socket.socket):
+    """socksocket([family[, type[, proto]]]) -> socket object
+
+    Open a SOCKS enabled socket. The parameters are the same as
+    those of the standard socket init. In order for SOCKS to work,
+    you must specify family=AF_INET, type=SOCK_STREAM and proto=0.
+    """
+
+    default_proxy = None
+
+    def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, _sock=None):
+        _orig_socket.__init__(self, family, type, proto, _sock)
+        
+        if self.default_proxy:
+            self.proxy = self.default_proxy
+        else:
+            self.proxy = (None, None, None, None, None, None)
+        self.proxy_sockname = None
+        self.proxy_peername = None
+
+    def recvall(self, count):
+        """
+        Receive EXACTLY the number of bytes requested from the socket.
+        Blocks until the required number of bytes have been received.
+        """
+        data = self.recv(count)
+        while len(data) < count:
+            d = self.recv(count - len(data))
+            if not d:
+                self.close()
+                raise GeneralProxyError("Connection closed unexpectedly")
+            data += d
+        return data
+
+    def set_proxy(self, proxy_type=None, addr=None, port=None, rdns=True, username=None, password=None):
+        """set_proxy(proxy_type, addr[, port[, rdns[, username[, password]]]])
+        Sets the proxy to be used.
+
+        proxy_type -    The type of the proxy to be used. Three types
+                        are supported: PROXY_TYPE_SOCKS4 (including socks4a),
+                        PROXY_TYPE_SOCKS5 and PROXY_TYPE_HTTP
+        addr -        The address of the server (IP or DNS).
+        port -        The port of the server. Defaults to 1080 for SOCKS
+                       servers and 8080 for HTTP proxy servers.
+        rdns -        Should DNS queries be performed on the remote side
+                       (rather than the local side). The default is True.
+                       Note: This has no effect with SOCKS4 servers.
+        username -    Username to authenticate with to the server.
+                       The default is no authentication.
+        password -    Password to authenticate with to the server.
+                       Only relevant when username is also provided.
+        """
+        self.proxy = (proxy_type, addr.encode(), port, rdns, 
+                      username.encode() if username else None,
+                      password.encode() if password else None)
+
+    setproxy = set_proxy
+
+    def get_proxy_sockname(self):
+        """
+        Returns the bound IP address and port number at the proxy.
+        """
+        return self.proxy_sockname
+
+    getproxysockname = get_proxy_sockname
+
+    def get_proxy_peername(self):
+        """
+        Returns the IP and port number of the proxy.
+        """
+        return _orig_socket.getpeername(self)
+
+    getproxypeername = get_proxy_peername
+
+    def get_peername(self):
+        """
+        Returns the IP address and port number of the destination
+        machine (note: get_proxy_peername returns the proxy)
+        """
+        return self.proxy_peername
+
+    getpeername = get_peername
+
+    def _negotiate_SOCKS5(self, dest_addr, dest_port):
+        """
+        Negotiates a connection through a SOCKS5 server.
+        """
+        proxy_type, addr, port, rdns, username, password = self.proxy
+
+        # First we'll send the authentication packages we support.
+        if username and password:
+            # The username/password details were supplied to the
+            # set_proxy method so we support the USERNAME/PASSWORD
+            # authentication (in addition to the standard none).
+            self.sendall(b"\x05\x02\x00\x02")
+        else:
+            # No username/password were entered, therefore we
+            # only support connections with no authentication.
+            self.sendall(b"\x05\x01\x00")
+        
+        # We'll receive the server's response to determine which
+        # method was selected
+        chosen_auth = self.recvall(2)
+
+        if chosen_auth[0:1] != b"\x05":
+            # Note: string[i:i+1] is used because indexing of a bytestring 
+            # via bytestring[i] yields an integer in Python 3
+            self.close()
+            raise GeneralProxyError("SOCKS5 proxy server sent invalid data")
+        
+        # Check the chosen authentication method
+        
+        if chosen_auth[1:2] == b"\x02":
+            # Okay, we need to perform a basic username/password
+            # authentication.
+            self.sendall(b"\x01" + chr(len(username)).encode()
+                         + username
+                         + chr(len(password)).encode()
+                         + password)
+            auth_status = self.recvall(2)
+            if auth_status[0:1] != b"\x01":
+                # Bad response
+                self.close()
+                raise GeneralProxyError("SOCKS5 proxy server sent invalid data")
+            if auth_status[1:2] != b"\x00":
+                # Authentication failed
+                self.close()
+                raise SOCKS5AuthError("SOCKS5 authentication failed")
+            
+            # Otherwise, authentication succeeded
+
+        # No authentication is required if 0x00 
+        elif chosen_auth[1:2] != b"\x00":
+            # Reaching here is always bad
+            self.close()
+            if chosen_auth[1:2] == b"\xFF":
+                raise SOCKS5AuthError("All offered SOCKS5 authentication methods were rejected")
+            else:
+                raise GeneralProxyError("SOCKS5 proxy server sent invalid data")
+        
+        # Now we can request the actual connection
+        req = b"\x05\x01\x00"
+        # If the given destination address is an IP address, we'll
+        # use the IPv4 address request even if remote resolving was specified.
+        try:
+            addr_bytes = socket.inet_aton(dest_addr)
+            req += b"\x01" + addr_bytes
+        except socket.error:
+            # Well it's not an IP number, so it's probably a DNS name.
+            if rdns:
+                # Resolve remotely
+                addr_bytes = None
+                req += b"\x03" + chr(len(dest_addr)).encode() + dest_addr.encode()
+            else:
+                # Resolve locally
+                addr_bytes = socket.inet_aton(socket.gethostbyname(dest_addr))
+                req += b"\x01" + addr_bytes
+
+        req += struct.pack(">H", dest_port)
+        self.sendall(req)
+        
+        # Get the response
+        resp = self.recvall(4)
+        if resp[0:1] != b"\x05":
+            self.close()
+            raise GeneralProxyError("SOCKS5 proxy server sent invalid data")
+
+        status = ord(resp[1:2])
+        if status != 0x00:
+            # Connection failed: server returned an error
+            self.close()
+            error = SOCKS5_ERRORS.get(status, "Unknown error")
+            raise SOCKS5Error("{:#04x}: {}".format(status, error))
+        
+        # Get the bound address/port
+        if resp[3:4] == b"\x01":
+            bound_addr = self.recvall(4)
+        elif resp[3:4] == b"\x03":
+            resp += self.recv(1)
+            bound_addr = self.recvall(ord(resp[4:5]))
+        else:
+            self.close()
+            raise GeneralProxyError("SOCKS5 proxy server sent invalid data")
+        
+        bound_port = struct.unpack(">H", self.recvall(2))[0]
+        self.proxy_sockname = bound_addr, bound_port
+        if addr_bytes:
+            self.proxy_peername = socket.inet_ntoa(addr_bytes), dest_port
+        else:
+            self.proxy_peername = dest_addr, dest_port
+
+    def _negotiate_SOCKS4(self, dest_addr, dest_port):
+        """
+        Negotiates a connection through a SOCKS4 server.
+        """
+        proxy_type, addr, port, rdns, username, password = self.proxy
+
+        # Check if the destination address provided is an IP address
+        remote_resolve = False
+        try:
+            addr_bytes = socket.inet_aton(dest_addr)
+        except socket.error:
+            # It's a DNS name. Check where it should be resolved.
+            if rdns:
+                addr_bytes = b"\x00\x00\x00\x01"
+                remote_resolve = True
+            else:
+                addr_bytes = socket.inet_aton(socket.gethostbyname(dest_addr))
+        
+        # Construct the request packet
+        req = struct.pack(">BBH", 0x04, 0x01, dest_port) + addr_bytes
+        
+        # The username parameter is considered userid for SOCKS4
+        if username:
+            req += username
+        req += b"\x00"
+        
+        # DNS name if remote resolving is required
+        # NOTE: This is actually an extension to the SOCKS4 protocol
+        # called SOCKS4A and may not be supported in all cases.
+        if remote_resolve:
+            req += dest_addr.encode() + b"\x00"
+        self.sendall(req)
+
+        # Get the response from the server
+        resp = self.recvall(8)
+        if resp[0:1] != b"\x00":
+            # Bad data
+            self.close()
+            raise GeneralProxyError("SOCKS4 proxy server sent invalid data")
+
+        status = ord(resp[1:2])
+        if status != 0x5A:
+            # Connection failed: server returned an error
+            self.close()
+            error = SOCKS4_ERRORS.get(status, "Unknown error")
+            raise SOCKS4Error("{:#04x}: {}".format(status, error))
+
+        # Get the bound address/port
+        self.proxy_sockname = (socket.inet_ntoa(resp[4:]), struct.unpack(">H", resp[2:4])[0])
+        if remote_resolve:
+            self.proxy_peername = socket.inet_ntoa(addr_bytes), dest_port
+        else:
+            self.proxy_peername = dest_addr, dest_port
+
+    def _negotiate_HTTP(self, dest_addr, dest_port):
+        """
+        Negotiates a connection through an HTTP server.
+        NOTE: This currently only supports HTTP CONNECT-style proxies.
+        """
+        proxy_type, addr, port, rdns, username, password = self.proxy
+
+        # If we need to resolve locally, we do this now
+        addr = dest_addr if rdns else socket.gethostbyname(dest_addr)
+
+        self.sendall(b"CONNECT " + addr.encode() + b":" + str(dest_port).encode() + 
+                     b" HTTP/1.1\r\n" + b"Host: " + dest_addr.encode() + b"\r\n\r\n")
+        
+        resp = self.recv(4096)
+        while b"\r\n\r\n" not in resp and b"\n\n" not in resp:
+            d = self.recv(4096)
+            if not d:
+                self.close()
+                raise GeneralProxyError("Connection closed unexpectedly")
+            resp += d
+            
+       # We just need the first line to check if the connection was successful
+        status_line = resp.splitlines()[0].split(b" ", 2)
+
+        if not status_line[0].startswith(b"HTTP/"):
+            self.close()
+            raise GeneralProxyError("Proxy server does not appear to be an HTTP proxy")
+        
+        try:
+            status_code = int(status_line[1])
+        except ValueError:
+            self.close()
+            raise HTTPError("HTTP proxy server did not return a valid HTTP status")
+
+        if status_code != 200:
+            self.close()
+            error = "{}: {}".format(status_code, status_line[2].decode())
+            if status_code in (400, 403, 405):
+                # It's likely that the HTTP proxy server does not support the CONNECT tunneling method
+                error += ("\n[*] Note: The HTTP proxy server may not be supported by PySocks"
+                          " (must be a CONNECT tunnel proxy)")
+            raise HTTPError(error)
+
+        self.proxy_sockname = (b"0.0.0.0", 0)
+        self.proxy_peername = addr, dest_port
+
+    def connect(self, dest_pair):
+        """        
+        Connects to the specified destination through a proxy.
+        Uses the same API as socket's connect().
+        To select the proxy server, use set_proxy().
+
+        dest_pair - 2-tuple of (IP/hostname, port).
+        """
+        proxy_type, proxy_addr, proxy_port, rdns, username, password = self.proxy
+        dest_addr, dest_port = dest_pair
+
+        # Do a minimal input check first
+        if (not isinstance(dest_pair, (list, tuple))
+                or len(dest_pair) != 2
+                or not isinstance(dest_addr, type(""))
+                or not isinstance(dest_port, int)):
+            raise GeneralProxyError("Invalid destination-connection (host, port) pair")
+        
+        try:
+            if proxy_type is None:
+                _orig_socket.connect(self, (dest_addr, dest_port))
+            else:
+                port = proxy_port or DEFAULT_PORTS.get(proxy_type)
+                if not port:
+                    raise GeneralProxyError("Invalid proxy type")
+
+                _orig_socket.connect(self, (proxy_addr, port))
+                
+                if proxy_type == SOCKS5:
+                    self._negotiate_SOCKS5(dest_addr, dest_port)
+                elif proxy_type == SOCKS4:
+                    self._negotiate_SOCKS4(dest_addr, dest_port)
+                elif proxy_type == HTTP:
+                    self._negotiate_HTTP(dest_addr, dest_port)
+
+        except socket.error as error:
+            self.close()
+            proxy_server = "{}:{}".format(proxy_addr.decode(), proxy_port)
+            printable_type = PRINTABLE_PROXY_TYPES[proxy_type]
+            errno, msg = error.args
+            msg = "Error connecting to {} proxy {}: {}".format(printable_type,
+                                                               proxy_server, msg)
+            raise socket.error(errno, msg)

--- a/urllib3/util.py
+++ b/urllib3/util.py
@@ -122,7 +122,7 @@ class Timeout(object):
         self.total = self._validate_timeout(total, 'total')
         self._start_connect = None
 
-    def __str__(self):
+    def __repr__(self):
         return '%s(connect=%r, read=%r, total=%r)' % (
             type(self).__name__, self._connect, self._read, self.total)
 
@@ -605,7 +605,6 @@ def is_fp_closed(obj):
         return obj.fp is None
 
     return obj.closed
-
 
 if SSLContext is not None:  # Python 3.2+
     def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,


### PR DESCRIPTION
Here's the SOCKS proxy support patch.

Usage is identical to setting HTTP proxies: `ProxyManager("socks4://localhost:1080")` or `ProxyManager("socks5://localhost:1080")` (or `proxy_from_url()`). Default ports for both are 1080.

I added new SOCKS Connection classes in `connection.py`, and added a `_is_socks` attribute to the proxy URL that is passed to `ProxyManager` (on the `Url` object). The `_is_socks` attribute is used by the connection pools so that HTTP proxy negotiation steps aren't taken when the proxy has a SOCKS scheme. This could possibly be refactored (separate `socks_proxy` and `http_proxy` attributes?); tell me how you feel about the `_is_socks` solution.

I also touched up some other parts of the codebase, as follows, which I noticed while working through files and debugging.

* Fixed inconsistent indentation in a few places.
* Fixed some typos in comments.
* Changed `__str__` methods to `__repr__`. `__str__` automatically defers to `__repr__` if it isn't already defined, but the reverse isn't true. So this keeps the same behavior while also allowing easier debugging from the REPL.
* Added a newline in the middle of the proxy connection exception message, to make it a little easier to read.

I believe this branch should currently work fine for regular usage; it seems to have no trouble with any SOCKS proxies.

However, I had many confusing issues and bugs while trying to modify the test suite. The tests are currently broken (I added `raise SkipTest()` in the proxy tests, for the time being). I am using Twisted for the SOCKS4 and SOCKS5 proxy servers, and added that to the test requirements.

The test issues seem to stem from the Tornado HTTP and HTTPS dummy servers. On my computer, they spat out odd SSL errors (like `SSLError: [Errno 1] _ssl.c:504: error:1411B072:SSL routines:SSL3_GET_NEW_SESSION_TICKET:bad message type
` and many others), and would hang seemingly randomly.

I upgraded the Tornado version in `test-requirements.txt` because the version listed before appeared to have a bug that prevented me (or others) from running in IPv6 mode, see here: https://github.com/facebook/tornado/pull/593; I had to upgrade to get IPv6-related tests to pass. I'm not sure if the upgrade has anything to do with the current issues.

I think it has something to do with trying to run Tornado in separate threads. I was not able to get multithreading to work with Twisted, so I spawned a new process for each SOCKS proxy server instead; Twisted seems to work fine, as I can connect to and use the proxy servers while the tests are running.

I would appreciate if someone could modify the tests so the HTTP servers work properly, or give me some advice on how to fix the issue. And of course, I'd appreciate any suggestions or changes for the SOCKS patch itself.