### PR TITLE
Emit warnings when SSLContext isn't available.

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -111,6 +111,8 @@ Once you find your root certificate file::
         ...
 
 
+.. _pyopenssl:
+
 OpenSSL / PyOpenSSL
 -------------------
 
@@ -136,6 +138,8 @@ Now you can continue using urllib3 as you normally would.
 
 For more details, check the :mod:`~urllib3.contrib.pyopenssl` module.
 
+
+.. _insecurerequestwarning:
 
 InsecureRequestWarning
 ----------------------
@@ -166,3 +170,20 @@ warnings to your own log::
 
 Capturing the warnings to your own log is much preferred over simply disabling
 the warnings.
+
+SSLConfigurationWarning
+-----------------------
+
+.. versionadded:: 1.11
+
+Certain Python platforms have limitations in their ``ssl`` module that limits
+the configuration that ``urllib3`` can apply. In particular, this can cause
+HTTPS requests that would succeed on more featureful platforms to fail.
+
+If you encounter this warning, it is strongly recommended you upgrade to a
+newer Python version, or that you use pyOpenSSL as described in the
+:ref:`pyopenssl` section.
+
+If you know what you are doing and would like to disable this and other
+warnings, please consult the :ref:`insecurerequestwarning` section for
+instructions on how to handle the warnings.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -176,9 +176,10 @@ SSLConfigurationWarning
 
 .. versionadded:: 1.11
 
-Certain Python platforms have limitations in their ``ssl`` module that limits
-the configuration that ``urllib3`` can apply. In particular, this can cause
-HTTPS requests that would succeed on more featureful platforms to fail.
+Certain Python platforms (specifically, versions of Python earlier than 2.7.9)
+have restrictions in their ``ssl`` module that limit the configuration that
+``urllib3`` can apply. In particular, this can cause HTTPS requests that would
+succeed on more featureful platforms to fail.
 
 If you encounter this warning, it is strongly recommended you upgrade to a
 newer Python version, or that you use pyOpenSSL as described in the

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -171,7 +171,7 @@ warnings to your own log::
 Capturing the warnings to your own log is much preferred over simply disabling
 the warnings.
 
-SSLConfigurationWarning
+InsecurePlatformWarning
 -----------------------
 
 .. versionadded:: 1.11
@@ -179,7 +179,8 @@ SSLConfigurationWarning
 Certain Python platforms (specifically, versions of Python earlier than 2.7.9)
 have restrictions in their ``ssl`` module that limit the configuration that
 ``urllib3`` can apply. In particular, this can cause HTTPS requests that would
