### PR TITLE
Disable SSLv2 and SSLv3 from being used where possible

### DIFF
--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -22,6 +22,47 @@ except ImportError:
     OP_NO_SSLv2, OP_NO_SSLv3 = 0x1000000, 0x2000000
 
 
+class TLSOptions(object):
+    """Provide one way of specifying what TLS options you want urllib3 to use.
+
+    This allows the user to pass one item instead of several options for
+    enabling and disabling TLS specific features. For example::
+
+        opts = TLSOptions(allow_sslv3=True)
+
+    .. attribute:: allow_compression
+
+        Default: ``False``.
+
+    .. attribute:: ciphers
+
+        Default: 'TLS_ECDHE_RSA_AES_GCM_SHA_256'
+
+    .. attribute:: versions
+
+        Default: ['TLSv1_1', 'TLSv1_2']
+
+    .. attribute:: allow_sslv3
+
+        Default: False
+
+    """
+
+    def __init__(self, **kwargs):
+        # Default options: (option_name, default)
+        options = (('allow_compression', False),
+                   ('allow_sslv3', False),
+                   ('ciphers', 'TLS_ECDHE_RSA_AES_GCM_SHA_256'),
+                   ('versions', ['TLSv1_1', 'TLSv1_2']),
+                   )
+        _setattr = super(TLSOptions, self).__setattr__
+        for option, default in options:
+            _setattr(option, kwargs.get(option, default))
+
+    def __setattr__(self, attr, value):
+        return TypeError('Attribute "{0}" is not mutable'.format(attr))
+
+
 def assert_fingerprint(cert, fingerprint):
     """
     Checks if given fingerprint matches the supplied certificate.

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -16,6 +16,12 @@ except ImportError:
     pass
 
 
+try:
+    from ssl import OP_NO_SSLv2, OP_NO_SSLv3
+except ImportError:
+    OP_NO_SSLv2, OP_NO_SSLv3 = 0x1000000, 0x2000000
+
+
 def assert_fingerprint(cert, fingerprint):
     """
     Checks if given fingerprint matches the supplied certificate.
@@ -108,6 +114,9 @@ if SSLContext is not None:  # Python 3.2+
         # Disable TLS compression to migitate CRIME attack (issue #309)
         OP_NO_COMPRESSION = 0x20000
         context.options |= OP_NO_COMPRESSION
+        # Disable SSLv2 and SSLv3. Both are terrible (issues #471, #487)
+        context.options |= OP_NO_SSLv2
+        context.options |= OP_NO_SSLv3
 
         if ca_certs:
             try:


### PR DESCRIPTION
This will hopefully mitigate POODLE and all attacks related to SSLv2
and SSLv3 for versions of Python that allow us to disable this via
SSLContext options. Currently that excludes Python 2.6 and Python 2.7.
Python 2.7.9 should include the ability to disable these.

cc @Lukasa @dstufft @alex

Related issues: #471, #487