### PR TITLE
Remove `memoryview` usage in urllib3.contrib.pyopenssl#sendall

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -175,6 +175,8 @@ In chronological order:
 * Adam Talsma <https://github.com/a-tal>
   * Bugfix to ca_cert file paths.
 
+* Evan Meagher <https://evanmeagher.net>
+  * Bugfix related to `memoryview` usage in PyOpenSSL adapter
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]
-

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -88,12 +88,6 @@ DEFAULT_SSL_CIPHER_LIST = util.ssl_.DEFAULT_CIPHERS
 # OpenSSL will only write 16K at a time
 SSL_WRITE_BLOCKSIZE = 16384
 
-try:
-    _ = memoryview
-    has_memoryview = True
-except NameError:
-    has_memoryview = False
-
 orig_util_HAS_SNI = util.HAS_SNI
 orig_connection_ssl_wrap_socket = connection.ssl_wrap_socket
 
@@ -212,9 +206,6 @@ class WrappedSocket(object):
                 continue
 
     def sendall(self, data):
-        if has_memoryview and not isinstance(data, memoryview):
-            data = memoryview(data)
-
         total_sent = 0
         while total_sent < len(data):
             sent = self._send_until_done(data[total_sent:total_sent+SSL_WRITE_BLOCKSIZE])


### PR DESCRIPTION
As described in #717, `urllib3.contrib.pyopenssl#sendall` currently fails when WantWriteError is thrown by OpenSSL due to urllib3 preemptively casting the data to be written as a `memoryview`. This results in duplicate bytestring allocations by pyopenssl and OpenSSL issuing a SSL3_WRITE_PENDING error.

This change removes `memoryview` usage from `urllib3/contrib/pyopenssl.py`. We thus rely on the underlying pyOpenSSL library's ability to cast data to the proper bytestring type.