### PR TITLE
Catch exceptions on connection close

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -217,7 +217,10 @@ class WrappedSocket(object):
 
     def close(self):
         if self._makefile_refs < 1:
-            return self.connection.close()
+            try:
+                return self.connection.close()
+            except OpenSSL.SSL.Error:
+                return
         else:
             self._makefile_refs -= 1
 


### PR DESCRIPTION
Typically caused by remote IIS server dropping HTTPS keepalive
connections without shutting down properly

Fixes #728