### PR TITLE
Faster headers implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 dev (master)
 ++++++++++++
 
+* Don't re-use connections which experienced an SSLError. (Issue #529)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ dev (master)
 
 * Add sha256 support for fingerprint verification. (Issue #540)
 
+* Fixed handling of header values containing commas. (Issue #533)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ dev (master)
 
 * Don't re-use connections which experienced an SSLError. (Issue #529)
 
+* Don't fail when gzip decoding an empty stream. (Issue #535)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 dev (master)
 ++++++++++++
 
+* Pools can used as context managers. (Issue #545)
+
 * Don't re-use connections which experienced an SSLError. (Issue #529)
 
 * Don't fail when gzip decoding an empty stream. (Issue #535)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ dev (master)
 
 * Don't fail when gzip decoding an empty stream. (Issue #535)
 
+* Add sha256 support for fingerprint verification. (Issue #540)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -239,6 +239,14 @@ class TestHTTPHeaderDict(unittest.TestCase):
         rep = "HTTPHeaderDict({'Cookie': 'foo, bar'})"
         self.assertEqual(repr(self.d), rep)
 
+    def test_items(self):
+        items = self.d.items()
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0][0], 'Cookie')
+        self.assertEqual(items[0][1], 'foo')
+        self.assertEqual(items[1][0], 'Cookie')
+        self.assertEqual(items[1][1], 'bar')
+
     def test_items_preserving_case(self):
         # Should not be tested only in connectionpool
         HEADERS = {'Content-Length': '0', 'Content-type': 'text/plain',

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -222,7 +222,7 @@ class TestHTTPHeaderDict(unittest.TestCase):
         a = self.d[key]
         b = self.d.pop(key)
         self.assertEqual(a, b)
-        self.assertNotIn(key, self.d)
+        self.assertFalse(key in self.d)
         with self.assertRaises(KeyError):
             self.d.pop(key)
         dummy = object()
@@ -230,7 +230,7 @@ class TestHTTPHeaderDict(unittest.TestCase):
 
     def test_discard(self):
         self.d.discard('cookie')
-        self.assertNotIn('cookie', self.d)
+        self.assertFalse('cookie' in self.d)
         self.d.discard('cookie')
 
     def test_len(self):

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -223,10 +223,9 @@ class TestHTTPHeaderDict(unittest.TestCase):
         b = self.d.pop(key)
         self.assertEqual(a, b)
         self.assertFalse(key in self.d)
-        with self.assertRaises(KeyError):
-            self.d.pop(key)
+        self.assertRaises(KeyError, self.d.pop, key)
         dummy = object()
-        self.assertIs(dummy, self.d.pop(key, dummy))
+        self.assertTrue(dummy is self.d.pop(key, dummy))
 
     def test_discard(self):
         self.d.discard('cookie')

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -213,5 +213,12 @@ class TestHTTPHeaderDict(unittest.TestCase):
         rep = "HTTPHeaderDict({'A': 'foo, bar'})"
         self.assertEqual(repr(self.d), rep)
 
+    def test_items_preserving_case(self):
+        # Should not be tested only in connectionpool
+        HEADERS = {'Content-Length': '0', 'Content-type': 'text/plain',
+                    'Server': 'TornadoServer/1.2.3'}
+        h = dict(HTTPHeaderDict(HEADERS).items())
+        self.assertEqual(HEADERS, h) # to preserve case sensitivity        
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -156,11 +156,11 @@ class TestHTTPHeaderDict(unittest.TestCase):
         d.add('a', 'asdf')
         self.assertEqual(d['a'], 'foo, bar, asdf')
         
-    def test_update_add(self):
-        self.d.update_add([('c', '100'), ('c', '200'), ('c', '300')], c='400')
+    def test_extend(self):
+        self.d.extend([('c', '100'), ('c', '200'), ('c', '300')], c='400')
         self.assertEqual(self.d['c'], '100, 200, 300, 400')
 
-        self.d.update_add(dict(a='asdf'))
+        self.d.extend(dict(a='asdf'))
         self.assertEqual(self.d['a'], 'foo, bar, asdf')
         
         class NonMappingHeaderContainer(object):
@@ -175,7 +175,7 @@ class TestHTTPHeaderDict(unittest.TestCase):
                 return self._data[key]
 
         header_object = NonMappingHeaderContainer(e='foofoo')
-        self.d.update_add(header_object)
+        self.d.extend(header_object)
         self.assertEqual(self.d['e'], 'foofoo')
 
     def test_getlist(self):
@@ -199,12 +199,13 @@ class TestHTTPHeaderDict(unittest.TestCase):
     def test_equal(self):
         b = HTTPHeaderDict({'a': 'foo, bar'})
         self.assertEqual(self.d, b)
+        self.assertFalse(self.d == 2)
+
+    def test_not_equal(self):
+        b = HTTPHeaderDict({'a': 'foo, bar'})
+        self.assertFalse(self.d != b)
         c = [('a', 'foo, bar')]
         self.assertNotEqual(self.d, c)
-        
-        # For some reason, the test above doesn't run into the __eq__ function,
-        # lacking test coverage for line 165, so comparing directly here
-        self.assertFalse(self.d == 2)
 
     def test_len(self):
         self.assertEqual(len(self.d), 1)

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -127,43 +127,48 @@ class TestLRUContainer(unittest.TestCase):
 
 class TestHTTPHeaderDict(unittest.TestCase):
     def setUp(self):
-        self.d = HTTPHeaderDict(A='foo')
-        self.d.add('a', 'bar')
+        self.d = HTTPHeaderDict(Cookie='foo')
+        self.d.add('cookie', 'bar')
 
     def test_overwriting_with_setitem_replaces(self):
         d = HTTPHeaderDict()
 
-        d['A'] = 'foo'
-        self.assertEqual(d['a'], 'foo')
+        d['Cookie'] = 'foo'
+        self.assertEqual(d['cookie'], 'foo')
 
-        d['a'] = 'bar'
-        self.assertEqual(d['A'], 'bar')
+        d['cookie'] = 'bar'
+        self.assertEqual(d['Cookie'], 'bar')
 
     def test_copy(self):
         h = self.d.copy()
         self.assertTrue(self.d is not h)
         self.assertEqual(self.d, h)
 
-    def test_add(self):
+    def test_add_multiple_allowed(self):
         d = HTTPHeaderDict()
+        d['Cookie'] = 'foo'
+        d.add('cookie', 'bar')
 
-        d['A'] = 'foo'
-        d.add('a', 'bar')
+        self.assertEqual(d['cookie'], 'foo, bar')
+        self.assertEqual(d['Cookie'], 'foo, bar')
 
-        self.assertEqual(d['a'], 'foo, bar')
-        self.assertEqual(d['A'], 'foo, bar')
+        d.add('cookie', 'asdf')
+        self.assertEqual(d['cookie'], 'foo, bar, asdf')
 
-        d.add('a', 'asdf')
-        self.assertEqual(d['a'], 'foo, bar, asdf')
+    def test_add_multiple_not_allowed(self):
+        self.d.add('notmulti', 'should be overwritten on next add call')
+        self.d.add('notmulti', 'new val')
+        self.assertEqual(self.d['notmulti'], 'new val')
         
     def test_extend(self):
-        self.d.extend([('c', '100'), ('c', '200'), ('c', '300')], c='400')
-        self.assertEqual(self.d['c'], '100, 200, 300, 400')
+        self.d.extend([('set-cookie', '100'), ('set-cookie', '200'), ('set-cookie', '300')])
+        self.assertEqual(self.d['set-cookie'], '100, 200, 300')
 
-        self.d.extend(dict(a='asdf'))
-        self.assertEqual(self.d['a'], 'foo, bar, asdf')
-        self.d.add('a', 'with, comma')
-        self.assertEqual(self.d.getlist('a'), ['foo', 'bar', 'asdf', 'with, comma'])
+        self.d.extend(dict(cookie='asdf'), b='100')
+        self.assertEqual(self.d['cookie'], 'foo, bar, asdf')
+        self.assertEqual(self.d['b'], '100')
+        self.d.add('cookie', 'with, comma')
+        self.assertEqual(self.d.getlist('cookie'), ['foo', 'bar', 'asdf', 'with, comma'])
         
         class NonMappingHeaderContainer(object):
             def __init__(self, **kwargs):
@@ -181,37 +186,37 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(self.d['e'], 'foofoo')
 
     def test_getlist(self):
-        self.assertEqual(self.d.getlist('a'), ['foo', 'bar'])
-        self.assertEqual(self.d.getlist('A'), ['foo', 'bar'])
+        self.assertEqual(self.d.getlist('cookie'), ['foo', 'bar'])
+        self.assertEqual(self.d.getlist('Cookie'), ['foo', 'bar'])
         self.assertEqual(self.d.getlist('b'), [])
         self.d.add('b', 'asdf')
         self.assertEqual(self.d.getlist('b'), ['asdf'])
 
     def test_update(self):
-        self.d.update(dict(a='with, comma'))
-        self.assertEqual(self.d.getlist('a'), ['with, comma'])
+        self.d.update(dict(cookie='with, comma'))
+        self.assertEqual(self.d.getlist('cookie'), ['with, comma'])
 
     def test_delitem(self):
-        del self.d['a']
-        self.assertFalse('a' in self.d)
-        self.assertFalse('A' in self.d)
+        del self.d['cookie']
+        self.assertFalse('cookie' in self.d)
+        self.assertFalse('COOKIE' in self.d)
 
     def test_equal(self):
-        b = HTTPHeaderDict({'a': 'foo, bar'})
+        b = HTTPHeaderDict({'cookie': 'foo, bar'})
         self.assertEqual(self.d, b)
         self.assertFalse(self.d == 2)
 
     def test_not_equal(self):
-        b = HTTPHeaderDict({'a': 'foo, bar'})
+        b = HTTPHeaderDict({'cookie': 'foo, bar'})
         self.assertFalse(self.d != b)
-        c = [('a', 'foo, bar')]
+        c = [('cookie', 'foo, bar')]
         self.assertNotEqual(self.d, c)
 
     def test_len(self):
         self.assertEqual(len(self.d), 1)
 
     def test_repr(self):
-        rep = "HTTPHeaderDict({'A': 'foo, bar'})"
+        rep = "HTTPHeaderDict({'Cookie': 'foo, bar'})"
         self.assertEqual(repr(self.d), rep)
 
     def test_items_preserving_case(self):

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -162,6 +162,8 @@ class TestHTTPHeaderDict(unittest.TestCase):
 
         self.d.extend(dict(a='asdf'))
         self.assertEqual(self.d['a'], 'foo, bar, asdf')
+        self.d.add('a', 'with, comma')
+        self.assertEqual(self.d.getlist('a'), ['foo', 'bar', 'asdf', 'with, comma'])
         
         class NonMappingHeaderContainer(object):
             def __init__(self, **kwargs):
@@ -186,10 +188,8 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(self.d.getlist('b'), ['asdf'])
 
     def test_update(self):
-        d = HTTPHeaderDict()
-        d.update(self.d)
-        d.add('a', 'with, comma')
-        self.assertEqual(d.getlist('a'), ['foo', 'bar', 'with, comma'])
+        self.d.update(dict(a='with, comma'))
+        self.assertEqual(self.d.getlist('a'), ['with, comma'])
 
     def test_delitem(self):
         del self.d['a']

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -270,7 +270,7 @@ Set-Cookie: bb_lastactivity=0; expires=Sat, 21-Sep-2013 18:49:35 GMT; path=/
 
 """
         msg = HTTPMessage(StringIO(msg.lstrip().replace('\n', '\r\n')))
-        d = HTTPHeaderDict.from_rfc822(msg)
+        d = HTTPHeaderDict.from_httplib(msg)
         self.assertEqual(d['server'], 'nginx')
         cookies = d.getlist('set-cookie')
         self.assertEqual(len(cookies), 2)

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -7,6 +7,7 @@ from urllib3._collections import (
 from urllib3.packages import six
 xrange = six.moves.xrange
 
+from nose.plugins.skip import SkipTest
 
 class TestLRUContainer(unittest.TestCase):
     def test_maxsize(self):
@@ -254,8 +255,9 @@ class TestHTTPHeaderDict(unittest.TestCase):
         h = dict(HTTPHeaderDict(HEADERS).items())
         self.assertEqual(HEADERS, h) # to preserve case sensitivity        
 
-    @unittest.skipIf(six.PY3, "PY2 only")
-    def test_from_rfc822(self):
+    def test_from_httplib(self):
+        if six.PY3:
+            raise SkipTest()
         from httplib import HTTPMessage
         from StringIO import StringIO
 

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -153,10 +153,37 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(d['a'], 'foo, bar')
         self.assertEqual(d['A'], 'foo, bar')
 
+        d.add('a', 'asdf')
+        self.assertEqual(d['a'], 'foo, bar, asdf')
+        
+    def test_update_add(self):
+        self.d.update_add([('c', '100'), ('c', '200'), ('c', '300')], c='400')
+        self.assertEqual(self.d['c'], '100, 200, 300, 400')
+
+        self.d.update_add(dict(a='asdf'))
+        self.assertEqual(self.d['a'], 'foo, bar, asdf')
+        
+        class NonMappingHeaderContainer(object):
+            def __init__(self, **kwargs):
+                self._data = {}
+                self._data.update(kwargs)
+
+            def keys(self):
+                return self._data.keys()
+            
+            def __getitem__(self, key):
+                return self._data[key]
+
+        header_object = NonMappingHeaderContainer(e='foofoo')
+        self.d.update_add(header_object)
+        self.assertEqual(self.d['e'], 'foofoo')
+
     def test_getlist(self):
         self.assertEqual(self.d.getlist('a'), ['foo', 'bar'])
         self.assertEqual(self.d.getlist('A'), ['foo', 'bar'])
         self.assertEqual(self.d.getlist('b'), [])
+        self.d.add('b', 'asdf')
+        self.assertEqual(self.d.getlist('b'), ['asdf'])
 
     def test_update(self):
         d = HTTPHeaderDict()
@@ -174,6 +201,10 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(self.d, b)
         c = [('a', 'foo, bar')]
         self.assertNotEqual(self.d, c)
+        
+        # For some reason, the test above doesn't run into the __eq__ function,
+        # lacking test coverage for line 165, so comparing directly here
+        self.assertFalse(self.d == 2)
 
     def test_len(self):
         self.assertEqual(len(self.d), 1)

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -165,7 +165,6 @@ class HTTPHeaderDict(dict):
             other = type(self)(other)
         return dict((k1, self[k1]) for k1 in self) == dict((k2, other[k2]) for k2 in other)
 
-    items = MutableMapping.items
     values = MutableMapping.values
     get = MutableMapping.get
     pop = MutableMapping.pop
@@ -174,7 +173,6 @@ class HTTPHeaderDict(dict):
     if not PY3: # Python 2:
         iterkeys = MutableMapping.iterkeys
         itervalues = MutableMapping.itervalues
-        iteritems = MutableMapping.iteritems
 
     def add(self, key, val):
         """Adds a (name, value) pair, doesn't overwrite the value if it already
@@ -254,6 +252,15 @@ class HTTPHeaderDict(dict):
                 val = list(val)
             _dict_setitem(clone, key, val)
         return clone
+    
+    def iteritems(self):
+        # Extration of the original headers
+        for key in self:
+            val = _dict_getitem(self, key)
+            yield val[0], ', '.join(val[1:])
+
+    def items(self):
+        return list(self.iteritems())
 
     def compatible_dict(self):
         """
@@ -261,11 +268,7 @@ class HTTPHeaderDict(dict):
         can create a backwards and standards compatible version containing comma joined
         strings instead of lists for multiple headers.
         """
-        ret = dict()
-        for key in self:
-            val = _dict_getitem(self, key)
-            ret[val[0]] = ', '.join(val[1:])
-        return ret
+        return dict(self.iteritems())
     
     @classmethod
     def from_httplib(cls, headers):

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -14,7 +14,7 @@ try:  # Python 2.7+
     from collections import OrderedDict
 except ImportError:
     from .packages.ordered_dict import OrderedDict
-from .packages.six import iterkeys, itervalues, PY3
+from .packages.six import iterkeys, itervalues, _iterkeys, _itervalues, _iteritems
 
 
 __all__ = ['RecentlyUsedContainer', 'HTTPHeaderDict']
@@ -172,11 +172,10 @@ class HTTPHeaderDict(dict):
     get = MutableMapping.get
     pop = MutableMapping.pop
     update = MutableMapping.update
-
-    if not PY3:
-        itervalues = MutableMapping.itervalues
-        iteritems = MutableMapping.iteritems
-
+    
+    iterkeys = getattr(MutableMapping, _iterkeys)
+    itervalues = getattr(MutableMapping, _itervalues)
+    iteritems = getattr(MutableMapping, _iteritems)
 
     def add(self, key, val):
         """Adds a (name, value) pair, doesn't overwrite the value if it already
@@ -268,4 +267,10 @@ class HTTPHeaderDict(dict):
         ret = dict()
         for key in self:
             ret[self._format_field(key)] = self[key]
+        return ret
+    
+    @classmethod
+    def from_httplib(cls, headers):
+        ret = cls()
+        ret.update_add(headers)
         return ret

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -97,7 +97,13 @@ class RecentlyUsedContainer(MutableMapping):
             return list(iterkeys(self._container))
 
 
-class HTTPHeaderDict(MutableMapping):
+_dict_setitem = dict.__setitem__
+_dict_getitem = dict.__getitem__
+_dict_delitem = dict.__delitem__
+_dict_contains = dict.__contains__
+
+
+class HTTPHeaderDict(dict):
     """
     :param headers:
         An iterable of field-value pairs. Must not contain multiple field names
@@ -129,25 +135,47 @@ class HTTPHeaderDict(MutableMapping):
     'foo=bar, baz=quxx'
     >>> headers['Content-Length']
     '7'
-
-    If you want to access the raw headers with their original casing
-    for debugging purposes you can access the private ``._data`` attribute
-    which is a normal python ``dict`` that maps the case-insensitive key to a
-    list of tuples stored as (case-sensitive-original-name, value). Using the
-    structure from above as our example:
-
-    >>> headers._data
-    {'set-cookie': [('Set-Cookie', 'foo=bar'), ('set-cookie', 'baz=quxx')],
-    'content-length': [('content-length', '7')]}
     """
 
     def __init__(self, headers=None, **kwargs):
-        self._data = {}
-        if headers is None:
-            headers = {}
-        self.update(headers, **kwargs)
+        dict.__init__(self)
+        if headers is not None:
+            self.update(headers)
+        if kwargs:
+            self.update(kwargs)
 
-    def add(self, key, value):
+    def __setitem__(self, key, val):
+        return _dict_setitem(self, key.lower(), val)
+
+    def __getitem__(self, key):
+        val = _dict_getitem(self, key.lower())
+        if isinstance(val, list):
+            return ', '.join(val)
+        else:
+            return val
+
+    def __delitem__(self, key):
+        return _dict_delitem(self, key.lower())
+
+    def __contains__(self, key):
+        return _dict_contains(self, key.lower())
+
+    def __eq__(self, other):
+        if not isinstance(other, Mapping):
+            return False
+        if not isinstance(other, type(self)):
+            other = type(self)(other)
+        return dict((k1, self[k1]) for k1 in self) == dict((k2, other[k2]) for k2 in other)
+
+    itervalues = MutableMapping.itervalues
+    iteritems = MutableMapping.iteritems
+    items = MutableMapping.items
+    values = MutableMapping.values
+    get = MutableMapping.get
+    pop = MutableMapping.pop
+    update = MutableMapping.update
+
+    def add(self, key, val):
         """Adds a (name, value) pair, doesn't overwrite the value if it already
         exists.
 
@@ -156,51 +184,84 @@ class HTTPHeaderDict(MutableMapping):
         >>> headers['foo']
         'bar, baz'
         """
-        self._data.setdefault(key.lower(), []).append((key, value))
+        key = key.lower()
+        # Use lower only once and then stick with inbuilt functions for speed
+        if not _dict_contains(self, key):
+            _dict_setitem(self, key, val)
+        else:
+            item = _dict_getitem(self, key)
+            if isinstance(item, list):
+                item.append(val)
+            else:
+                _dict_setitem(self, key, [item, val])
+
+    def update_add(*args, **kwds):
+        """Adapted version of MutableMapping.update in order to insert items
+        with self.add instead of self.__setitem__
+        """
+        if len(args) > 2:
+            raise TypeError("update() takes at most 2 positional "
+                            "arguments ({} given)".format(len(args)))
+        elif not args:
+            raise TypeError("update() takes at least 1 argument (0 given)")
+        self = args[0]
+        other = args[1] if len(args) >= 2 else ()
+        
+        if isinstance(other, Mapping):
+            for key in other:
+                self.add(key, other[key])
+        elif hasattr(other, "keys"):
+            for key in other.keys():
+                self.add(key, other[key])
+        else:
+            for key, value in other:
+                self.add(key, value)
+
+        for key, value in kwds.items():
+            self.add(key, value)
 
     def getlist(self, key):
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
-        return [v for k, v in self._data.get(key.lower(), [])]
+        try:
+            ret = _dict_getitem(self, key.lower())
+        except KeyError:
+            return []
+        else:
+            if isinstance(ret, list):
+                return ret
+            else:
+                return [ret]
 
-    def copy(self):
-        h = HTTPHeaderDict()
-        for key in self._data:
-            for rawkey, value in self._data[key]:
-                h.add(rawkey, value)
-        return h
-
-    def __eq__(self, other):
-        if not isinstance(other, Mapping):
-            return False
-        other = HTTPHeaderDict(other)
-        return dict((k1, self[k1]) for k1 in self._data) == \
-                dict((k2, other[k2]) for k2 in other._data)
-
-    def __getitem__(self, key):
-        values = self._data[key.lower()]
-        return ', '.join(value[1] for value in values)
-
-    def __setitem__(self, key, value):
-        self._data[key.lower()] = [(key, value)]
-
-    def __delitem__(self, key):
-        del self._data[key.lower()]
-
-    def __len__(self):
-        return len(self._data)
-
-    def __iter__(self):
-        for headers in itervalues(self._data):
-            yield headers[0][0]
+    # Backwards compatibility for httplib
+    getheaders = getlist
+    getallmatchingheaders = getlist
+    iget = getlist
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, dict(self.items()))
+        return "%s(%s)" % (type(self).__name__, self.compatible_dict())
 
-    def update(self, *args, **kwds):
-        headers = args[0]
-        if isinstance(headers, HTTPHeaderDict):
-            for key in iterkeys(headers._data):
-                self._data.setdefault(key.lower(), []).extend(headers._data[key])
-        else:
-            super(HTTPHeaderDict, self).update(*args, **kwds)
+    def copy(self):
+        clone = type(self)()
+        for key in self:
+            val = _dict_getitem(self, key)
+            if isinstance(val, list):
+                # Need to create a copy instead of a reference
+                val = list(val)
+            _dict_setitem(clone, key, val)
+        return clone
+
+    @staticmethod
+    def _format_field(field):
+        return '-'.join(field_pt.capitalize() for field_pt in field.split('-'))
+
+    def compatible_dict(self):
+        """
+        If the client performing the request is not adjusted for this class, this function
+        can create a backwards and standards compatible version containing comma joined
+        strings instead of lists for multiple headers.
+        """
+        ret = dict()
+        for key in self:
+            ret[self._format_field(key)] = self[key]
+        return ret

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -165,6 +165,9 @@ class HTTPHeaderDict(dict):
             other = type(self)(other)
         return dict((k1, self[k1]) for k1 in self) == dict((k2, other[k2]) for k2 in other)
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     values = MutableMapping.values
     get = MutableMapping.get
     pop = MutableMapping.pop
@@ -196,7 +199,7 @@ class HTTPHeaderDict(dict):
                 # Only one item so far, need to convert the tuple to list
                 _dict_setitem(self, key_lower, [vals[0], vals[1], val])
 
-    def update_add(*args, **kwds):
+    def extend(*args, **kwds):
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -273,5 +276,5 @@ class HTTPHeaderDict(dict):
     @classmethod
     def from_httplib(cls, headers):
         ret = cls()
-        ret.update_add(headers)
+        ret.extend(headers)
         return ret

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -196,7 +196,8 @@ class HTTPHeaderDict(dict):
                 _dict_setitem(self, key, [item, val])
 
     def update_add(*args, **kwds):
-        """Adapted version of MutableMapping.update in order to insert items
+        """Generic import function for any type of header-like object.
+        Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
         """
         if len(args) > 2:

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -141,9 +141,9 @@ class HTTPHeaderDict(dict):
     def __init__(self, headers=None, **kwargs):
         dict.__init__(self)
         if headers is not None:
-            self.update(headers)
+            self.extend(headers)
         if kwargs:
-            self.update(kwargs)
+            self.extend(kwargs)
 
     def __setitem__(self, key, val):
         return _dict_setitem(self, key.lower(), (key, val))
@@ -199,7 +199,7 @@ class HTTPHeaderDict(dict):
                 # Only one item so far, need to convert the tuple to list
                 _dict_setitem(self, key_lower, [vals[0], vals[1], val])
 
-    def extend(*args, **kwds):
+    def extend(*args, **kwargs):
         """Generic import function for any type of header-like object.
         Adapted version of MutableMapping.update in order to insert items
         with self.add instead of self.__setitem__
@@ -222,7 +222,7 @@ class HTTPHeaderDict(dict):
             for key, value in other:
                 self.add(key, value)
 
-        for key, value in kwds.items():
+        for key, value in kwargs.items():
             self.add(key, value)
 
     def getlist(self, key):
@@ -272,9 +272,3 @@ class HTTPHeaderDict(dict):
         strings instead of lists for multiple headers.
         """
         return dict(self.iteritems())
-    
-    @classmethod
-    def from_httplib(cls, headers):
-        ret = cls()
-        ret.extend(headers)
-        return ret

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -14,7 +14,7 @@ try:  # Python 2.7+
     from collections import OrderedDict
 except ImportError:
     from .packages.ordered_dict import OrderedDict
-from .packages.six import iterkeys, itervalues
+from .packages.six import iterkeys, itervalues, PY3
 
 
 __all__ = ['RecentlyUsedContainer', 'HTTPHeaderDict']
@@ -167,13 +167,16 @@ class HTTPHeaderDict(dict):
             other = type(self)(other)
         return dict((k1, self[k1]) for k1 in self) == dict((k2, other[k2]) for k2 in other)
 
-    itervalues = MutableMapping.itervalues
-    iteritems = MutableMapping.iteritems
     items = MutableMapping.items
     values = MutableMapping.values
     get = MutableMapping.get
     pop = MutableMapping.pop
     update = MutableMapping.update
+
+    if not PY3:
+        itervalues = MutableMapping.itervalues
+        iteritems = MutableMapping.iteritems
+
 
     def add(self, key, val):
         """Adds a (name, value) pair, doesn't overwrite the value if it already

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -174,7 +174,7 @@ class HTTPHeaderDict(dict):
     get = MutableMapping.get
     update = MutableMapping.update
     
-    if not PY3: # Python 2:
+    if not PY3: # Python 2
         iterkeys = MutableMapping.iterkeys
         itervalues = MutableMapping.itervalues
 
@@ -274,7 +274,7 @@ class HTTPHeaderDict(dict):
     iget = getlist
 
     def __repr__(self):
-        return "%s(%s)" % (type(self).__name__, dict(self.iteritems()))
+        return "%s(%s)" % (type(self).__name__, dict(self.itermerged()))
 
     def copy(self):
         clone = type(self)()
@@ -287,6 +287,13 @@ class HTTPHeaderDict(dict):
         return clone
 
     def iteritems(self):
+        """Iterate over all header lines, including duplicate ones."""
+        for key in self:
+            vals = _dict_getitem(self, key)
+            for val in vals[1:]:
+                yield vals[0], val
+
+    def itermerged(self):
         """Iterate over all headers, merging duplicate ones together."""
         for key in self:
             val = _dict_getitem(self, key)

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -303,16 +303,17 @@ class HTTPHeaderDict(dict):
         return list(self.iteritems())
 
     @classmethod
-    def from_rfc822(cls, message, duplicates=('set-cookie',)): # Python 2
-        """Read headers from a Python 2 message object."""
+    def from_httplib(cls, message, duplicates=('set-cookie',)): # Python 2
+        """Read headers from a Python 2 httplib message object."""
         ret = cls(message.items())
         # ret now contains only the last header line for each duplicate.
-        # Parsing this with duplicates would be nice, but this would
-        # mean to repeat most parsing already done, when the message
-        # object was created. Extracting only the headers of interest 
-        # separately - the cookies - should be faster.
+        # Importing with all duplicates would be nice, but this would
+        # mean to repeat most of the raw parsing already done, when the
+        # message object was created. Extracting only the headers of interest 
+        # separately, the cookies, should be faster and requires less
+        # extra code.
         for key in duplicates:
             ret.discard(key)
-            for header in message.getheaders(key):
-                ret.add(key, header)
+            for val in message.getheaders(key):
+                ret.add(key, val)
             return ret

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -287,14 +287,9 @@ class HTTPResponse(io.IOBase):
         # HTTPResponse.getheaders() returns a list with tuples of name, value for PY2 as well as PY3
         # No ambiguation for PY3 required, PY3 automatically contains duplicate headers
         # No special handling of cookie headers required
-        httplib_headers = r.getheaders()
-        if isinstance(httplib_headers, HTTPHeaderDict):
-            headers = httplib_headers
-        else:
-            headers = HTTPHeaderDict()
-            # Should be done by the update
-            for k, v in httplib_headers:
-                headers.add(k, v)
+        headers = r.getheaders()
+        if not isinstance(headers, HTTPHeaderDict):
+            headers = HTTPHeaderDict.from_httplib(headers)
 
         # HTTPResponse objects in Python 3 don't have a .strict attribute
         strict = getattr(r, 'strict', 0)

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -289,7 +289,7 @@ class HTTPResponse(io.IOBase):
         # No special handling of cookie headers required
         headers = r.getheaders()
         if not isinstance(headers, HTTPHeaderDict):
-            headers = HTTPHeaderDict.from_httplib(headers)
+            headers = HTTPHeaderDict(headers)
 
         # HTTPResponse objects in Python 3 don't have a .strict attribute
         strict = getattr(r, 'strict', 0)

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -289,7 +289,7 @@ class HTTPResponse(io.IOBase):
             if PY3: # Python 3
                 headers = HTTPHeaderDict(headers.items())
             else: # Python 2
-                headers = HTTPHeaderDict.from_rfc822(headers)
+                headers = HTTPHeaderDict.from_httplib(headers)
 
         # HTTPResponse objects in Python 3 don't have a .strict attribute
         strict = getattr(r, 'strict', 0)


### PR DESCRIPTION
I had been trying to speed up urllib3 by monkeypatching with geventhttpclient. Unfortunately there is not too much gain, as lots of copying of response and header objects is done, which could largely be skipped, when the header and response objects would be sufficiently compatible and directly recognized and accepted as compatible, instead of being converted by lots of copying around.

So for the sake of better compatibility and speedups, I would have liked to directly create a header class - the standard urllib3.HTTPHeaderDict - by geventhttpclients c-parser when monkeypatching, which won't need any further processing from urllib3s response object. When I compared both header container implementations, turned out that the current urllib3 version isn't that fast as it could be. Below some timings comparing the old vs the new version, HTTPHeaderDict_ being the old version:

```python
print "Empty initializations"
%timeit h = HTTPHeaderDict_()
%timeit x = HTTPHeaderDict()

print "Initializations with data"
%timeit h = HTTPHeaderDict_(asdf='ddd', abc='100', ddd='200', efg='300')
%timeit x = HTTPHeaderDict(asdf='ddd', abc='100', ddd='200', efg='300')

from random import choice
from string import ascii_lowercase as asciis
hdrs = dict((''.join(choice(asciis) for _ in range(9)),
             ''.join(choice(asciis) for _ in range(9))) for _ in range(200))

print "Initializations with more data"
%timeit h = HTTPHeaderDict_(hdrs)
%timeit x = HTTPHeaderDict(hdrs)

h = HTTPHeaderDict_(asdf='ddd', abc='100', ddd='200', efg='300')
x = HTTPHeaderDict(asdf='ddd', abc='100', ddd='200', efg='300')

print "Fetching items"
%timeit h.__getitem__('abc')
%timeit x.__getitem__('abc')

print "Copying"
%timeit h.copy()
%timeit x.copy()

print "Adding headers"
%timeit h = HTTPHeaderDict_(); [h.add(k,v) for k, v in hdrs.iteritems()];
%timeit x = HTTPHeaderDict(); [x.add(k,v) for k, v in hdrs.iteritems()];

h = HTTPHeaderDict_(hdrs)
x = HTTPHeaderDict(hdrs)

print "Iteration of keys"
%timeit [k for k in h]
%timeit [k for k in x]

print "Iteration of values"
%timeit [h[k] for k in h]
%timeit [x[k] for k in x]

print "Getting keys"
%timeit h.keys()
%timeit x.keys()

print "Getting values"
%timeit h.values()
%timeit x.values()
```

For my machine, I get the following timings:
```
Empty initializations
100000 loops, best of 3: 4.38 µs per loop
1000000 loops, best of 3: 858 ns per loop
Initializations with data
100000 loops, best of 3: 11.3 µs per loop
100000 loops, best of 3: 12 µs per loop
Initializations with more data
1000 loops, best of 3: 252 µs per loop
1000 loops, best of 3: 235 µs per loop
Fetching items
100000 loops, best of 3: 2.34 µs per loop
1000000 loops, best of 3: 1 µs per loop
Copying
100000 loops, best of 3: 11.7 µs per loop
100000 loops, best of 3: 5.36 µs per loop
Adding headers
1000 loops, best of 3: 267 µs per loop
1000 loops, best of 3: 242 µs per loop
Iteration of keys
10000 loops, best of 3: 58.3 µs per loop
100000 loops, best of 3: 17.9 µs per loop
Iteration of values
1000 loops, best of 3: 706 µs per loop
1000 loops, best of 3: 271 µs per loop
Getting keys
10000 loops, best of 3: 44.6 µs per loop
100000 loops, best of 3: 2.25 µs per loop
Getting values
1000 loops, best of 3: 671 µs per loop
1000 loops, best of 3: 267 µs per loop
```
The new version passes all current tests, though it comes with one downside, which is worth discussing: It's not storing the original case of the header items. While the current version stores that, and therefore can restore the case if desired e.g. when iterating over the keys, this implementation is consequently using lower case, except when pretty printing the object. The standards require case insensitivity, so not preserving the case seems to me like an acceptable, maybe even desireable behaviour. Furthermore, also the current implementation has to drop the case information, when joining same header items together.

In terms of compatibility, I hope this should work with all python versions, though I mainly tested it on 2.7.

```
python test/test_collections.py
................
----------------------------------------------------------------------
Ran 16 tests in 0.004s

OK
```