### PR TITLE
Defensively close connections

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -181,5 +181,8 @@ In chronological order:
 * John Vandenberg <jayvdb@gmail.com>
   * Python 2.6 fixes; pyflakes and pep8 compliance
 
+* Andy Caldwell <andy.m.caldwell@googlemail.com>
+  * Bugfix related to reusing connections in indeterminate states.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -236,6 +236,12 @@ class HTTPResponse(io.IOBase):
             if self._original_response and not self._original_response.isclosed():
                 self._original_response.close()
 
+            # Closing the response may not actually be sufficient to close
+            # everything, so if we have a hold of the connection close that
+            # too.
+            if self._connection is not None:
+                self._connection.close()
+
             raise
         finally:
             if self._original_response and self._original_response.isclosed():


### PR DESCRIPTION
Generally speaking, if we hit an exception when working with a connection we should assume that the connection is dead. We've not been defensive enough with this in the past, and that attitude pretty much just leads us to a constant cycle of bug-squashing each time we discover a new connection-invalidating exception.

In this case, the problem (and the fix) were inspired by [this HN post](https://news.ycombinator.com/item?id=10512343). For that reason, I'd like to credit @rkday (in his guise as @rkd-msw) for the actual fix. Rob, if you'd like to, I'm happy for you to open a new pull request with these commits in place. If you don't care about the commit log, I've made sure you're added to CONTRIBUTORS.