### PR TITLE
Add ssl_context parameter to Connection classes

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -344,12 +344,11 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(timeout.get_connect_duration(), 37)
 
     def test_resolve_cert_reqs(self):
-        self.assertEqual(resolve_cert_reqs(None), ssl.CERT_NONE)
-        self.assertEqual(resolve_cert_reqs(ssl.CERT_NONE), ssl.CERT_NONE)
-
-        self.assertEqual(resolve_cert_reqs(ssl.CERT_REQUIRED), ssl.CERT_REQUIRED)
-        self.assertEqual(resolve_cert_reqs('REQUIRED'), ssl.CERT_REQUIRED)
-        self.assertEqual(resolve_cert_reqs('CERT_REQUIRED'), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs(None, None), ssl.CERT_NONE)
+        self.assertEqual(resolve_cert_reqs(ssl.CERT_NONE, None), ssl.CERT_NONE)
+        self.assertEqual(resolve_cert_reqs(ssl.CERT_REQUIRED, None), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs('REQUIRED', None), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs('CERT_REQUIRED', None), ssl.CERT_REQUIRED)
 
     def test_is_fp_closed_object_supports_closed(self):
         class ClosedFile(object):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -344,11 +344,11 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(timeout.get_connect_duration(), 37)
 
     def test_resolve_cert_reqs(self):
-        self.assertEqual(resolve_cert_reqs(None, None), ssl.CERT_NONE)
-        self.assertEqual(resolve_cert_reqs(ssl.CERT_NONE, None), ssl.CERT_NONE)
-        self.assertEqual(resolve_cert_reqs(ssl.CERT_REQUIRED, None), ssl.CERT_REQUIRED)
-        self.assertEqual(resolve_cert_reqs('REQUIRED', None), ssl.CERT_REQUIRED)
-        self.assertEqual(resolve_cert_reqs('CERT_REQUIRED', None), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs(None), ssl.CERT_NONE)
+        self.assertEqual(resolve_cert_reqs(ssl.CERT_NONE), ssl.CERT_NONE)
+        self.assertEqual(resolve_cert_reqs(ssl.CERT_REQUIRED), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs('REQUIRED'), ssl.CERT_REQUIRED)
+        self.assertEqual(resolve_cert_reqs('CERT_REQUIRED'), ssl.CERT_REQUIRED)
 
     def test_is_fp_closed_object_supports_closed(self):
         class ClosedFile(object):

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -167,17 +167,15 @@ class HTTPSConnection(HTTPConnection):
     default_port = port_by_scheme['https']
 
     def __init__(self, host, port=None, key_file=None, cert_file=None,
-                 strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, **kw):
-
-        # Remove the ssl_context keyword argument before passking the keyword
-        # arguments to HTTPConnection's initializer.
-        self.ssl_context = kw.pop('ssl_context', None)
+                 strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+                 ssl_context=None, **kw):
 
         HTTPConnection.__init__(self, host, port, strict=strict,
                                 timeout=timeout, **kw)
 
         self.key_file = key_file
         self.cert_file = cert_file
+        self.ssl_context = ssl_context
 
         # Required property for Google AppEngine 1.9.0 which otherwise causes
         # HTTPS requests to go out as HTTP. (See Issue #356)
@@ -220,8 +218,10 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         # Add certificate verification
         conn = self._new_conn()
 
-        resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs)
-        resolved_ssl_version = resolve_ssl_version(self.ssl_version)
+        resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs,
+                                               self.ssl_context)
+        resolved_ssl_version = resolve_ssl_version(self.ssl_version,
+                                                   self.ssl_context)
 
         hostname = self.host
         if getattr(self, '_tunnel_host', None):

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -166,18 +166,17 @@ class HTTPConnection(_HTTPConnection, object):
 
 class HTTPSConnection(HTTPConnection):
     default_port = port_by_scheme['https']
-    ssl_version = None
 
     def __init__(self, host, port=None, key_file=None, cert_file=None,
                  strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
-                 ssl_context=None, **kw):
+                 ssl_context=None, ssl_version=None, **kw):
 
         HTTPConnection.__init__(self, host, port, strict=strict,
                                 timeout=timeout, **kw)
 
         if ssl_context is None:
             ssl_context = create_urllib3_context(
-                ssl_version=resolve_ssl_version(self.ssl_version),
+                ssl_version=resolve_ssl_version(ssl_version),
                 cert_reqs=ssl.CERT_NONE,
             )
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -169,6 +169,10 @@ class HTTPSConnection(HTTPConnection):
     def __init__(self, host, port=None, key_file=None, cert_file=None,
                  strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, **kw):
 
+        # Remove the ssl_context keyword argument before passking the keyword
+        # arguments to HTTPConnection's initializer.
+        self.ssl_context = kw.pop('ssl_context', None)
+
         HTTPConnection.__init__(self, host, port, strict=strict,
                                 timeout=timeout, **kw)
 
@@ -249,7 +253,8 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                                     ca_certs=self.ca_certs,
                                     ca_cert_dir=self.ca_cert_dir,
                                     server_hostname=hostname,
-                                    ssl_version=resolved_ssl_version)
+                                    ssl_version=resolved_ssl_version,
+                                    ssl_context=self.ssl_context)
 
         if self.assert_fingerprint:
             assert_fingerprint(self.sock.getpeercert(binary_form=True),

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -727,7 +727,6 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                           ca_cert_dir=self.ca_cert_dir,
                           assert_hostname=self.assert_hostname,
                           assert_fingerprint=self.assert_fingerprint)
