### PR TITLE
Fix HTTPHeaderDict implementation for multiple headers

### DIFF
--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -201,6 +201,11 @@ class TestHTTPHeaderDict(unittest.TestCase):
         d2 = HTTPHeaderDict(d)
         self.assertEqual(d.getlist('set-cookie'), d2.getlist('set-cookie'))
 
+    def test_add_multi(self):
+        d = HTTPHeaderDict({'x-my-header': 'foo'})
+        d.add_multi('x-my-header', ['biz', 'baz'])
+        self.assertEqual(['foo', 'biz', 'baz'], d.getlist('x-my-header'))
+
     def test_update(self):
         self.d.update(dict(cookie='with, comma'))
         self.assertEqual(self.d.getlist('cookie'), ['with, comma'])

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -43,7 +43,6 @@ class TestCookies(SocketDummyServerTestCase):
         self._start_server(multicookie_response_handler)
         pool = HTTPConnectionPool(self.host, self.port)
         r = pool.request('GET', '/', retries=0)
-        self.assertEqual(r.headers, {'set-cookie': 'foo=1, bar=1'})
         self.assertEqual(r.headers.getlist('set-cookie'), ['foo=1', 'bar=1'])
 
 

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -155,8 +155,9 @@ class HTTPHeaderDict(dict):
         return val
 
     def __getitem__(self, key):
-        header, values = _dict_getitem(self, key.lower())
-        if header in SPECIAL_CASE_MULTIPLE_HEADERS:
+        key_lower = key.lower()
+        _, values = _dict_getitem(self, key_lower)
+        if key_lower in SPECIAL_CASE_MULTIPLE_HEADERS:
             # NOTE(sigmavirus24): Should we return something else?
             return values[0]
         return ', '.join(values)
@@ -172,10 +173,13 @@ class HTTPHeaderDict(dict):
             return False
         if not isinstance(other, type(self)):
             other = type(self)(other)
-        return dict((k1, self[k1]) for k1 in self) == dict((k2, other[k2]) for k2 in other)
+        getlist = self.getlist
+        otherlist = other.getlist
+        return (dict((k1.lower(), getlist(k1)) for k1 in self) ==
+                dict((k2.lower(), otherlist(k2)) for k2 in other))
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not (self == other)
 
     values = MutableMapping.values
     get = MutableMapping.get


### PR DESCRIPTION
- Allow all headers to have multiple values
- Special-case how cookie, set-cookie, and set-cookie2 are presented/handled
- Trim some extraneous whitespace

Fixes #561