### PR TITLE
Don't spam the platform warning

### DIFF
--- a/urllib3/__init__.py
+++ b/urllib3/__init__.py
@@ -55,9 +55,11 @@ def add_stderr_logger(level=logging.DEBUG):
 del NullHandler
 
 
-# Set security warning to always go off by default.
+# Set security warning to always go off by default, but leave InsecurePlatform
+# alone
 import warnings
 warnings.simplefilter('always', exceptions.SecurityWarning)
+warnings.simplefilter('default', exceptions.InsecurePlatformWarning)
 
 def disable_warnings(category=exceptions.HTTPWarning):
     """


### PR DESCRIPTION
The new ``InsecurePlatformWarning`` inherits from ``SecurityWarning``. The platform isn't going to vary based on different requests so it probably makes sense to set that one back to the default of ``once``? Otherwise users of urllib3 are getting spammed about their platform for any use instead of just once.

<bountysource-plugin>
---
Want to back this issue? **[Post a bounty on it!](https://www.bountysource.com/issues/9680856-don-t-spam-the-platform-warning?utm_campaign=plugin&utm_content=tracker%2F192525&utm_medium=issues&utm_source=github)** We accept bounties via [Bountysource](https://www.bountysource.com/?utm_campaign=plugin&utm_content=tracker%2F192525&utm_medium=issues&utm_source=github).
</bountysource-plugin>