### PR TITLE
Define an SNIMissingWarning.

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -206,6 +206,24 @@ newer Python version, or that you use pyOpenSSL as described in the
 For info about disabling warnings, see `Disabling Warnings`_.
 
 
+SNIMissingWarning
+-----------------
+
+.. versionadded:: 1.13
+
+Certain Python distributions (specifically, versions of Python earlier than
+2.7.9) and older OpenSSLs have restrictions that prevent them from using the
+SNI (Server Name Indication) extension. This can cause unexpected behaviour
+when making some HTTPS requests, usually causing the server to present the a
+TLS certificate that is not valid for the website you're trying to access.
+
+If you encounter this warning, it is strongly recommended that you upgrade
+to a newer Python version, or that you use pyOpenSSL as described in the
+:ref:`pyopenssl` section.
+
+For info about disabling warnings, see `Disabling Warnings`_.
+
+
 Disabling Warnings
 ------------------
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -35,6 +35,7 @@ from urllib3.exceptions import (
 )
 from urllib3.packages import six
 from urllib3.util.timeout import Timeout
+from urllib3.util.ssl_ import HAS_SNI
 
 
 ResourceWarning = getattr(
@@ -77,7 +78,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 self.assertFalse(warn.called, warn.call_args_list)
             else:
                 self.assertTrue(warn.called)
-                call = warn.call_args_list[0]
+                if HAS_SNI:
+                    call = warn.call_args_list[0]
+                else:
+                    call = warn.call_args_list[1]
                 error = call[0][1]
                 self.assertEqual(error, InsecurePlatformWarning)
 
@@ -176,8 +180,10 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             calls = warn.call_args_list
             if sys.version_info >= (2, 7, 9):
                 category = calls[0][0][1]
-            else:
+            elif HAS_SNI:
                 category = calls[1][0][1]
+            else:
+                category = calls[2][0][1]
             self.assertEqual(category, InsecureRequestWarning)
 
     @requires_network

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -77,7 +77,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                 self.assertFalse(warn.called, warn.call_args_list)
             else:
                 self.assertTrue(warn.called)
-                call, = warn.call_args_list
+                call = warn.call_args_list[0]
                 error = call[0][1]
                 self.assertEqual(error, InsecurePlatformWarning)
 

--- a/urllib3/__init__.py
+++ b/urllib3/__init__.py
@@ -81,6 +81,8 @@ warnings.simplefilter('default', exceptions.SubjectAltNameWarning)
 # InsecurePlatformWarning's don't vary between requests, so we keep it default.
 warnings.simplefilter('default', exceptions.InsecurePlatformWarning,
                       append=True)
+# SNIMissingWarnings should go off only once.
+warnings.simplefilter('default', exceptions.SNIMissingWarning)
 
 
 def disable_warnings(category=exceptions.HTTPWarning):

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -175,6 +175,11 @@ class InsecurePlatformWarning(SecurityWarning):
     pass
 
 
+class SNIMissingWarning(HTTPWarning):
+    "Warned when making a HTTPS request without SNI available."
+    pass
+
+
 class ResponseNotChunked(ProtocolError, ValueError):
     "Response needs to be chunked in order to read it as chunks."
     pass

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -305,7 +305,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         return context.wrap_socket(sock, server_hostname=server_hostname)
 
     warnings.warn(
-        'A HTTPS request has been made, but the SNI (Subject Name '
+        'An HTTPS request has been made, but the SNI (Subject Name '
         'Indication) extension to TLS is not available on this platform. '
         'This may cause the server to present an incorrect TLS '
         'certificate, which can cause validation failures. For more '

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -6,7 +6,7 @@ import hmac
 from binascii import hexlify, unhexlify
 from hashlib import md5, sha1, sha256
 
-from ..exceptions import SSLError, InsecurePlatformWarning
+from ..exceptions import SSLError, InsecurePlatformWarning, SNIMissingWarning
 
 
 SSLContext = None
@@ -303,4 +303,15 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         context.load_cert_chain(certfile, keyfile)
     if HAS_SNI:  # Platform-specific: OpenSSL with enabled SNI
         return context.wrap_socket(sock, server_hostname=server_hostname)
+
+    warnings.warn(
+        'A HTTPS request has been made, but the SNI (Subject Name '
+        'Indication) extension to TLS is not available on this platform. '
+        'This may cause the server to present an incorrect TLS '
+        'certificate, which can cause validation failures. For more '
+        'information, see '
+        'https://urllib3.readthedocs.org/en/latest/security.html'
+        '#snimissingwarning.',
+        SNIMissingWarning
+    )
     return context.wrap_socket(sock)


### PR DESCRIPTION
This fires whenever we make a HTTPS request and don't have SNI present. Should only fire once per run.

Resolves #753.

While we're here, @shazow @sigmavirus24: I'm thinking about having the docs URL be a property on the warning itself, so that requests can override them to point at our own docs when requests is being used. Thoughts?