### PR TITLE
close response on connection errors during read

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -312,7 +312,6 @@ class TestSocketClosing(SocketDummyServerTestCase):
                        '\r\n' % len(body)).encode('utf-8'))
 
             timed_out.wait()
-            sock.send(body.encode('utf-8'))
             sock.close()
 
         self._start_server(socket_handler)

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -231,45 +231,65 @@ class HTTPResponse(io.IOBase):
             return
 
         flush_decoder = False
+        data = None
 
         try:
-            try:
-                if amt is None:
-                    # cStringIO doesn't like amt=None
-                    data = self._fp.read()
+            if amt is None:
+                # cStringIO doesn't like amt=None
+                data = self._fp.read()
+                flush_decoder = True
+            else:
+                cache_content = False
+                data = self._fp.read(amt)
+                if amt != 0 and not data:  # Platform-specific: Buggy versions of Python.
+                    # Close the connection when no data is returned
+                    #
+                    # This is redundant to what httplib/http.client _should_
+                    # already do.  However, versions of python released before
+                    # December 15, 2012 (http://bugs.python.org/issue16298) do
+                    # not properly close the connection in all cases. There is
+                    # no harm in redundantly calling close.
+                    self._fp.close()
                     flush_decoder = True
-                else:
-                    cache_content = False
-                    data = self._fp.read(amt)
-                    if amt != 0 and not data:  # Platform-specific: Buggy versions of Python.
-                        # Close the connection when no data is returned
-                        #
-                        # This is redundant to what httplib/http.client _should_
-                        # already do.  However, versions of python released before
-                        # December 15, 2012 (http://bugs.python.org/issue16298) do
-                        # not properly close the connection in all cases. There is
-                        # no harm in redundantly calling close.
-                        self._fp.close()
-                        flush_decoder = True
 
-            except SocketTimeout:
-                # FIXME: Ideally we'd like to include the url in the ReadTimeoutError but
-                # there is yet no clean way to get at it from this context.
-                raise ReadTimeoutError(self._pool, None, 'Read timed out.')
+        except SocketTimeout:
+            # the response may not be closed but we're not going to use it anymore
+            # so close it now to ensure that the connection is released back to the pool
+            if self._original_response and not self._original_response.isclosed():
+                self._original_response.close()
 
-            except BaseSSLError as e:
-                # FIXME: Is there a better way to differentiate between SSLErrors?
-                if 'read operation timed out' not in str(e):  # Defensive:
-                    # This shouldn't happen but just in case we're missing an edge
-                    # case, let's avoid swallowing SSL errors.
-                    raise
+            # FIXME: Ideally we'd like to include the url in the ReadTimeoutError but
+            # there is yet no clean way to get at it from this context.
+            raise ReadTimeoutError(self._pool, None, 'Read timed out.')
 
-                raise ReadTimeoutError(self._pool, None, 'Read timed out.')
+        except BaseSSLError as e:
+            # the response may not be closed but we're not going to use it anymore
+            # so close it now to ensure that the connection is released back to the pool
+            if self._original_response and not self._original_response.isclosed():
+                self._original_response.close()
 
-            except HTTPException as e:
-                # This includes IncompleteRead.
-                raise ProtocolError('Connection broken: %r' % e, e)
+            # FIXME: Is there a better way to differentiate between SSLErrors?
+            if 'read operation timed out' not in str(e):  # Defensive:
+                # This shouldn't happen but just in case we're missing an edge
+                # case, let's avoid swallowing SSL errors.
+                raise
 
+            raise ReadTimeoutError(self._pool, None, 'Read timed out.')
+
+        except HTTPException as e:
+            # the response may not be closed but we're not going to use it anymore
+            # so close it now to ensure that the connection is released back to the pool
+            if self._original_response and not self._original_response.isclosed():
+                self._original_response.close()
+
+            # This includes IncompleteRead.
+            raise ProtocolError('Connection broken: %r' % e, e)
+
+        finally:
+            if self._original_response and self._original_response.isclosed():
+                self.release_conn()
+
+        if data:
             self._fp_bytes_read += len(data)
 
             data = self._decode(data, decode_content, flush_decoder)
@@ -277,11 +297,8 @@ class HTTPResponse(io.IOBase):
             if cache_content:
                 self._body = data
 
-            return data
+        return data
 
-        finally:
-            if self._original_response and self._original_response.isclosed():
-                self.release_conn()
 
     def stream(self, amt=2**16, decode_content=None):
         """


### PR DESCRIPTION
I've added a couple of test cases for this in test_socketlevel.py that just compare the poolsize before and after calls to read (that fail). Without the changes to request.py these tests will fail.
I also moved the finally block to above the decoding code, which means we get to release the connection a little bit sooner. If there's an exception during self._fp.read that code will be skipped anyway.