### PR TITLE
Issue #610 -- Tests fallback to IPv4 if IPv6 fails

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -148,6 +148,9 @@ In chronological order:
 * tlynn <https://github.com/tlynn>
   * Respect the warning preferences at import.
 
+* David D. Riddle <ddriddle@illinois.edu>
+  * IPv6 bugfixes in testsuite
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -36,7 +36,7 @@ from urllib3.util.timeout import Timeout
 
 import tornado
 from dummyserver.testcase import HTTPDummyServerTestCase
-from dummyserver.server import NoIPv6Warning
+from dummyserver.server import NoIPv6Warning, HAS_IPV6_AND_DNS
 
 from nose.tools import timed
 
@@ -600,7 +600,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
     def test_source_address(self):
         for addr, is_ipv6 in VALID_SOURCE_ADDRESSES:
-            if is_ipv6 and not socket.has_ipv6:
+            if is_ipv6 and not HAS_IPV6_AND_DNS:
                 warnings.warn("No IPv6 support: skipping.",
                               NoIPv6Warning)
                 continue

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,6 +1,8 @@
 import unittest
 import json
 
+from nose.plugins.skip import SkipTest
+from dummyserver.server import HAS_IPV6
 from dummyserver.testcase import (HTTPDummyServerTestCase,
                                   IPv6HTTPDummyServerTestCase)
 from urllib3.poolmanager import PoolManager
@@ -154,6 +156,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
 
 class TestIPv6PoolManager(IPv6HTTPDummyServerTestCase):
+    if not HAS_IPV6:
+        raise SkipTest("IPv6 is not supported on this system.")
+
     def setUp(self):
         self.base_url = 'http://[%s]:%d' % (self.host, self.port)
 


### PR DESCRIPTION
On some systems binding to an IPv6 address will fail with a socket.gaierror exception even though socket.has_ipv6 is set to True. Added code to catch these exceptions and fallback to using IPv4.