### PR TITLE
Repair flaky connection timeout tests.

### DIFF
--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -69,7 +69,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
         try:
             http.request('GET', '%s/redirect' % self.base_url,
                          fields={'target': cross_host_location},
-                         timeout=0.01, retries=0)
+                         timeout=1, retries=0)
             self.fail("Request succeeded instead of raising an exception like it should.")
 
         except MaxRetryError:
@@ -77,7 +77,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         r = http.request('GET', '%s/redirect' % self.base_url,
                          fields={'target': '%s/echo?a=b' % self.base_url_alt},
-                         timeout=0.01, retries=1)
+                         timeout=1, retries=1)
 
         self.assertEqual(r._pool.host, self.host_alt)
 
@@ -137,7 +137,7 @@ class TestPoolManager(HTTPDummyServerTestCase):
         r = http.request('POST', '%s/headers' % self.base_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
-        
+
         r = http.request_encode_url('GET', '%s/headers' % self.base_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -124,7 +124,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         try:
             http.request('GET', '%s/redirect' % self.http_url,
                          fields={'target': cross_host_location},
-                         timeout=0.1, retries=0)
+                         timeout=1, retries=0)
             self.fail("We don't want to follow redirects here.")
 
         except MaxRetryError:
@@ -132,7 +132,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
         r = http.request('GET', '%s/redirect' % self.http_url,
                          fields={'target': '%s/echo?a=b' % self.http_url_alt},
-                         timeout=0.1, retries=1)
+                         timeout=1, retries=1)
         self.assertNotEqual(r._pool.host, self.http_host_alt)
 
     def test_cross_protocol_redirect(self):
@@ -142,7 +142,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         try:
             http.request('GET', '%s/redirect' % self.http_url,
                          fields={'target': cross_protocol_location},
-                         timeout=0.1, retries=0)
+                         timeout=1, retries=0)
             self.fail("We don't want to follow redirects here.")
 
         except MaxRetryError:
@@ -150,7 +150,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
         r = http.request('GET', '%s/redirect' % self.http_url,
                          fields={'target': '%s/echo?a=b' % self.https_url},
-                         timeout=0.1, retries=1)
+                         timeout=1, retries=1)
         self.assertEqual(r._pool.host, self.https_host)
 
     def test_headers(self):


### PR DESCRIPTION
This PR changes the tests that previously used the `noop_handler` to instead use the `TARPIT_HOST`, which should fix their flakiness. See also #748.