### PR TITLE
Link the security docs from the front page of the docs.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ urllib3 Documentation
    helpers
    collections
    contrib
+   security
 
 
 Highlights


### PR DESCRIPTION
I keep getting confused by the fact that I can't find the security docs from the index.