### PR TITLE
Fix IPv6 HTTPS proxy

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -163,6 +163,9 @@ In chronological order:
 * James Atherfold <jlatherfold@hotmail.com>
   * Bugfixes relating to cleanup of connections during errors.
 
+* Christian Pedersen <https://github.com/chripede>
+  * IPv6 HTTPS proxy bugfix
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]
 

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -14,7 +14,6 @@ from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
 
 
-
 class SocketDummyServerTestCase(unittest.TestCase):
     """
     A simple socket-based server is created for this class that is good for
@@ -131,3 +130,16 @@ class IPv6HTTPDummyServerTestCase(HTTPDummyServerTestCase):
             raise SkipTest('IPv6 not available')
         else:
             super(IPv6HTTPDummyServerTestCase, cls).setUpClass()
+
+
+class IPv6HTTPDummyProxyTestCase(HTTPDummyProxyTestCase):
+
+    http_host = 'localhost'
+    http_host_alt = '127.0.0.1'
+
+    https_host = 'localhost'
+    https_host_alt = '127.0.0.1'
+    https_certs = DEFAULT_CERTS
+
+    proxy_host = '::1'
+    proxy_host_alt = '127.0.0.1'

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -4,7 +4,7 @@ import unittest
 
 from nose.tools import timed
 
-from dummyserver.testcase import HTTPDummyProxyTestCase
+from dummyserver.testcase import HTTPDummyProxyTestCase, IPv6HTTPDummyProxyTestCase
 from dummyserver.server import (
     DEFAULT_CA, DEFAULT_CA_BAD, get_unreachable_address)
 from .. import TARPIT_HOST
@@ -282,6 +282,27 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.fail("Failed to raise retry error.")
         except MaxRetryError as e:
             assert isinstance(e.reason, ConnectTimeoutError)
+
+
+class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
+
+    def setUp(self):
+        self.http_url = 'http://%s:%d' % (self.http_host, self.http_port)
+        self.http_url_alt = 'http://%s:%d' % (self.http_host_alt,
+                                              self.http_port)
+        self.https_url = 'https://%s:%d' % (self.https_host, self.https_port)
+        self.https_url_alt = 'https://%s:%d' % (self.https_host_alt,
+                                                self.https_port)
+        self.proxy_url = 'http://[%s]:%d' % (self.proxy_host, self.proxy_port)
+
+    def test_basic_ipv6_proxy(self):
+        http = proxy_from_url(self.proxy_url)
+
+        r = http.request('GET', '%s/' % self.http_url)
+        self.assertEqual(r.status, 200)
+
+        r = http.request('GET', '%s/' % self.https_url)
+        self.assertEqual(r.status, 200)
 
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -60,8 +60,8 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     """
 
     host, port = address
-    if host[0] == '[':
-        host = host.replace('[', '').replace(']', '')
+    if host.startswith('['):
+        host = host.strip('[]')
     err = None
     for res in socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM):
         af, socktype, proto, canonname, sa = res

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -60,6 +60,8 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     """
 
     host, port = address
+    if host[0] == '[':
+        host = host.replace('[', '').replace(']', '')
     err = None
     for res in socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM):
         af, socktype, proto, canonname, sa = res


### PR DESCRIPTION
When using an IPv6 proxy for https connections the connection would fail with

`MaxRetryError: HTTPSConnectionPool(host='localhost', port=53619): Max retries exceeded with url: / (Caused by ProxyError('Cannot connect to proxy.', gaierror(-2, 'Name or service not known')))`

That happens because the hard brackets are not removed before calling getaddrinfo.

This fixes that.