### PR TITLE
Add proxy authentication example using ProxyManager

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -70,6 +70,17 @@ connections and individual per-server:port
 :class:`~urllib3.connectionpool.HTTPSConnectionPool` instances for tunnelled
 HTTPS connections.
 
+Example using proxy authentication:
+
+::
+
+	>>> headers = urllib3.make_headers(proxy_basic_auth='myusername:mypassword')
+	>>> proxy = urllib3.ProxyManager('http://localhost:3128', proxy_headers=headers)
+	>>> r = proxy.request('GET', 'http://example.com/')
+	>>> r.status
+	200
+
+
 API
 ---
     .. autoclass:: ProxyManager


### PR DESCRIPTION
I've struggled a bit while trying to google an example of using basic proxy authentication using urllib3,  therefore decided to add a bit of code sample to ProxyManager docs.
Not sure if I've placed it to the right place, doctests in source code seemed to be not appropriate.