### PR TITLE
There's no reason not to preload chunked bodies.

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -130,8 +130,8 @@ class HTTPResponse(io.IOBase):
         if "chunked" in encodings:
             self.chunked = True
 
-        # We certainly don't want to preload content when the response is chunked.
-        if not self.chunked and preload_content and not self._body:
+        # If requested, preload the body.
+        if preload_content and not self._body:
             self._body = self.read(decode_content=decode_content)
 
     def get_redirect_location(self):


### PR DESCRIPTION
Resolves #718.

This was introduced during our work on chunked transfer encoding. It's actually a fairly dramatic functional change, and potentially moves the point of exceptions being thrown quite dramatically, as well as changes how long each function call will take. However, I think it's more in line with our internal implementation and our documented behaviour.