### PR TITLE
Decoding Exhausted Stream

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -73,6 +73,15 @@ class TestResponse(unittest.TestCase):
             'content-encoding': 'deflate'
         })
 
+    def test_reference_read(self):
+        fp = BytesIO(b'foo')
+        r = HTTPResponse(fp, preload_content=False)
+
+        self.assertEqual(r.read(1), b'f')
+        self.assertEqual(r.read(2), b'oo')
+        self.assertEqual(r.read(), b'')
+        self.assertEqual(r.read(), b'')
+
     def test_decode_deflate(self):
         import zlib
         data = zlib.compress(b'foo')
@@ -102,6 +111,9 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(r.read(3), b'')
         self.assertEqual(r.read(1), b'f')
         self.assertEqual(r.read(2), b'oo')
+        self.assertEqual(r.read(), b'')
+        self.assertEqual(r.read(), b'')
+
 
     def test_chunked_decoding_deflate2(self):
         import zlib
@@ -116,6 +128,9 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(r.read(1), b'')
         self.assertEqual(r.read(1), b'f')
         self.assertEqual(r.read(2), b'oo')
+        self.assertEqual(r.read(), b'')
+        self.assertEqual(r.read(), b'')
+
 
     def test_chunked_decoding_gzip(self):
         import zlib
@@ -130,6 +145,9 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(r.read(11), b'')
         self.assertEqual(r.read(1), b'f')
         self.assertEqual(r.read(2), b'oo')
+        self.assertEqual(r.read(), b'')
+        self.assertEqual(r.read(), b'')
+
 
     def test_body_blob(self):
         resp = HTTPResponse(b'foo')

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -216,14 +216,14 @@ class HTTPResponse(io.IOBase):
             self._fp_bytes_read += len(data)
 
             try:
-                if decode_content and self._decoder:
+                if data and decode_content and self._decoder:
                     data = self._decoder.decompress(data)
             except (IOError, zlib.error) as e:
                 raise DecodeError(
                     "Received response with content-encoding: %s, but "
                     "failed to decode it." % content_encoding, e)
 
-            if flush_decoder and decode_content and self._decoder:
+            if data and flush_decoder and decode_content and self._decoder:
                 buf = self._decoder.decompress(binary_type())
                 data += buf + self._decoder.flush()
 


### PR DESCRIPTION
Added a "reference" read() test, as well as a demonstration of how it differs from the streaming behavior for deflate or gzip. "reference" may be too strong of word in the context of urllib3, but seems to hold true for the standard library:

```python
>>> from io import BytesIO
>>> f = BytesIO('foo')
>>> f.read(3)
'foo'
>>> f.read()
''
>>> f.read()
''
``` 

As of this PR opening - I expect 3 existing tests to fail and 1 new test to succeed. No solution yet!