### PR TITLE
don't use IPv6 in tests when it's not available

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -13,7 +13,8 @@ from urllib3.packages import six
 # Reset. SO suggests this hostname
 TARPIT_HOST = '10.255.255.1'
 
-VALID_SOURCE_ADDRESSES = [('::1', 0), ('127.0.0.1', 0)]
+# (Arguments for socket, is it IPv6 address?)
+VALID_SOURCE_ADDRESSES = [(('::1', 0), True), (('127.0.0.1', 0), False)]
 # RFC 5737: 192.0.2.0/24 is for testing only.
 # RFC 3849: 2001:db8::/32 is for documentation only.
 INVALID_SOURCE_ADDRESSES = [('192.0.2.255', 0), ('2001:db8::1', 0)]

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -4,6 +4,7 @@ import socket
 import sys
 import unittest
 import time
+import warnings
 
 import mock
 
@@ -35,6 +36,7 @@ from urllib3.util.timeout import Timeout
 
 import tornado
 from dummyserver.testcase import HTTPDummyServerTestCase
+from dummyserver.server import NoIPv6Warning
 
 from nose.tools import timed
 
@@ -597,7 +599,11 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertRaises(MaxRetryError, pool.request, 'GET', '/test', retries=2)
 
     def test_source_address(self):
-        for addr in VALID_SOURCE_ADDRESSES:
+        for addr, is_ipv6 in VALID_SOURCE_ADDRESSES:
+            if is_ipv6 and not socket.has_ipv6:
+                warnings.warn("No IPv6 support: skipping.",
+                              NoIPv6Warning)
+                continue
             pool = HTTPConnectionPool(self.host, self.port,
                     source_address=addr, retries=False)
             r = pool.request('GET', '/source_address')


### PR DESCRIPTION
Fixes #568