### PR TITLE
allows user paths for ca_cert verify path

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -172,6 +172,9 @@ In chronological order:
 * Predrag Gruevski <https://github.com/obi1kenobi>
   * Made cert digest comparison use a constant-time algorithm.
 
+* Adam Talsma <https://github.com/a-tal>
+  * Bugfix to ca_cert file paths.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import sys
 import socket
 from socket import error as SocketError, timeout as SocketTimeout
@@ -205,10 +206,12 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.key_file = key_file
         self.cert_file = cert_file
         self.cert_reqs = cert_reqs
-        self.ca_certs = ca_certs
         self.ca_cert_dir = ca_cert_dir
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
+        if ca_certs:
+            ca_certs = os.path.expanduser(ca_certs)
+        self.ca_certs = ca_certs
 
     def connect(self):
         # Add certificate verification

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -208,14 +208,8 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.cert_reqs = cert_reqs
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
-
-        if ca_certs:
-            ca_certs = os.path.expanduser(ca_certs)
-        if ca_cert_dir:
-            ca_cert_dir = os.path.expanduser(ca_cert_dir)
-
-        self.ca_certs = ca_certs
-        self.ca_cert_dir = ca_cert_dir
+        self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
+        self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
 
     def connect(self):
         # Add certificate verification

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -206,12 +206,16 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.key_file = key_file
         self.cert_file = cert_file
         self.cert_reqs = cert_reqs
-        self.ca_cert_dir = ca_cert_dir
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
+
         if ca_certs:
             ca_certs = os.path.expanduser(ca_certs)
+        if ca_cert_dir:
+            ca_cert_dir = os.path.expanduser(ca_cert_dir)
+
         self.ca_certs = ca_certs
+        self.ca_cert_dir = ca_cert_dir
 
     def connect(self):
         # Add certificate verification


### PR DESCRIPTION
currently you get the following error:

```SSLError("bad ca_certs: '~/example.crt'", Error([('system library', 'fopen', 'No such file or directory'), ('BIO routines', 'BIO_new_file', 'no such file'), ('x509 certificate routines', 'X509_load_cert_crl_file', 'system lib')],))```