### PR TITLE
Replace select.select with util functions

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -55,7 +55,6 @@ from pyasn1.codec.der import decoder as der_decoder
 from pyasn1.type import univ, constraint
 from socket import _fileobject, timeout
 import ssl
-import select
 
 from .. import connection
 from .. import util
@@ -188,8 +187,8 @@ class WrappedSocket(object):
             else:
                 raise
         except OpenSSL.SSL.WantReadError:
-            rd, wd, ed = select.select(
-                [self.socket], [], [], self.socket.gettimeout())
+            socket = self.socket
+            rd = util.wait_to_read_data(socket, socket.gettimeout())
             if not rd:
                 raise timeout('The read operation timed out')
             else:
@@ -205,8 +204,8 @@ class WrappedSocket(object):
             try:
                 return self.connection.send(data)
             except OpenSSL.SSL.WantWriteError:
-                _, wlist, _ = select.select([], [self.socket], [],
-                                            self.socket.gettimeout())
+                socket = self.socket
+                wlist = util.wait_to_write_data(socket, socket.gettimeout())
                 if not wlist:
                     raise timeout()
                 continue
@@ -298,7 +297,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         try:
             cnx.do_handshake()
         except OpenSSL.SSL.WantReadError:
-            rd, _, _ = select.select([sock], [], [], sock.gettimeout())
+            rd = util.wait_to_read_data(sock, sock.gettimeout())
             if not rd:
                 raise timeout('select timed out')
             continue


### PR DESCRIPTION
select.poll is preferable when it is available. Unfortunately it isn't
available on every operating system but select.select is, so we can wrap
the logic to fall back to select.select from select.poll in helper
functions in urllib3.util.

Closes #589 
---

It is late here and this is more of a straw man PR than something I'm certain works. I was careful about the logic though so it should work (but again, I haven't done extensive testing).
