### PR TITLE
Example downloading files with shutil.copyfileobj

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,6 +97,20 @@ like buffering:
     >>> secondpart = b.read()
 
 
+The response can be treated as a file-like object.
+A file can be downloaded directory to a local file in a context without
+being saved in memory.
+
+.. doctest ::
+
+    >>> import urllib3
+    >>> import shutil
+    >>> url = 'http://example.com/big.file'
+    >>> http = urllib3.PoolManager()
+    >>> with http.request('GET', url, preload_content=False) as r, open(filename, 'wb') as f_out:
+    >>> ....    shutil.copyfileobj(r, f_out)
+
+
 Components
 ==========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,6 +105,7 @@ being saved in memory.
 
     >>> import urllib3
     >>> import shutil
+    >>> filename = '/path/to/local/file'
     >>> url = 'http://example.com/big.file'
     >>> http = urllib3.PoolManager()
     >>> with http.request('GET', url, preload_content=False) as r, open(filename, 'wb') as f_out:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,7 +98,7 @@ like buffering:
 
 
 The response can be treated as a file-like object.
-A file can be downloaded directory to a local file in a context without
+A file can be downloaded directly to a local file in a context without
 being saved in memory.
 
 .. doctest ::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,13 +103,10 @@ being saved in memory.
 
 .. doctest ::
 
-    >>> import urllib3
-    >>> import shutil
-    >>> filename = '/path/to/local/file'
-    >>> url = 'http://example.com/big.file'
+    >>> url = 'http://example.com/file'
     >>> http = urllib3.PoolManager()
-    >>> with http.request('GET', url, preload_content=False) as r, open(filename, 'wb') as f_out:
-    >>> ....    shutil.copyfileobj(r, f_out)
+    >>> with http.request('GET', url, preload_content=False) as r, open('filename', 'wb') as fp:
+    >>> ....    shutil.copyfileobj(r, fp)
 
 
 Components


### PR DESCRIPTION
Added an example on using the response as a file-like object in a context manager to properly handle large files.

Current documentation is not very clear on how to properly download large files in a context manager.

(see http://stackoverflow.com/questions/27387783/how-to-download-a-file-with-urllib3 for more details)