### PR TITLE
implement generator for chunked responses

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -142,5 +142,9 @@ In chronological order:
 * Alex Gaynor <alex.gaynor@gmail.com>
   * Updates to the default SSL configuration
 
+* Tomas Tomecek <ttomecek@redhat.com>
+  * Implemented generator for getting chunks from chunked responses.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -257,6 +257,35 @@ disabled individually.
 See the :class:`~urllib3.util.retry.Retry` definition for more details.
 
 
+Stream
+------
+
+You may also stream your response and get data as they come (e.g. when using
+``transfer-encoding: chunked``). In this case, method
+:func:`~urllib3.response.HTTPResponse.stream` will return generator.
+
+::
+
+    >>> import urllib3, datetime
+    >>> http = urllib3.PoolManager()
+
+    >>> # https://gist.github.com/josiahcarlson/3250376
+    >>> # server which responds with chunked encoding responses and
+    >>> # generates chunks every second
+    >>> r = http.request("GET", "http://localhost:8080/")
+
+    >>> r.getheader("transfer-encoding")
+    'chunked'
+
+    >>> for chunk in http.request("GET", "http://localhost:8080/").stream():
+          print "[%s] %s" % (datetime.datetime.now().strftime("%H:%M:%S.%f"), chunk)
+    [10:57:35.650812] this is chunk: 0
+    [10:57:36.652022] this is chunk: 1
+    [10:57:37.653238] this is chunk: 2
+    [10:57:38.654431] this is chunk: 3
+    [10:57:39.655601] this is chunk: 4
+
+
 Foundation
 ----------
 

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -162,3 +162,8 @@ class SystemTimeWarning(SecurityWarning):
 class InsecurePlatformWarning(SecurityWarning):
     "Warned when certain SSL configuration is not available on a platform."
     pass
+
+
+class ResponseNotChunked(ProtocolError, ValueError):
+    "Response needs to be chunked in order to read it as chunks."
+    pass

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -1,9 +1,15 @@
+try:
+    import http.client as httplib
+except ImportError:
+    import httplib
 import zlib
 import io
 from socket import timeout as SocketTimeout
 
 from ._collections import HTTPHeaderDict
-from .exceptions import ProtocolError, DecodeError, ReadTimeoutError
+from .exceptions import (
+    ProtocolError, DecodeError, ReadTimeoutError, ResponseNotChunked
+)
 from .packages.six import string_types as basestring, binary_type, PY3
 from .connection import HTTPException, BaseSSLError
 from .util.response import is_fp_closed
@@ -117,8 +123,17 @@ class HTTPResponse(io.IOBase):
         if hasattr(body, 'read'):
             self._fp = body
 
-        if preload_content and not self._body:
-            self._body = self.read(decode_content=decode_content)
+        # Are we using the chunked-style of transfer encoding?
+        self.chunked = False
+        self.chunk_left = None
+        tr_enc = self.headers.get('transfer-encoding', '')
+        if tr_enc.lower() == "chunked":
+            self.chunked = True
+
+        # We certainly don't want to preload content when the response is chunked.
+        if not self.chunked:
+            if preload_content and not self._body:
+                self._body = self.read(decode_content=decode_content)
 
     def get_redirect_location(self):
         """
@@ -269,11 +284,15 @@ class HTTPResponse(io.IOBase):
             If True, will attempt to decode the body based on the
             'content-encoding' header.
         """
-        while not is_fp_closed(self._fp):
-            data = self.read(amt=amt, decode_content=decode_content)
+        if self.chunked:
+            for line in self.read_chunked(amt):
+                yield line
+        else:
+            while not is_fp_closed(self._fp):
+                data = self.read(amt=amt, decode_content=decode_content)
 
-            if data:
-                yield data
+                if data:
+                    yield data
 
     @classmethod
     def from_httplib(ResponseCls, r, **response_kw):
@@ -351,3 +370,59 @@ class HTTPResponse(io.IOBase):
         else:
             b[:len(temp)] = temp
             return len(temp)
+
+    def read_chunked(self, amt=None):
+        # FIXME: Rewrite this method and make it a class with
+        #        a better structured logic.
+        if not self.chunked:
+            raise ResponseNotChunked("Response is not chunked. "
+                "Header 'transfer-encoding: chunked' is missing.")
+        while True:
+            # First, we'll figure out length of a chunk and then
+            # we'll try to read it from socket.
+            if self.chunk_left is None:
+                line = self._fp.fp.readline()
+                line = line.decode()
+                # See RFC 7230: Chunked Transfer Coding.
+                i = line.find(';')
+                if i >= 0:
+                    line = line[:i]  # Strip chunk-extensions.
+                try:
+                    self.chunk_left = int(line, 16)
+                except ValueError:
+                    # Invalid chunked protocol response, abort.
+                    self.close()
+                    raise httplib.IncompleteRead(''.join(line))
+                if self.chunk_left == 0:
+                    break
+            if amt is None:
+                chunk = self._fp._safe_read(self.chunk_left)
+                yield chunk
+                self._fp._safe_read(2)  # Toss the CRLF at the end of the chunk.
+                self.chunk_left = None
+            elif amt < self.chunk_left:
+                value = self._fp._safe_read(amt)
+                self.chunk_left = self.chunk_left - amt
+                yield value
+            elif amt == self.chunk_left:
+                value = self._fp._safe_read(amt)
+                self._fp._safe_read(2)  # Toss the CRLF at the end of the chunk.
+                self.chunk_left = None
+                yield value
+            else:  # amt > self.chunk_left
+                yield self._fp._safe_read(self.chunk_left)
+                self._fp._safe_read(2)  # Toss the CRLF at the end of the chunk.
+                self.chunk_left = None
+
+        # Chunk content ends with \r\n: discard it.
+        while True:
+            line = self._fp.fp.readline()
+            if not line:
+                # Some sites may not end with '\r\n'.
+                break
+            if line == b'\r\n':
+                break
+
+        # We read everything; close the "file".
+        self.close()
+


### PR DESCRIPTION
Fixes #550

So, I have figured out first, proof of concept, very hacky, very ugly implementation. I would like to get some feedback.

(Bear in mind that I haven't run a single test yet)

### How to test

I have used this code to generate chunked responses: https://gist.github.com/josiahcarlson/3250376

Client code:

```python
import urllib3
http = urllib3.PoolManager()
r = http.request('GET', 'http://localhost:8080/')
for x in r.stream():
    print x,
```