-succeed on more featureful platforms to fail.
+succeed on more featureful platforms to fail, and can cause certain security
+features to be unavailable.
 
 If you encounter this warning, it is strongly recommended you upgrade to a
 newer Python version, or that you use pyOpenSSL as described in the

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -18,14 +18,12 @@ from urllib3.util.url import (
 from urllib3.util.ssl_ import (
     resolve_cert_reqs,
     ssl_wrap_socket,
-    create_urllib3_context,
 )
 from urllib3.exceptions import (
     LocationParseError,
     TimeoutStateError,
     InsecureRequestWarning,
     SSLError,
-    SSLConfigurationWarning,
 )
 
 from urllib3.util import is_fp_closed, ssl_
@@ -378,24 +376,6 @@ class TestUtil(unittest.TestCase):
             pass
 
         self.assertRaises(ValueError, is_fp_closed, NotReallyAFile())
-
-    @patch('warnings.warn')
-    @patch('urllib3.util.ssl_.SSLContext')
-    def test_ssl_configuration_warnings(self, context, warn):
-        # The mock context will have the urllib3 attribute that fires the
-        # warning we want.
-        mock_context = Mock()
-        context.return_value = mock_context
-
-        # We need to allow options to be ORed in
-        mock_context.options = 0
-
-        create_urllib3_context()
-        self.assertTrue(warn.called)
-        call, = warn.call_args_list
-        category = call[0][1]
-        self.assertEqual(category, SSLConfigurationWarning)
-
 
     def test_ssl_wrap_socket_loads_the_cert_chain(self):
         socket = object()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -15,12 +15,17 @@ from urllib3.util.url import (
     split_first,
     Url,
 )
-from urllib3.util.ssl_ import resolve_cert_reqs, ssl_wrap_socket
+from urllib3.util.ssl_ import (
+    resolve_cert_reqs,
+    ssl_wrap_socket,
+    create_urllib3_context,
+)
 from urllib3.exceptions import (
     LocationParseError,
     TimeoutStateError,
     InsecureRequestWarning,
     SSLError,
+    SSLConfigurationWarning,
 )
 
 from urllib3.util import is_fp_closed, ssl_
@@ -373,6 +378,24 @@ class TestUtil(unittest.TestCase):
             pass
 
         self.assertRaises(ValueError, is_fp_closed, NotReallyAFile())
+
+    @patch('warnings.warn')
+    @patch('urllib3.util.ssl_.SSLContext')
+    def test_ssl_configuration_warnings(self, context, warn):
+        # The mock context will have the urllib3 attribute that fires the
+        # warning we want.
+        mock_context = Mock()
+        context.return_value = mock_context
+
+        # We need to allow options to be ORed in
+        mock_context.options = 0
+
+        create_urllib3_context()
+        self.assertTrue(warn.called)
+        call, = warn.call_args_list
+        category = call[0][1]
+        self.assertEqual(category, SSLConfigurationWarning)
+
 
     def test_ssl_wrap_socket_loads_the_cert_chain(self):
         socket = object()

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -30,7 +30,7 @@ from urllib3.exceptions import (
     ConnectTimeoutError,
     InsecureRequestWarning,
     SystemTimeWarning,
-    SSLConfigurationWarning,
+    InsecurePlatformWarning,
 )
 from urllib3.util.timeout import Timeout
 
@@ -72,7 +72,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 self.assertTrue(warn.called)
                 call, = warn.call_args_list
                 error = call[0][1]
-                self.assertEqual(error, SSLConfigurationWarning)
+                self.assertEqual(error, InsecurePlatformWarning)
 
     def test_invalid_common_name(self):
         https_pool = HTTPSConnectionPool('127.0.0.1', self.port,

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -30,6 +30,7 @@ from urllib3.exceptions import (
     ConnectTimeoutError,
     InsecureRequestWarning,
     SystemTimeWarning,
+    SSLConfigurationWarning,
 )
 from urllib3.util.timeout import Timeout
 
@@ -64,7 +65,14 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         with mock.patch('warnings.warn') as warn:
             r = https_pool.request('GET', '/')
             self.assertEqual(r.status, 200)
-            self.assertFalse(warn.called, warn.call_args_list)
+
+            if sys.version_info >= (2, 7, 9):
+                self.assertFalse(warn.called, warn.call_args_list)
+            else:
+                self.assertTrue(warn.called)
+                call, = warn.call_args_list
+                error = call[0][1]
+                self.assertEqual(error, SSLConfigurationWarning)
 
     def test_invalid_common_name(self):
         https_pool = HTTPSConnectionPool('127.0.0.1', self.port,
@@ -137,8 +145,11 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             self.assertEqual(r.status, 200)
             self.assertTrue(warn.called)
 
-            call, = warn.call_args_list
-            category = call[0][1]
+            calls = warn.call_args_list
+            if sys.version_info >= (2, 7, 9):
+                category = calls[0][0][1]
+            else:
+                category = calls[1][0][1]
             self.assertEqual(category, InsecureRequestWarning)
 
     @requires_network

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -144,6 +144,11 @@ class ResponseError(HTTPError):
     SPECIFIC_ERROR = 'too many {status_code} error responses'
 
 
+class SSLConfigurationWarning(HTTPWarning):
+    "Warned when certain SSL configuration is not available."
+    pass
+
+
 class SecurityWarning(HTTPWarning):
     "Warned when perfoming security reducing actions"
     pass

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -144,11 +144,6 @@ class ResponseError(HTTPError):
     SPECIFIC_ERROR = 'too many {status_code} error responses'
 
 
-class SSLConfigurationWarning(HTTPWarning):
-    "Warned when certain SSL configuration is not available."
-    pass
-
-
 class SecurityWarning(HTTPWarning):
     "Warned when perfoming security reducing actions"
     pass
@@ -161,4 +156,9 @@ class InsecureRequestWarning(SecurityWarning):
 
 class SystemTimeWarning(SecurityWarning):
     "Warned when system time is suspected to be wrong"
+    pass
+
+
+class InsecurePlatformWarning(SecurityWarning):
+    "Warned when certain SSL configuration is not available on a platform."
     pass

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -71,6 +71,14 @@ except ImportError:
             self.ciphers = cipher_suite
 
         def wrap_socket(self, socket, server_hostname=None):
+            warnings.warn(
+                'A true SSLContext object is not available. This prevents '
+                'urllib3 from configuring SSL appropriately. This may cause '
+                'certain SSL connections to fail. For more information, see '
+                'http://urllib3.readthedocs.org/en/latest/security.html'
+                '#sslconfigurationwarning.',
+                SSLConfigurationWarning
+            )
             kwargs = {
                 'keyfile': self.keyfile,
                 'certfile': self.certfile,
@@ -196,16 +204,6 @@ def create_urllib3_context(ssl_version=None, cert_reqs=ssl.CERT_REQUIRED,
     :rtype: SSLContext
     """
     context = SSLContext(ssl_version or ssl.PROTOCOL_SSLv23)
-
-    if hasattr(context, 'urllib3_wrapper_context'):
-        warnings.warn(
-            'A true SSLContext object is not available. This prevents urllib3 '
-            'from configuring SSL appropriately. This may cause certain SSL '
-            'connections to fail. For more information, see '
-            'http://urllib3.readthedocs.org/en/latest/security.html'
-            '#sslconfigurationwarning.',
-            SSLConfigurationWarning
-        )
 
     if options is None:
         options = 0

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -1,7 +1,7 @@
 from binascii import hexlify, unhexlify
 from hashlib import md5, sha1, sha256
 
-from ..exceptions import SSLError, SSLConfigurationWarning
+from ..exceptions import SSLError, InsecurePlatformWarning
 
 
 SSLContext = None
@@ -76,8 +76,8 @@ except ImportError:
                 'urllib3 from configuring SSL appropriately and may cause '
                 'certain SSL connections to fail. For more information, see '
                 'https://urllib3.readthedocs.org/en/latest/security.html'
-                '#sslconfigurationwarning.',
-                SSLConfigurationWarning
+                '#insecureplatformwarning.',
+                InsecurePlatformWarning
             )
             kwargs = {
                 'keyfile': self.keyfile,

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -73,9 +73,9 @@ except ImportError:
         def wrap_socket(self, socket, server_hostname=None):
             warnings.warn(
                 'A true SSLContext object is not available. This prevents '
-                'urllib3 from configuring SSL appropriately. This may cause '
+                'urllib3 from configuring SSL appropriately and may cause '
                 'certain SSL connections to fail. For more information, see '
-                'http://urllib3.readthedocs.org/en/latest/security.html'
+                'https://urllib3.readthedocs.org/en/latest/security.html'
                 '#sslconfigurationwarning.',
                 SSLConfigurationWarning
             )

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -41,7 +41,6 @@ except ImportError:
 
     class SSLContext(object):  # Platform-specific: Python 2 & 3.1
         supports_set_ciphers = sys.version_info >= (2, 7)
-        urllib3_wrapper_context = True
 
         def __init__(self, protocol_version):
             self.protocol = protocol_version


### PR DESCRIPTION
This change emits warnings when the `SSLContext` object isn't available.

To restrict the scope of the warning to situations only when it really isn't available, this warning actually gets emitted only if the weird mock object we use is actually being used. In no other circumstances should this warning be emitted.

The test is pretty ghetto, but it turns out to be kinda a pain in the ass to test this really properly. If you'd like me to, I can take another swing at it.