### PR TITLE
Rely on six to import httplib or http.client

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -1,7 +1,3 @@
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
 from contextlib import contextmanager
 import zlib
 import io
@@ -12,6 +8,7 @@ from .exceptions import (
     ProtocolError, DecodeError, ReadTimeoutError, ResponseNotChunked
 )
 from .packages.six import string_types as basestring, binary_type, PY3
+from .packages.six.moves import http_client as httplib
 from .connection import HTTPException, BaseSSLError
 from .util.response import is_fp_closed, is_response_to_head
 

--- a/urllib3/util/response.py
+++ b/urllib3/util/response.py
@@ -1,7 +1,4 @@
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
+from ..packages.six.moves import http_client as httplib
 
 from ..exceptions import HeaderParsingError
 


### PR DESCRIPTION
Regarding https://github.com/elastic/elasticsearch-py/issues/253