### PR TITLE
make test suite more robust and compatible with Tornado 4

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -9,7 +9,7 @@ import time
 import zlib
 
 from io import BytesIO
-from tornado.wsgi import HTTPRequest
+from tornado.web import RequestHandler
 
 try:
     from urllib.parse import urlsplit
@@ -28,16 +28,17 @@ class Response(object):
         self.status = status
         self.headers = headers or [("Content-type", "text/plain")]
 
-    def __call__(self, environ, start_response):
-        start_response(self.status, self.headers)
-        return [self.body]
+    def __call__(self, request_handler):
+        status, reason = self.status.split(' ', 1)
+        request_handler.set_status(int(status), reason)
+        for header,value in self.headers:
+            request_handler.add_header(header,value.decode('utf8'))
 
+        request_handler.write(self.body)
 
-class WSGIHandler(object):
-    pass
+RETRY_TEST_NAMES = collections.defaultdict(int)
 
-
-class TestingApp(WSGIHandler):
+class TestingApp(RequestHandler):
     """
     Simple app that performs various operations, useful for testing an HTTP
     library.
@@ -46,10 +47,25 @@ class TestingApp(WSGIHandler):
     it exists. Status code 200 indicates success, 400 indicates failure. Each
     method has its own conditions for success/failure.
     """
-    def __call__(self, environ, start_response):
-        """ Call the correct method in this class based on the incoming URI """
-        req = HTTPRequest(environ)
+    def get(self):
+        """ Handle GET requests """
+        self._call_method()
 
+    def post(self):
+        """ Handle POST requests """
+        self._call_method()
+
+    def put(self):
+        """ Handle PUT requests """
+        self._call_method()
+
+    def options(self):
+        """ Handle OPTIONS requests """
+        self._call_method()
+
+    def _call_method(self):
+        """ Call the correct method in this class based on the incoming URI """
+        req = self.request
         req.params = {}
         for k, v in req.arguments.items():
             req.params[k] = next(iter(v))
@@ -60,13 +76,14 @@ class TestingApp(WSGIHandler):
 
         target = path[1:].replace('/', '_')
         method = getattr(self, target, self.index)
+
         resp = method(req)
 
         if dict(resp.headers).get('Connection') == 'close':
             # FIXME: Can we kill the connection somehow?
             pass
 
-        return resp(environ, start_response)
+        resp(self)
 
     def index(self, _request):
         "Render simple message"
@@ -184,11 +201,9 @@ class TestingApp(WSGIHandler):
             return Response("test-name header not set",
                             status="400 Bad Request")
 
-        if not hasattr(self, 'retry_test_names'):
-            self.retry_test_names = collections.defaultdict(int)
-        self.retry_test_names[test_name] += 1
+        RETRY_TEST_NAMES[test_name] += 1
 
-        if self.retry_test_names[test_name] >= 2:
+        if RETRY_TEST_NAMES[test_name] >= 2:
             return Response("Retry successful!")
         else:
             return Response("need to keep retrying!", status="418 I'm A Teapot")

--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -32,7 +32,7 @@ class Response(object):
         status, reason = self.status.split(' ', 1)
         request_handler.set_status(int(status), reason)
         for header,value in self.headers:
-            request_handler.add_header(header,value.decode('utf8'))
+            request_handler.add_header(header,value)
 
         request_handler.write(self.body)
 

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -18,7 +18,6 @@ import warnings
 from urllib3.exceptions import HTTPWarning
 
 from tornado.platform.auto import set_close_exec
-import tornado.wsgi
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web
@@ -206,7 +205,7 @@ if __name__ == '__main__':
     host = '127.0.0.1'
 
     io_loop = tornado.ioloop.IOLoop()
-    app = tornado.wsgi.WSGIContainer(TestingApp())
+    app = tornado.web.Application([(r".*", TestingApp)])
     server, port = run_tornado_app(app, io_loop, None,
                                    'http', host)
     server_thread = run_loop_in_thread(io_loop)

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -30,7 +30,8 @@ class SocketDummyServerTestCase(unittest.TestCase):
                                                ready_event=ready_event,
                                                host=cls.host)
         cls.server_thread.start()
-        ready_event.wait()
+        if not ready_event.wait(5):
+            raise Exception("most likely failed to start server")
         cls.port = cls.server_thread.port
 
     @classmethod

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -30,7 +30,8 @@ class SocketDummyServerTestCase(unittest.TestCase):
                                                ready_event=ready_event,
                                                host=cls.host)
         cls.server_thread.start()
