### PR TITLE
Further improvements to pyopenssl sendall()

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -85,6 +85,8 @@ _openssl_verify = {
 
 DEFAULT_SSL_CIPHER_LIST = util.ssl_.DEFAULT_CIPHERS
 
+# OpenSSL will only write 16K at a time
+SSL_WRITE_BLOCKSIZE = 16384
 
 orig_util_HAS_SNI = util.HAS_SNI
 orig_connection_ssl_wrap_socket = connection.ssl_wrap_socket
@@ -206,8 +208,7 @@ class WrappedSocket(object):
     def sendall(self, data):
         total_sent = 0
         while total_sent < len(data):
-            # OpenSSL will only write 16K at once
-            sent = self._send_until_done(data[total_sent:total_sent+16384])
+            sent = self._send_until_done(data[total_sent:total_sent+SSL_WRITE_BLOCKSIZE])
             total_sent += sent
 
     def shutdown(self):

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -56,7 +56,6 @@ from pyasn1.type import univ, constraint
 from socket import _fileobject, timeout
 import ssl
 import select
-import sys
 
 from .. import connection
 from .. import util
@@ -88,6 +87,12 @@ DEFAULT_SSL_CIPHER_LIST = util.ssl_.DEFAULT_CIPHERS
 
 # OpenSSL will only write 16K at a time
 SSL_WRITE_BLOCKSIZE = 16384
+
+try:
+    _ = memoryview
+    has_memoryview = True
+except NameError:
+    has_memoryview = False
 
 orig_util_HAS_SNI = util.HAS_SNI
 orig_connection_ssl_wrap_socket = connection.ssl_wrap_socket
@@ -207,7 +212,7 @@ class WrappedSocket(object):
                 continue
 
     def sendall(self, data):
-        if sys.version_info >= (2, 7) and not isinstance(data, memoryview):
+        if has_memoryview and not isinstance(data, memoryview):
             data = memoryview(data)
 
         total_sent = 0

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -56,6 +56,7 @@ from pyasn1.type import univ, constraint
 from socket import _fileobject, timeout
 import ssl
 import select
+import sys
 
 from .. import connection
 from .. import util
@@ -206,6 +207,9 @@ class WrappedSocket(object):
                 continue
 
     def sendall(self, data):
+        if sys.version_info >= (2, 7) and not isinstance(data, memoryview):
+            data = memoryview(data)
+
         total_sent = 0
         while total_sent < len(data):
             sent = self._send_until_done(data[total_sent:total_sent+SSL_WRITE_BLOCKSIZE])


### PR DESCRIPTION
Trying to address the feedback from #626 and #627
* no semi-magic number
* use a memoryview, even if PyOpenSSL will still perform a conversion to string (to make cffi happy) today.  Futureproofing!