### PR TITLE
add a new test-nossl Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ clean:
 test: requirements
 	nosetests
 
+test-nossl: requirements
+	BLOCK_SSL=yes nosetests test/
+
 test-all: requirements
 	tox
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,7 @@
+import os
+if 'BLOCK_SSL' in os.environ:
+    import ssl_blocker
+
 import warnings
 import sys
 import errno

--- a/test/ssl_blocker.py
+++ b/test/ssl_blocker.py
@@ -1,0 +1,36 @@
+"""
+This module blocks importing SSL
+"""
+
+import sys
+
+
+if any(name.startswith('urllib3') for name in sys.modules.keys()):
+    raise ImportError('you must import the ssl_blocker before urllib3')
+
+
+# Nosetest will have implicitly imported ssl by now
+sys.modules.pop('ssl', None)
+sys.modules.pop('_ssl', None)
+
+
+class ImportBlocker(object):
+    """
+    Block Imports
+
+    To be placed on ``sys.meta_path``. This ensures that the modules
+    specified cannot be imported, even if they are a builtin.
+    """
+    def __init__(self, *namestoblock):
+        self.namestoblock = dict.fromkeys(namestoblock)
+        
+    def find_module(self, fullname, path=None):
+        if fullname in self.namestoblock:
+            return self
+        return None
+    
+    def load_module(self, fullname):
+        raise ImportError('import of {0} is blocked'.format(fullname))
+
+
+sys.meta_path.insert(0, ImportBlocker('ssl', '_ssl'))

--- a/test/test_no_ssl.py
+++ b/test/test_no_ssl.py
@@ -1,0 +1,24 @@
+"""
+Test what happens if Python was built without SSL
+
+* Everything that does not involve HTTPS should still work
+* HTTPS requests must fail with an error that points at the ssl module
+"""
+
+import sys
+from nose.plugins.skip import SkipTest
+import unittest
+
+
+if 'test.ssl_blocker' not in sys.modules:
+    raise SkipTest('you must set BLOCK_SSL=yes to block SSL')
+
+
+class TestWithoutSSL(unittest.TestCase):
+
+    def test_cannot_import_ssl(self):
+        with self.assertRaises(ImportError):
+            import ssl
+
+    def test_import_urllib3(self):
+        import urllib3


### PR DESCRIPTION
Adds "make test-nossl" to run the unittests  without ssl being importable. Right now urllib3 cannot be imported without ssl, but you can only fix it if you can test it.

Its somewhat tricky to test this because nosetests will have urllib3 already imported by the time the unittest is run. Hence this contraption with blocking ssl from the tip of `test/__init__.py`