-        if not ready_event.wait(5):
+        ready_event.wait(5)
+        if not ready_event.is_set():
             raise Exception("most likely failed to start server")
         cls.port = cls.server_thread.port
 

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -2,7 +2,7 @@ import unittest
 import socket
 import threading
 from nose.plugins.skip import SkipTest
-from tornado import ioloop, web, wsgi
+from tornado import ioloop, web
 
 from dummyserver.server import (
     SocketServerThread,
@@ -55,7 +55,7 @@ class HTTPDummyServerTestCase(unittest.TestCase):
     @classmethod
     def _start_server(cls):
         cls.io_loop = ioloop.IOLoop()
-        app = wsgi.WSGIContainer(TestingApp())
+        app = web.Application([(r".*", TestingApp)])
         cls.server, cls.port = run_tornado_app(app, cls.io_loop, cls.certs,
                                                cls.scheme, cls.host)
         cls.server_thread = run_loop_in_thread(cls.io_loop)
@@ -97,11 +97,11 @@ class HTTPDummyProxyTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.io_loop = ioloop.IOLoop()
 
-        app = wsgi.WSGIContainer(TestingApp())
+        app = web.Application([(r'.*', TestingApp)])
         cls.http_server, cls.http_port = run_tornado_app(
             app, cls.io_loop, None, 'http', cls.http_host)
 
-        app = wsgi.WSGIContainer(TestingApp())
+        app = web.Application([(r'.*', TestingApp)])
         cls.https_server, cls.https_port = run_tornado_app(
             app, cls.io_loop, cls.https_certs, 'https', cls.http_host)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -618,14 +618,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             self.assertRaises(ProtocolError,
                     pool.request, 'GET', '/source_address')
 
-    @onlyPy3
-    def test_httplib_headers_case_insensitive(self):
-        HEADERS = {'Content-Length': '0', 'Content-type': 'text/plain',
-                    'Server': 'TornadoServer/%s' % tornado.version}
-        r = self.pool.request('GET', '/specific_method',
-                               fields={'method': 'GET'})
-        self.assertEqual(HEADERS, dict(r.headers.items())) # to preserve case sensitivity
-
 
 class TestRetry(HTTPDummyServerTestCase):
     def setUp(self):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -18,6 +18,8 @@ from dummyserver.testcase import SocketDummyServerTestCase
 from dummyserver.server import (
     DEFAULT_CERTS, DEFAULT_CA, get_unreachable_address)
 
+from .. import onlyPy3
+
 from nose.plugins.skip import SkipTest
 from threading import Event
 import socket
@@ -598,3 +600,19 @@ class TestErrorWrapping(SocketDummyServerTestCase):
         self._start_server(handler)
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
         self.assertRaises(ProtocolError, pool.request, 'GET', '/')
+
+class TestHeaders(SocketDummyServerTestCase):
+
+    @onlyPy3
+    def test_httplib_headers_case_insensitive(self):
+        handler = create_response_handler(
+           b'HTTP/1.1 200 OK\r\n'
+           b'Content-Length: 0\r\n'
+           b'Content-type: text/plain\r\n'
+           b'\r\n'
+        )
+        self._start_server(handler)
+        pool = HTTPConnectionPool(self.host, self.port, retries=False)
+        HEADERS = {'Content-Length': '0', 'Content-type': 'text/plain'}
+        r = pool.request('GET', '/')
+        self.assertEqual(HEADERS, dict(r.headers.items())) # to preserve case sensitivity


### PR DESCRIPTION
the current test suite relies on WSGI compatibility layer from Tornado 3, which was significantly reworked in version 4. As a result, one can't easily create Tornado HTTPRequests from WSGI parameters (I ran afoul of issue https://github.com/tornadoweb/tornado/issues/1118, which has since been fixed, but it is still safer to avoid it entirely).
fwiw, creating HTTPRequest from WSGI values this way doesn't make sense when the whole point of Tornado WSGI wrapper is to convert HTTPRequest *to* WSGI values, so, um.

This is a rather crude but practical way to use Tornado RequestHandler directly instead of the WSGI runaround.

In the second commit, I make the socket-based tests time out instead of hanging forever if for whatever reason the server fails to start. A similar change might be useful for the HTTP tests, but it's not as straightforward, so maybe next time ;)