### PR TITLE
Learn from httplib how to handle chunked HEAD requests

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -616,3 +616,33 @@ class TestHeaders(SocketDummyServerTestCase):
         HEADERS = {'Content-Length': '0', 'Content-type': 'text/plain'}
         r = pool.request('GET', '/')
         self.assertEqual(HEADERS, dict(r.headers.items())) # to preserve case sensitivity
+
+
+class TestHEAD(SocketDummyServerTestCase):
+    def test_chunked_head_response_does_not_hang(self):
+        handler = create_response_handler(
+           b'HTTP/1.1 200 OK\r\n'
+           b'Transfer-Encoding: chunked\r\n'
+           b'Content-type: text/plain\r\n'
+           b'\r\n'
+        )
+        self._start_server(handler)
+        pool = HTTPConnectionPool(self.host, self.port, retries=False)
+        r = pool.request('HEAD', '/', timeout=1, preload_content=False)
+
+        # stream will use the read_chunked method here.
+        self.assertEqual([], list(r.stream()))
+
+    def test_empty_head_response_does_not_hang(self):
+        handler = create_response_handler(
+           b'HTTP/1.1 200 OK\r\n'
+           b'Content-Length: 256\r\n'
+           b'Content-type: text/plain\r\n'
+           b'\r\n'
+        )
+        self._start_server(handler)
+        pool = HTTPConnectionPool(self.host, self.port, retries=False)
+        r = pool.request('HEAD', '/', timeout=1, preload_content=False)
+
+        # stream will use the read method here.
+        self.assertEqual([], list(r.stream()))

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -432,14 +432,14 @@ class HTTPResponse(io.IOBase):
             'content-encoding' header.
         """
         self._init_decoder()
-        # FIXME: Rewrite this method and make it a class with
-        #        a better structured logic.
+        # FIXME: Rewrite this method and make it a class with a better structured logic.
         if not self.chunked:
             raise ResponseNotChunked("Response is not chunked. "
                 "Header 'transfer-encoding: chunked' is missing.")
 
-        if (self._original_response and
-                self._original_response._method.upper() == 'HEAD'):
+        if self._original_response and self._original_response._method.upper() == 'HEAD':
+            # Don't bother reading the body of a HEAD request.
+            # FIXME: Can we do this somehow without accessing private httplib _method?
             self._original_response.close()
             return
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -437,6 +437,12 @@ class HTTPResponse(io.IOBase):
         if not self.chunked:
             raise ResponseNotChunked("Response is not chunked. "
                 "Header 'transfer-encoding: chunked' is missing.")
+
+        if (self._original_response and
+                self._original_response._method.upper() == 'HEAD'):
+            self._original_response.close()
+            return
+
         while True:
             self._update_chunk_length()
             if self.chunk_left == 0:


### PR DESCRIPTION
When we perform a HEAD request and get a response with a chunked
transfer-encoding, there's no point in looking for a body at all. We
should just close the response immediately.

Fixes #601 

cc @Lukasa this needs (probably) socket-level tests