### PR TITLE
don't allow path in urls which do not begin with /

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -97,6 +97,7 @@ class TestUtil(unittest.TestCase):
     parse_url_host_map = {
         'http://google.com/mail': Url('http', host='google.com', path='/mail'),
         'http://google.com/mail/': Url('http', host='google.com', path='/mail/'),
+        'http://google.com/mail': Url('http', host='google.com', path='mail'),
         'google.com/mail': Url(host='google.com', path='/mail'),
         'http://google.com/': Url('http', host='google.com', path='/'),
         'http://google.com': Url('http', host='google.com'),

--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -15,6 +15,8 @@ class Url(namedtuple('Url', url_attrs)):
 
     def __new__(cls, scheme=None, auth=None, host=None, port=None, path=None,
                 query=None, fragment=None):
+        if path and not path.startswith('/'):
+            path = '/' + path
         return super(Url, cls).__new__(cls, scheme, auth, host, port, path,
                                        query, fragment)
 


### PR DESCRIPTION
It was possible to create such an object, but it would not
serialize -> parse roundtrip.

The alternative would be to reject paths without a leading /