### PR TITLE
We do not require square brackets for httplib.

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -68,8 +68,7 @@ class ConnectionPool(object):
         if not host:
             raise LocationValueError("No host specified.")
 
-        # httplib doesn't like it when we include brackets in ipv6 addresses
-        self.host = host.strip('[]')
+        self.host = host
         self.port = port
 
     def __str__(self):


### PR DESCRIPTION
Resolves #707.

I need to come up with a test for this that doesn't suck, but it should be considered illuminating that no tests break with this change.