### PR TITLE
Allow PoolManager and ConnectionPool to be used as a context manager.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -136,5 +136,8 @@ In chronological order:
 * Benjamen Meyer <bm_witness@yahoo.com>
   * Security Warning Documentation update for proper capture
 
+* Shivan Sornarajah <github@sornars.com>
+  * Support for using ConnectionPool and PoolManager as context managers.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -36,9 +36,23 @@ pools. That is, if you set the PoolManager ``num_pools`` to 10, then after
 making requests to 11 or more different hosts, the least recently used pools
 will be cleaned up eventually.
 
-Cleanup of stale pools does not happen immediately. You can read more about the
-implementation and the various adjustable variables within
-:class:`~urllib3._collections.RecentlyUsedContainer`.
+Cleanup of stale pools does not happen immediately but can be forced when used 
+as a context manager.
+
+.. doctest ::
+    
+    >>> from urllib3 import PoolManager
+    >>> with PoolManager(10) as manager:
+    ...     r = manager.request('GET', 'http://example.com')
+    ...     r = manager.request('GET', 'http://httpbin.org/')
+    ...     len(manager.pools)
+    ...
+    2
+    >>> len(manager.pools)
+    0
+
+You can read more about the implementation and the various adjustable variables 
+within :class:`~urllib3._collections.RecentlyUsedContainer`.
 
 API
 ---

--- a/docs/pools.rst
+++ b/docs/pools.rst
@@ -33,7 +33,21 @@ If you need to make requests to the same host repeatedly, then you should use a
 By default, the pool will cache just one connection. If you're planning on using
 such a pool in a multithreaded environment, you should set the ``maxsize`` of
 the pool to a higher number, such as the number of threads. You can also control
-many other variables like timeout, blocking, and default headers.
+many other variables like timeout, blocking, and default headers. Additionally, 
+you can use a ConnectionPool as a context manager so the pool will be automatically
+cleared after usage.
+
+.. doctest ::
+
+    >>> from urllib3 import HTTPConnectionPool
+    >>> with  HTTPConnectionPool('ajax.googleapis.com', maxsize=1) as pool:
+    ...     r = pool.request('GET', '/ajax/services/search/web',
+    ...                      fields={'q': 'urllib3', 'v': '1.0'})
+    ...     print(pool.pool)
+    ... 
+    <queue.LifoQueue object at 0x7f67367dfcf8>
+    >>> print(pool.pool)
+    None
 
 Helpers
 -------

--- a/docs/pools.rst
+++ b/docs/pools.rst
@@ -33,14 +33,15 @@ If you need to make requests to the same host repeatedly, then you should use a
 By default, the pool will cache just one connection. If you're planning on using
 such a pool in a multithreaded environment, you should set the ``maxsize`` of
 the pool to a higher number, such as the number of threads. You can also control
-many other variables like timeout, blocking, and default headers. Additionally, 
-you can use a ConnectionPool as a context manager so the pool will be automatically
-cleared after usage.
+many other variables like timeout, blocking, and default headers. 
+
+A ConnectionPool can be used as a context manager to automatically clear the 
+pool after usage. 
 
 .. doctest ::
 
     >>> from urllib3 import HTTPConnectionPool
-    >>> with  HTTPConnectionPool('ajax.googleapis.com', maxsize=1) as pool:
+    >>> with HTTPConnectionPool('ajax.googleapis.com', maxsize=1) as pool:
     ...     r = pool.request('GET', '/ajax/services/search/web',
     ...                      fields={'q': 'urllib3', 'v': '1.0'})
     ...     print(pool.pool)

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -205,6 +205,26 @@ class TestConnectionPool(unittest.TestCase):
     def test_no_host(self):
         self.assertRaises(LocationValueError, HTTPConnectionPool, None)
 
+    def test_contextmanager(self):
+        with connection_from_url('http://google.com:80') as pool:
+            # Populate with some connections
+            conn1 = pool._get_conn()
+            conn2 = pool._get_conn()
+            conn3 = pool._get_conn()
+            pool._put_conn(conn1)
+            pool._put_conn(conn2)
+
+            old_pool_queue = pool.pool
+
+        self.assertEqual(pool.pool, None)
+
+        self.assertRaises(ClosedPoolError, pool._get_conn)
+
+        pool._put_conn(conn3)
+
+        self.assertRaises(ClosedPoolError, pool._get_conn)
+
+        self.assertRaises(Empty, old_pool_queue.get, block=False)
 
 
 if __name__ == '__main__':

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -71,6 +71,22 @@ class TestPoolManager(unittest.TestCase):
         self.assertRaises(LocationValueError, p.connection_from_url, 'http://@')
         self.assertRaises(LocationValueError, p.connection_from_url, None)
 
+    def test_contextmanager(self):
+        with PoolManager(1) as p:
+            conn_pool = p.connection_from_url('http://google.com')
+            self.assertEqual(len(p.pools), 1)
+            conn = conn_pool._get_conn()
+
+        self.assertEqual(len(p.pools), 0)
+
+        self.assertRaises(ClosedPoolError, conn_pool._get_conn)
+
+        conn_pool._put_conn(conn)
+
+        self.assertRaises(ClosedPoolError, conn_pool._get_conn)
+
+        self.assertEqual(len(p.pools), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -77,6 +77,7 @@ class ConnectionPool(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+        # Return False to re-raise any potential exceptions
         return False
 
     def close():

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -72,6 +72,20 @@ class ConnectionPool(object):
         return '%s(host=%r, port=%r)' % (type(self).__name__,
                                          self.host, self.port)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close():
+        """
+        Close all pooled connections and disable the pool.
+        """
+        pass
+
+
 # This is taken from http://hg.python.org/cpython/file/7aaba721ebc0/Lib/socket.py#l252
 _blocking_errnos = set([errno.EAGAIN, errno.EWOULDBLOCK])
 
@@ -178,13 +192,6 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # We cannot know if the user has added default socket options, so we cannot replace the
             # list.
             self.conn_kw.setdefault('socket_options', [])
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-        return False
 
     def _new_conn(self):
         """

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -179,6 +179,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # list.
             self.conn_kw.setdefault('socket_options', [])
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
     def _new_conn(self):
         """
         Return a fresh :class:`HTTPConnection`.

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -64,6 +64,13 @@ class PoolManager(RequestMethods):
         self.pools = RecentlyUsedContainer(num_pools,
                                            dispose_func=lambda p: p.close())
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.clear()
+        return False
+
     def _new_pool(self, scheme, host, port):
         """
         Create a new :class:`ConnectionPool` based on host, port and scheme.

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -69,6 +69,7 @@ class PoolManager(RequestMethods):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.clear()
+        # Return False to re-raise any potential exceptions
         return False
 
     def _new_pool(self, scheme, host, port):


### PR DESCRIPTION
Fixes #514 

I'm not sure if any behaviour beyond closing/clearing the pools is expected from a context manager, let me know if I've missed the mark.