-            conn.ssl_version = self.ssl_version
 
         return conn
 
@@ -769,7 +768,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
 
         conn = self.ConnectionCls(host=actual_host, port=actual_port,
                                   timeout=self.timeout.connect_timeout,
-                                  strict=self.strict, **self.conn_kw)
+                                  strict=self.strict,
+                                  ssl_version=self.ssl_version,
+                                  **self.conn_kw)
 
         return self._prepare_conn(conn)
 

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -26,7 +26,7 @@ pool_classes_by_scheme = {
 log = logging.getLogger(__name__)
 
 SSL_KEYWORDS = ('key_file', 'cert_file', 'cert_reqs', 'ca_certs',
-                'ssl_version', 'ca_cert_dir')
+                'ssl_version', 'ca_cert_dir', 'ssl_context')
 
 
 class PoolManager(RequestMethods):

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -159,7 +159,7 @@ def assert_fingerprint(cert, fingerprint):
                        .format(fingerprint, hexlify(cert_digest)))
 
 
-def resolve_cert_reqs(candidate):
+def resolve_cert_reqs(candidate, ssl_context):
     """
     Resolves the argument to a numeric constant, which can be passed to
     the wrap_socket function/method from the ssl module.
@@ -170,8 +170,11 @@ def resolve_cert_reqs(candidate):
     If it's neither `None` nor a string we assume it is already the numeric
     constant which can directly be passed to wrap_socket.
     """
-    if candidate is None:
+    if candidate is None and ssl_context is None:
         return CERT_NONE
+
+    if ssl_context:
+        return ssl_context.verify_mode
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)
@@ -182,12 +185,15 @@ def resolve_cert_reqs(candidate):
     return candidate
 
 
-def resolve_ssl_version(candidate):
+def resolve_ssl_version(candidate, ssl_context):
     """
     like resolve_cert_reqs
     """
-    if candidate is None:
+    if candidate is None and ssl_context is None:
         return PROTOCOL_SSLv23
+
+    if ssl_context:
+        return ssl_context.protocol
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -159,7 +159,7 @@ def assert_fingerprint(cert, fingerprint):
                        .format(fingerprint, hexlify(cert_digest)))
 
 
-def resolve_cert_reqs(candidate, ssl_context):
+def resolve_cert_reqs(candidate):
     """
     Resolves the argument to a numeric constant, which can be passed to
     the wrap_socket function/method from the ssl module.
@@ -170,11 +170,8 @@ def resolve_cert_reqs(candidate, ssl_context):
     If it's neither `None` nor a string we assume it is already the numeric
     constant which can directly be passed to wrap_socket.
     """
-    if candidate is None and ssl_context is None:
+    if candidate is None:
         return CERT_NONE
-
-    if ssl_context:
-        return ssl_context.verify_mode
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)
@@ -185,15 +182,12 @@ def resolve_cert_reqs(candidate, ssl_context):
     return candidate
 
 
-def resolve_ssl_version(candidate, ssl_context):
+def resolve_ssl_version(candidate):
     """
     like resolve_cert_reqs
     """
-    if candidate is None and ssl_context is None:
+    if candidate is None:
         return PROTOCOL_SSLv23
-
-    if ssl_context:
-        return ssl_context.protocol
 
     if isinstance(candidate, str):
         res = getattr(ssl, candidate, None)


### PR DESCRIPTION
After creating a shim SSLContext class in urllib3.util.ssl_, we now want
to start accepting instances of that class in general so users can take
advantage of some features provided only on certain versions of Python.

The first step is to allow users to pass ssl_context to both
HTTPSConnection and VerifiedHTTPSConnection and then pass these down to
the shim ssl_wrap_socket function in urllib3.util.ssl_. This does not
yet account for use with PyOpenSSL.

---

So this basically just works except for the fact that the following will raise an InsecureRequestWarning:

```python
import ssl
import urllib3
import urllib3.util.ssl_ as ussl


context = ussl.SSLContext(ssl.PROTOCOL_SSLv23)
context.load_verify_locations('../requests/requests/cacert.pem')
context.verify_mode = ssl.CERT_REQUIRED

manager = urllib3.PoolManager(ssl_context=context)
resp = manager.urlopen('GET', 'https://api.github.com/users',
                       preload_content=False)
```

Because the way I wrote `urllib3.util.ssl_.ssl_wrap_socket`, any settings on the the context set needs to be confirmed when creating the pool manager, e.g., the following works:

```python
import ssl
import urllib3
import urllib3.util.ssl_ as ussl


context = ussl.SSLContext(ssl.PROTOCOL_SSLv23)
context.load_verify_locations('../requests/requests/cacert.pem')
context.verify_mode = ssl.CERT_REQUIRED

manager = urllib3.PoolManager(ssl_context=context,
                              cert_reqs=ssl.CERT_REQUIRED)
resp = manager.urlopen('GET', 'https://api.github.com/users',
                       preload_content=False)
```

I think if we have `urllib3.util.ssl_.ssl_wrap_socket` return early when given a valid context, we won't break any prior behaviour, but I have yet to test that. Does anyone have any thoughts?