### PR TITLE
Properly detect Python 3.0-3.1 in SSLContext

### DIFF
--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -40,7 +40,8 @@ except ImportError:
     import sys
 
     class SSLContext(object):  # Platform-specific: Python 2 & 3.1
-        supports_set_ciphers = sys.version_info >= (2, 7)
+        supports_set_ciphers = (2, 7) <= sys.version_info < (3,) or \
+                               (3, 2) <= sys.version_info
 
         def __init__(self, protocol_version):
             self.protocol = protocol_version

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -40,8 +40,8 @@ except ImportError:
     import sys
 
     class SSLContext(object):  # Platform-specific: Python 2 & 3.1
-        supports_set_ciphers = (2, 7) <= sys.version_info < (3,) or \
-                               (3, 2) <= sys.version_info
+        supports_set_ciphers = ((2, 7) <= sys.version_info < (3,) or
+                                (3, 2) <= sys.version_info)
 
         def __init__(self, protocol_version):
             self.protocol = protocol_version


### PR DESCRIPTION
This stops pip (through its use of requests) from working under Python 3.1 (and probably 3.0 too).