### PR TITLE
Fix usage headers argument for PoolManager

### DIFF
--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -130,6 +130,14 @@ class TestPoolManager(HTTPDummyServerTestCase):
     def test_headers(self):
         http = PoolManager(headers={'Foo': 'bar'})
 
+        r = http.request('GET', '%s/headers' % self.base_url)
+        returned_headers = json.loads(r.data.decode())
+        self.assertEqual(returned_headers.get('Foo'), 'bar')
+
+        r = http.request('POST', '%s/headers' % self.base_url)
+        returned_headers = json.loads(r.data.decode())
+        self.assertEqual(returned_headers.get('Foo'), 'bar')
+        
         r = http.request_encode_url('GET', '%s/headers' % self.base_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -152,7 +152,7 @@ class PoolManager(RequestMethods):
 
         kw['assert_same_host'] = False
         kw['redirect'] = False
-        if 'headers' not in kw or kw['headers'] == None:
+        if 'headers' not in kw:
             kw['headers'] = self.headers
 
         if self.proxy is not None and u.scheme == "http":

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -152,7 +152,7 @@ class PoolManager(RequestMethods):
 
         kw['assert_same_host'] = False
         kw['redirect'] = False
-        if 'headers' not in kw:
+        if 'headers' not in kw or kw['headers'] == None:
             kw['headers'] = self.headers
 
         if self.proxy is not None and u.scheme == "http":

--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -76,6 +76,9 @@ class RequestMethods(object):
         Make a request using :meth:`urlopen` with the ``fields`` encoded in
         the url. This is useful for request methods like GET, HEAD, DELETE, etc.
         """
+        if 'headers' not in urlopen_kw or urlopen_kw['headers'] is None:
+            urlopen_kw['headers'] = self.headers
+
         if fields:
             url += '?' + urlencode(fields)
         return self.urlopen(method, url, **urlopen_kw)

--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -71,17 +71,22 @@ class RequestMethods(object):
                                             headers=headers,
                                             **urlopen_kw)
 
-    def request_encode_url(self, method, url, fields=None, **urlopen_kw):
+    def request_encode_url(self, method, url, fields=None, headers=None,
+                           **urlopen_kw):
         """
         Make a request using :meth:`urlopen` with the ``fields`` encoded in
         the url. This is useful for request methods like GET, HEAD, DELETE, etc.
         """
-        if 'headers' not in urlopen_kw or urlopen_kw['headers'] is None:
-            urlopen_kw['headers'] = self.headers
+        if headers is None:
+            headers = self.headers
+
+        extra_kw = {'headers': headers}
+        extra_kw.update(urlopen_kw)
 
         if fields:
             url += '?' + urlencode(fields)
-        return self.urlopen(method, url, **urlopen_kw)
+
+        return self.urlopen(method, url, **extra_kw)
 
     def request_encode_body(self, method, url, fields=None, headers=None,
                             encode_multipart=True, multipart_boundary=None,


### PR DESCRIPTION
Argument headers for PoolManager doesn't work as it should ("Headers to include with all requests, unless other headers are given explicitly.") for request method.

Sample:

```python
import urllib3
manager = urllib3.PoolManager(headers = urllib3.make_headers(accept_encoding = True, user_agent = 'urllib3'))
request = manager.request('GET', 'http://httpbin.org/headers')
print request.data
```

Result:

```json
{
  "headers": {
    "Accept-Encoding": "identity",
    "Host": "httpbin.org"
  }
}
```