### PR TITLE
Do not use `assert`. Use a ValueError instead

### DIFF
--- a/test/test_proxymanager.py
+++ b/test/test_proxymanager.py
@@ -38,6 +38,10 @@ class TestProxyManager(unittest.TestCase):
         p = ProxyManager('https://something')
         self.assertEqual(p.proxy.port, 443)
 
+    def test_invalid_scheme(self):
+        self.assertRaises(AssertionError, ProxyManager, 'invalid://host/p')
+        self.assertRaises(ValueError, ProxyManager, 'invalid://host/p')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -167,3 +167,12 @@ class InsecurePlatformWarning(SecurityWarning):
 class ResponseNotChunked(ProtocolError, ValueError):
     "Response needs to be chunked in order to read it as chunks."
     pass
+
+
+class ProxySchemeUnknown(AssertionError, ValueError):
+    "ProxyManager does not support the supplied scheme"
+    # TODO(t-8ch): Stop inheriting from AssertionError in v2.0.
+
+    def __init__(self, scheme):
+        message = "Not supported proxy scheme %s" % scheme
+        super(ProxySchemeUnknown, self).__init__(self, message)

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -8,7 +8,7 @@ except ImportError:
 from ._collections import RecentlyUsedContainer
 from .connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from .connectionpool import port_by_scheme
-from .exceptions import LocationValueError, MaxRetryError
+from .exceptions import LocationValueError, MaxRetryError, ProxySchemeUnknown
 from .request import RequestMethods
 from .util.url import parse_url
 from .util.retry import Retry
@@ -227,8 +227,8 @@ class ProxyManager(PoolManager):
             port = port_by_scheme.get(proxy.scheme, 80)
             proxy = proxy._replace(port=port)
 
-        assert proxy.scheme in ("http", "https"), \
-            'Not supported proxy scheme %s' % proxy.scheme
+        if proxy.scheme not in ("http", "https"):
+            raise ProxySchemeUnknown(proxy.scheme)
 
         self.proxy = proxy
         self.proxy_headers = proxy_headers or {}


### PR DESCRIPTION
However we have to be backwards compatible.
See #634