### PR TITLE
Fix #602: don't override existing warning config at import

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -145,6 +145,9 @@ In chronological order:
 * Tomas Tomecek <ttomecek@redhat.com>
   * Implemented generator for getting chunks from chunked responses.
 
+* tlynn <https://github.com/tlynn>
+  * Respect the warning preferences at import.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]
 

--- a/urllib3/__init__.py
+++ b/urllib3/__init__.py
@@ -57,9 +57,10 @@ del NullHandler
 
 import warnings
 # SecurityWarning's always go off by default.
-warnings.simplefilter('always', exceptions.SecurityWarning)
+warnings.simplefilter('always', exceptions.SecurityWarning, append=True)
 # InsecurePlatformWarning's don't vary between requests, so we keep it default.
-warnings.simplefilter('default', exceptions.InsecurePlatformWarning)
+warnings.simplefilter('default', exceptions.InsecurePlatformWarning,
+                      append=True)
 
 def disable_warnings(category=exceptions.HTTPWarning):
     """


### PR DESCRIPTION
Filter warnings with append=True to fix issue #602.

No test since it affects import-time behaviour and it's a two-word change, but I've given it a quick try and it seems to do the right thing.

I haven't changed disable_warnings(), since if people are calling that they presumably mean it, and can call the underlying method if not.