### PR TITLE
Add optional support for Brotli content-encoding

### DIFF
--- a/urllib3/contrib/brotlipy.py
+++ b/urllib3/contrib/brotlipy.py
@@ -1,0 +1,55 @@
+"""
+Support for Brotli compression as content-encoding.
+
+This needs the brotlipy package installed from PyPI. You can install it with
+the following command:
+
+    pip install brotlipy
+
+To activate Brotli support, call
+:func:`~urllib3.contrib.brotli.inject_into_urllib3` from your Python code
+before you start making HTTP requests, like this::
+
+    try:
+        import urllib3.contrib.brotlipy
+        urllib3.contrib.brotlipy.inject_into_urllib3()
+    except ImportError:
+        pass
+
+Now you can use :mod:`urllib3` as you normally would, and it will support
+Brotli content-encoding when the required modules are installed.
+"""
+import brotli
+
+from .. import response
+from ..util import request
+
+# Original _get_decoder method.
+original_decoder = response._get_decoder
+
+
+# New _get_decoder method.
+def _new_decoder(mode):
+    if mode == 'brotli':
+        return BrotliDecoder()
+
+    return original_decoder(mode)
+
+
+class BrotliDecoder(object):
+    def __init__(self):
+        self._obj = brotli.Decompressor()
+
+    def __getattr__(self, name):
+        return getattr(self._obj, name)
+
+    def decompress(self, data):
+        if not data:
+            return data
+        return self._obj.decompress(data)
+
+
+def inject_into_urllib3():
+    response.HTTPResponse.CONTENT_DECODERS.append('brotli')
+    request.ACCEPT_ENCODING += ',brotli'
+    response._get_decoder = _new_decoder


### PR DESCRIPTION
This pull request adds optional support for the [Brotli](http://google-opensource.blogspot.co.uk/2015/09/introducing-brotli-new-compression.html) compression algorithm used as a content-encoding, alongside the current support for gzip and deflate. Chromium have announced their [intention to implement](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/xdVm8c2GOMQ) Brotli, and Firefox 44 included [their support for Brotli](https://bugzilla.mozilla.org/show_bug.cgi?id=366559). Curl also [intend to implement Brotli](http://curl.haxx.se/docs/todo.html#More_compressions), but it'd be nice to beat @bagder to the punch for once!

Google claims that Brotli achieves 20%-26% higher compression ratios than other compression algorithms. They claim the reference implementation decodes just as quickly as deflate in zlib, but with denser compression than LZMA and bzip2.

This implementation currently relies on the hyper project's [brotlipy](https://github.com/python-hyper/brotlipy) sub-project, a CFFI-based wrapper around the Brotli reference implementation. For obvious reasons, as this adds a third-party dependency, the proposed enhancement is a `contrib` module.

Right now this contrib module monkeypatches its way into urllib3, but in the act of writing it I couldn't help but notice that we're really not very far from being able to have a 'formal' content-encoding plugin system. If that sounds like something worth having let me know, and I could write it and then refactor this contrib module to be the first user of that system. (On the other hand, it may simply not be worth it!)

In the short term, I don't think we should merge this just because I'm having trouble actually finding a site that uses Brotli! I think the best way to handle this is for me to offer an enhancement to httpbin that uses brotlipy to provide a `/brotli` endpoint, but that means I need to sit down and actually write that. That's blocked behind python-hyper/brotlipy#2, but I can hopefully get around to that soonish.