### PR TITLE
Add absolute_import feature from the future

### DIFF
--- a/urllib3/__init__.py
+++ b/urllib3/__init__.py
@@ -1,6 +1,7 @@
 """
 urllib3 - Thread-safe connection pooling and re-using.
 """
+from __future__ import absolute_import
 import warnings
 
 from .connectionpool import (

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import Mapping, MutableMapping
 try:
     from threading import RLock

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import datetime
 import os
 import sys

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import errno
 import logging
 import sys

--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 import os
 import warnings

--- a/urllib3/contrib/ntlmpool.py
+++ b/urllib3/contrib/ntlmpool.py
@@ -3,6 +3,7 @@ NTLM authenticating pool, contributed by erikcederstran
 
 Issue #10, see: http://code.google.com/p/urllib3/issues/detail?id=10
 """
+from __future__ import absolute_import
 
 try:
     from http.client import HTTPSConnection

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -43,6 +43,7 @@ Module Variables
 .. _crime attack: https://en.wikipedia.org/wiki/CRIME_(security_exploit)
 
 '''
+from __future__ import absolute_import
 
 try:
     from ndg.httpsclient.ssl_peer_verification import SUBJ_ALT_NAME_SUPPORT

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -1,4 +1,4 @@
-
+from __future__ import absolute_import
 # Base Exceptions
 
 

--- a/urllib3/fields.py
+++ b/urllib3/fields.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import email.utils
 import mimetypes
 

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import codecs
 
 from uuid import uuid4

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 
 try:  # Python 3

--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 try:
     from urllib.parse import urlencode
 except ImportError:

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from contextlib import contextmanager
 import zlib
 import io

--- a/urllib3/util/__init__.py
+++ b/urllib3/util/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # For backwards compatibility, provide imports that used to be here.
 from .connection import is_connection_dropped
 from .request import make_headers

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import socket
 try:
     from select import poll, POLLIN

--- a/urllib3/util/request.py
+++ b/urllib3/util/request.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from base64 import b64encode
 
 from ..packages.six import b

--- a/urllib3/util/response.py
+++ b/urllib3/util/response.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from ..packages.six.moves import http_client as httplib
 
 from ..exceptions import HeaderParsingError

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import time
 import logging
 

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import errno
 import warnings
 import hmac

--- a/urllib3/util/timeout.py
+++ b/urllib3/util/timeout.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # The default socket timeout, used by httplib to indicate that no timeout was
 # specified by the user
 from socket import _GLOBAL_DEFAULT_TIMEOUT

--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from collections import namedtuple
 
 from ..exceptions import LocationParseError


### PR DESCRIPTION
This should prevent local files or modules from shadowing standard
library modules and will provide an all around better experience. This
does not, however, help us in the case where someone uses a library
like pies (which installs broken standard library shims for Python 2/
Python 3 compatibility).

Related to: https://github.com/kennethreitz/requests/issues/2771