### PR TITLE
HTTPHeaderDict in requests

### DIFF
--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -302,6 +302,7 @@ class TestHTTPHeaderDict(unittest.TestCase):
         hdict = {'Content-Length': '0', 'Content-type': 'text/plain', 'Server': 'TornadoServer/1.2.3'}
         h = dict(HTTPHeaderDict(hdict).items())
         self.assertEqual(hdict, h)
+        self.assertEqual(hdict, dict(HTTPHeaderDict(hdict)))
 
     def test_string_enforcement(self):
         # This currently throws AttributeError on key.lower(), should probably be something nicer

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -9,6 +9,7 @@ from dummyserver.server import (
     DEFAULT_CA, DEFAULT_CA_BAD, get_unreachable_address)
 from .. import TARPIT_HOST
 
+from urllib3._collections import HTTPHeaderDict
 from urllib3.poolmanager import proxy_from_url, ProxyManager
 from urllib3.exceptions import (
     MaxRetryError, SSLError, ProxyError, ConnectTimeoutError)
@@ -48,7 +49,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_proxy_conn_fail(self):
         host, port = get_unreachable_address()
-        http = proxy_from_url('http://%s:%s/' % (host, port), retries=1)
+        http = proxy_from_url('http://%s:%s/' % (host, port), retries=1, timeout=0.05)
         self.assertRaises(MaxRetryError, http.request, 'GET',
                           '%s/' % self.https_url)
         self.assertRaises(MaxRetryError, http.request, 'GET',
@@ -222,6 +223,22 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
                 '%s:%s'%(self.https_host,self.https_port))
+
+    def test_headerdict(self):
+        default_headers = HTTPHeaderDict(a='b')
+        proxy_headers = HTTPHeaderDict()
+        proxy_headers.add('foo', 'bar')
+
+        http = proxy_from_url(
+            self.proxy_url,
+            headers=default_headers,
+            proxy_headers=proxy_headers)
+
+        request_headers = HTTPHeaderDict(baz='quux')
+        r = http.request('GET', '%s/headers' % self.http_url, headers=request_headers)
+        returned_headers = json.loads(r.data.decode())
+        self.assertEqual(returned_headers.get('foo'), 'bar')
+        self.assertEqual(returned_headers.get('baz'), 'quux')
 
     def test_proxy_pooling(self):
         http = proxy_from_url(self.proxy_url)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -13,6 +13,7 @@ from urllib3.exceptions import (
 from urllib3.util.ssl_ import HAS_SNI
 from urllib3.util.timeout import Timeout
 from urllib3.util.retry import Retry
+from urllib3._collections import HTTPHeaderDict
 
 from dummyserver.testcase import SocketDummyServerTestCase
 from dummyserver.server import (
@@ -355,7 +356,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = 'http://%s:%d' % (self.host, self.port)
 
         # Define some proxy headers.
-        proxy_headers = {'For The Proxy': 'YEAH!'}
+        proxy_headers = HTTPHeaderDict({'For The Proxy': 'YEAH!'})
         proxy = proxy_from_url(base_url, proxy_headers=proxy_headers)
 
         conn = proxy.connection_from_url('http://www.google.com/')

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -174,7 +174,7 @@ class HTTPHeaderDict(dict):
     values = MutableMapping.values
     get = MutableMapping.get
     update = MutableMapping.update
-    
+
     if not PY3: # Python 2
         iterkeys = MutableMapping.iterkeys
         itervalues = MutableMapping.itervalues
@@ -236,7 +236,7 @@ class HTTPHeaderDict(dict):
             raise TypeError("extend() takes at most 1 positional "
                             "arguments ({} given)".format(len(args)))
         other = args[0] if len(args) >= 1 else ()
-        
+
         if isinstance(other, HTTPHeaderDict):
             for key, val in other.iteritems():
                 self.add(key, val)
@@ -307,16 +307,16 @@ class HTTPHeaderDict(dict):
     def from_httplib(cls, message): # Python 2
         """Read headers from a Python 2 httplib message object."""
         # python2.7 does not expose a proper API for exporting multiheaders
-        # efficiently. This function re-reads raw lines from the message 
+        # efficiently. This function re-reads raw lines from the message
         # object and extracts the multiheaders properly.
         headers = []
-         
+
         for line in message.headers:
             if line.startswith((' ', '\t')):
                 key, value = headers[-1]
                 headers[-1] = (key, value + '\r\n' + line.rstrip())
                 continue
-    
+
             key, value = line.split(':', 1)
             headers.append((key, value.strip()))
 


### PR DESCRIPTION
Do we want to accept HTTPHeaderDict objects in request header fields interchangeably with dicts/lists of tuples? Any reason why not?

Right now if we do that, `foo=bar` headers get encoded as `foo: ('Foo': 'bar')`

- [x] Tests
- [ ] Fix

Fixes #632