### PR TITLE
Specify minimum pyOpenSSL version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ universal = 1
 [metadata]
 provides-extra = secure
 requires-dist =
-    pyOpenSSL; python_version<="2.7" and extra == 'secure'
+    pyOpenSSL>=0.13; python_version<="2.7" and extra == 'secure'
     ndg-httpsclient; python_version<="2.7" and extra == 'secure'
     pyasn1; python_version<="2.7" and extra == 'secure'
     certifi; extra == 'secure'

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name='urllib3',
       test_suite='test',
       extras_require={
           'secure': [
-              'pyOpenSSL',
+              'pyOpenSSL>=0.13',
               'ndg-httpsclient',
               'pyasn1',
               'certifi',


### PR DESCRIPTION
urllib3 requires "set_tlsext_host_name" which was only added in
pyOpenSSL 0.13. As some distributions (e.g. Ubuntu 12.04) still ship an
older version enforce the correct minimum version during installation.