### PR TITLE
Indicate hostname in SubjectAltNameWarning

### DIFF
--- a/urllib3/__init__.py
+++ b/urllib3/__init__.py
@@ -58,6 +58,8 @@ del NullHandler
 import warnings
 # SecurityWarning's always go off by default.
 warnings.simplefilter('always', exceptions.SecurityWarning, append=True)
+# SubjectAltNameWarning's should go off once per host
+warnings.simplefilter('default', exceptions.SubjectAltNameWarning)
 # InsecurePlatformWarning's don't vary between requests, so we keep it default.
 warnings.simplefilter('default', exceptions.InsecurePlatformWarning,
                       append=True)

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -38,7 +38,7 @@ except NameError:  # Python 2:
 from .exceptions import (
     ConnectTimeoutError,
     SystemTimeWarning,
-    SecurityWarning,
+    SubjectAltNameWarning,
 )
 from .packages.ssl_match_hostname import match_hostname
 
@@ -248,10 +248,11 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             cert = self.sock.getpeercert()
             if not cert.get('subjectAltName', ()):
                 warnings.warn((
-                    'Certificate has no `subjectAltName`, falling back to check for a `commonName` for now. '
-                    'This feature is being removed by major browsers and deprecated by RFC 2818. '
-                    '(See https://github.com/shazow/urllib3/issues/497 for details.)'),
-                    SecurityWarning
+                    'Certificate for {0} has no `subjectAltName`, falling back to check for a '
+                    '`commonName` for now. This feature is being removed by major browsers and '
+                    'deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 '
+                    'for details.)'.format(hostname)),
+                    SubjectAltNameWarning
                 )
             match_hostname(cert, self.assert_hostname or hostname)
 

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -149,6 +149,11 @@ class SecurityWarning(HTTPWarning):
     pass
 
 
+class SubjectAltNameWarning(SecurityWarning):
+    "Warned when connecting to a host with a certificate missing a SAN."
+    pass
+
+
 class InsecureRequestWarning(SecurityWarning):
     "Warned when making an unverified HTTPS request."
     pass


### PR DESCRIPTION
This adds a new warning subclass for this warning specifically and has
it default to print exactly once (per message and therefore) per
hostname. This will reduce the number of warnings that users see and
provide an overall better user-experience. This allows the user to
determine the offending host and to only see the warning once per time
it connects to that host.