### PR TITLE
Cleanup properly after timeout or connection-based error.

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -17,6 +17,8 @@ from urllib3.exceptions import (
     SSLError,
 )
 
+from dummyserver.testcase import HTTPDummyServerTestCase
+
 from socket import error as SocketError
 from ssl import SSLError as BaseSSLError
 
@@ -226,40 +228,51 @@ class TestConnectionPool(unittest.TestCase):
 
         self.assertRaises(Empty, old_pool_queue.get, block=False)
 
-    def test_connection_recycling(self):
+
+class TestConnectionPoolConnectionCleanup(HTTPDummyServerTestCase):
+    '''
+    Tests in this suite are concerned with managing the pool
+    connections, specifically in the event of errors where
+    connection recycling must be handled internally.
+    '''
+    def test_cleanup_on_connection_error(self):
         '''
         Test that connections are recycled to the pool on 
-        connection/readtimeout errors where no http response 
-        is received.
+        connection errors where no http response is received.
         '''
         poolsize = 2
-        with HTTPConnectionPool('google.com', maxsize=poolsize, 
-                                  retries=1, block=True) as pool:
-
-            self.assertEqual(pool.pool.qsize(), poolsize)
-
-            # set a silly read timeout to force timeout exception. 
-            # We won't get a response for this and so the conn won't 
-            # be implicitly returned to the pool.
-            pool.timeout._read = 0
-            self.assertRaises(MaxRetryError, pool.urlopen, 'GET', 
-                              'http://google.com',
-                              release_conn=False)
-
-            # the pool should still contain poolsize elements
-            self.assertEqual(pool.pool.qsize(), poolsize)
-
         with HTTPConnectionPool('localhost', maxsize=poolsize, 
                                   retries=1, block=True) as pool:
 
             self.assertEqual(pool.pool.qsize(), poolsize)
 
-            # force a connection error by supplying a 
-            # non-existent url. We won't get a response for this 
-            # and so the conn won't be implicitly returned to 
-            # the pool.
+            # force a connection error by supplying a non-existent 
+            # url. We won't get a response for this  and so the 
+            # conn won't be implicitly returned to the pool.
             self.assertRaises(MaxRetryError, pool.urlopen, 'GET', 
                               'localhost/nosuchurl',
+                              release_conn=False)
+
+            # the pool should still contain poolsize elements
+            self.assertEqual(pool.pool.qsize(), poolsize)
+
+    def test_cleanup_on_read_timeout(self):
+        '''
+        Test that connections are recycled to the pool on 
+        connection errors where no http response is received.
+        '''
+        poolsize = 2
+        with HTTPConnectionPool('localhost', maxsize=poolsize, 
+                                  retries=1, block=True) as pool:
+
+            self.assertEqual(pool.pool.qsize(), poolsize)
+
+            # set a silly read timeout to force timeout exception.
+            # We won't get a response for this and so the conn won't
+            # be implicitly returned to the pool.
+            pool.timeout._read = 0
+            self.assertRaises(MaxRetryError, pool.urlopen, 'GET', 
+                              'localhost',
                               release_conn=False)
 
             # the pool should still contain poolsize elements


### PR DESCRIPTION
If you run the test I've added without the changes it will fail. It should pass with the updates to connectionpool.py.
I've added cleanup code for BaseSSLError, CertificateError, and SSLError as well (which looks like it should be handled in the same way) but no test for this.