### PR TITLE
Use proper environment markers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,11 @@ max-line-length=99
 
 [wheel]
 universal = 1
+
+[metadata]
+provides-extra = secure
+requires-dist =
+    pyOpenSSL; python_version<="2.7" and extra == 'secure'
+    ndg-httpsclient; python_version<="2.7" and extra == 'secure'
+    pyasn1; python_version<="2.7" and extra == 'secure'
+    certifi; extra == 'secure'

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,13 @@ setup(name='urllib3',
       ],
       test_suite='test',
       extras_require={
-          'secure;python_version<="2.7"': [
+          'secure:python_version<="2.7"': [
               'pyOpenSSL',
               'ndg-httpsclient',
               'pyasn1',
               'certifi',
           ],
-          'secure;python_version>"2.7"': [
+          'secure:python_version>"2.7"': [
               'certifi',
           ],
       },

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,10 @@ setup(name='urllib3',
       ],
       test_suite='test',
       extras_require={
-          'secure:python_version<="2.7"': [
+          'secure': [
               'pyOpenSSL',
               'ndg-httpsclient',
               'pyasn1',
-              'certifi',
-          ],
-          'secure:python_version>"2.7"': [
               'certifi',
           ],
       },


### PR DESCRIPTION
This will intelligently install the right dependencies for a "secure"
urllib3 but only if you have a recent enough version of setuptools and
pip.

Closes #684