### PR TITLE
Add timeout to ssl_wrap_socket

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -299,7 +299,9 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         try:
             cnx.do_handshake()
         except OpenSSL.SSL.WantReadError:
-            select.select([sock], [], [])
+            rd, _, _ = select.select([sock], [], [], sock.gettimeout())
+            if not rd:
+                raise timeout('select timed out')
             continue
         except OpenSSL.SSL.Error as e:
             raise ssl.SSLError('bad handshake', e)


### PR DESCRIPTION
Our code is getting stuck sometimes on `select.select([sock], [], [])` forever. It seems to me that we need a timeout in that call. Would adding `sock.gettimeout()` to the `select` call make any sense?