### PR TITLE
Get rid of any trailing whitespace on hostname

### DIFF
--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -177,6 +177,7 @@ def parse_url(url):
     # Port
     if ':' in url:
         _host, port = url.split(':', 1)
+	port = port.rstrip() # Drop any trailing whitespace
 
         if not host:
             host = _host


### PR DESCRIPTION
Add port.rstrip to get rid of any trialing whitespace on the hostname.
Any trialing whitespace will cause port.isdigit() to fail. This can be a
very hard bug to find. Many hostnames are taken from files and it is a
very simple thing for someone to leave a trailing space when typing in a
hostname.