### PR TITLE
[Docs] Suggest people `pip install cryptography`

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -126,7 +126,7 @@ are several limitations which are addressed by PyOpenSSL:
 To use the Python OpenSSL bindings instead, you'll need to install the required
 packages::
 
-    $ pip install pyopenssl ndg-httpsclient pyasn1
+    $ pip install pyopenssl ndg-httpsclient pyasn1 cryptography
 
 Once the packages are installed, you can tell urllib3 to switch the ssl backend
 to PyOpenSSL with :func:`~urllib3.contrib.pyopenssl.inject_into_urllib3`::

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -126,7 +126,11 @@ are several limitations which are addressed by PyOpenSSL:
 To use the Python OpenSSL bindings instead, you'll need to install the required
 packages::
 
-    $ pip install pyopenssl ndg-httpsclient pyasn1 cryptography
+    $ pip install pyopenssl ndg-httpsclient pyasn1
+
+If ``cryptography`` fails to install as a dependency, make sure you have `libffi
+<http://sourceware.org/libffi/>`_ available on your system and run
+``pip install cryptography``.
 
 Once the packages are installed, you can tell urllib3 to switch the ssl backend
 to PyOpenSSL with :func:`~urllib3.contrib.pyopenssl.inject_into_urllib3`::


### PR DESCRIPTION
When I tried to follow these instructions to use PyOpenSSL on Ubuntu 14.04, the `import urllib3.contrib.pyopenssl` line failed in Python as the `cryptography` was not already installed in my base Python.  Installing it separately (in the virtualenv in which I was doing this work) made it so these instructions worked.  I think it should be one of the requirements specified here; at worst, it will already be installed in the user's Python and be a no-op.

It was also necessary for me to `sudo apt-get install libffi-dev`, before some of the other `pip` requirements would install.  It may be worth noting that in a platform-agnostic way, or not.