### PR TITLE
Start keying connection pools off SSL arguments as well.

### DIFF
--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -95,20 +95,16 @@ class TestPoolManager(unittest.TestCase):
             'ca_certs': '/root/path_to_pem',
             'ssl_version': 'SSLv23_METHOD',
         }
-        p = PoolManager(5)
+        p = PoolManager(5, **ssl_kw)
         conns = []
         conns.append(
-            p.connection_from_host(
-                'example.com', 443, scheme='https', ssl_kwargs=ssl_kw
-            )
+            p.connection_from_host('example.com', 443, scheme='https')
         )
 
         for k in ssl_kw:
-            ssl_kw[k] = 'newval'
+            p.connection_pool_kw[k] = 'newval'
             conns.append(
-                p.connection_from_host(
-                    'example.com', 443, scheme='https', ssl_kwargs=ssl_kw
-                )
+                p.connection_from_host('example.com', 443, scheme='https')
             )
 
         self.assertTrue(

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -149,10 +149,10 @@ class PoolManager(RequestMethods):
         constructor.
         """
         u = parse_url(url)
-        ssl_kwargs = {
-            k: v for k, v in self.connection_pool_kw.items()
+        ssl_kwargs = dict(
+            (k, v) for k, v in self.connection_pool_kw.items()
             if k in SSL_KEYWORDS
-        }
+        )
         return self.connection_from_host(
             u.host, port=u.port, scheme=u.scheme, ssl_kwargs=ssl_kwargs
         )


### PR DESCRIPTION
This is a proposed patch that begins to implement the requirements for kennethreitz/requests#2863. In particular, it adds hooks to provide additional keyword arguments as part of the key for the connection pool.

There are some outstanding questions. For example:

- should we actually just use all the connection pool keyword arguments as part of the key? Why are `headers` et al exempt?
- Are we happy with this API, where `connection_from_host` picks up the new argument but `connection_from_url` does not?

Code review encouraged, please. :custard: