### PR TITLE
Add SOCKS support via contrib module (AKA SOCKS support, take 4)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,9 @@
 [run]
 omit =
     urllib3/packages/*
-    urllib3/contrib/*
+    urllib3/contrib/appengine.py
+    urllib3/contrib/ntlmpool.py
+    urllib3/contrib/pyopenssl.py
 
 [report]
 exclude_lines =

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -55,6 +55,8 @@ There are `limitations <https://cloud.google.com/appengine/docs/python/urlfetch/
 SOCKS Proxies
 -------------
 
+.. versionadded:: 1.14.0
+
 The :mod:`urllib3.contrib.socks` module enables urllib3 to work with proxies
 that use either the SOCKS4 or SOCKS5 protocols. These proxies are common in
 environments that want to allow generic TCP/UDP traffic through their borders,

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -69,6 +69,12 @@ extra, like so:
 
     $ pip install urllib3[socks]
 
+If you have already got urllib3 1.14.0 or later installed, run:
+
+.. code-block:: bash
+
+    $ pip install -U urllib3[socks]
+
 The SOCKS module provides a
 :class:`SOCKSProxyManager <urllib3.contrib.socks.SOCKSProxyManager>` that can
 be used when SOCKS support is required. This class behaves very much like a

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -80,8 +80,8 @@ machine, listening on port 8889:
 
     from urllib3.contrib.socks import SOCKSProxyManager
 
-    pm = SOCKSProxyManager('socks5://localhost:8889/')
-    r = pm.request('GET', 'https://www.google.com/')
+    http = SOCKSProxyManager('socks5://localhost:8889/')
+    r = http.request('GET', 'https://www.google.com/')
 
 The SOCKS implementation supports the full range of urllib3 features. It also
 supports the following SOCKS features:

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -4,7 +4,7 @@ Contrib Modules
 ===============
 
 These modules implement various extra features, that may not be ready for
-prime time.
+prime time or that require optional third-party dependencies.
 
 .. _contrib-pyopenssl:
 

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -16,7 +16,7 @@ SNI-support for Python 2
 
 .. _gae:
 
-Google App Engine 
+Google App Engine
 -----------------
 
 The :mod:`urllib3.contrib.appengine` module provides a pool manager that
@@ -45,8 +45,54 @@ There are `limitations <https://cloud.google.com/appengine/docs/python/urlfetch/
 
 1. You can use :class:`AppEngineManager` with URLFetch. URLFetch is cost-effective in many circumstances as long as your usage is within the limitations.
 2. You can use a normal :class:`PoolManager` by enabling sockets. Sockets also have `limitations and restrictions <https://cloud.google.com/appengine/docs/python/sockets/#limitations-and-restrictions>`_ and have a lower free quota than URLFetch. To use sockets, be sure to specify the following in your ``app.yaml``::
-    
+
     env_variables:
         GAE_USE_SOCKETS_HTTPLIB : 'true'
 
 3. If you are using `Managed VMs <https://cloud.google.com/appengine/docs/managed-vms/>`_, you can use the standard :class:`PoolManager` without any configuration or special environment variables.
+
+
+SOCKS Proxies
+-------------
+
+The :mod:`urllib3.contrib.socks` module enables urllib3 to work with proxies
+that use either the SOCKS4 or SOCKS5 protocols. These proxies are common in
+environments that want to allow generic TCP/UDP traffic through their borders,
+but don't want unrestricted traffic flows.
+
+To use it, either install ``PySocks`` or install urllib3 with the ``socks``
+extra, like so:
+
+.. code-block:: bash
+
+    $ pip install urllib3[socks]
+
+The SOCKS module provides a
+:class:`SOCKSProxyManager <urllib3.contrib.socks.SOCKSProxyManager>` that can
+be used when SOCKS support is required. This class behaves very much like a
+standard :class:`ProxyManager <urllib3.poolmanager.ProxyManager>`, but allows
+the use of a SOCKS proxy instead.
+
+Using it is simple. For example, with a SOCKS5 proxy running on the local
+machine, listening on port 8889:
+
+.. code-block:: python
+
+    from urllib3.contrib.socks import SOCKSProxyManager
+
+    pm = SOCKSProxyManager('socks5://localhost:8889/')
+    r = pm.request('GET', 'https://www.google.com/')
+
+The SOCKS implementation supports the full range of urllib3 features. It also
+supports the following SOCKS features:
+
+- SOCKS4
+- SOCKS4a
+- SOCKS5
+- Usernames and passwords for the SOCKS proxy
+
+The SOCKS module does have the following limitations:
+
+- No support for contacting a SOCKS proxy via IPv6.
+- No support for reaching websites via a literal IPv6 address: domain names
+  must be used.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -327,7 +327,7 @@ Contrib Modules
 ---------------
 
 These modules implement various extra features, that may not be ready for
-prime time.
+prime time or that require optional third-party dependencies.
 
 * :ref:`contrib-modules`
 

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -85,6 +85,8 @@ class SocketServerThread(threading.Thread):
     :param ready_event: Event which gets set when the socket handler is
         ready to receive requests.
     """
+    USE_IPV6 = HAS_IPV6_AND_DNS
+
     def __init__(self, socket_handler, host='localhost', port=8081,
                  ready_event=None):
         threading.Thread.__init__(self)
@@ -95,7 +97,7 @@ class SocketServerThread(threading.Thread):
         self.ready_event = ready_event
 
     def _start_server(self):
-        if HAS_IPV6_AND_DNS:
+        if self.USE_IPV6:
             sock = socket.socket(socket.AF_INET6)
         else:
             warnings.warn("No IPv6 support. Falling back to IPv4.",

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -86,7 +86,6 @@ class IPV4SocketDummyServerTestCase(SocketDummyServerTestCase):
         cls.port = cls.server_thread.port
 
 
-
 class HTTPDummyServerTestCase(unittest.TestCase):
     """ A simple HTTP server that runs when your test class runs
 

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -71,6 +71,22 @@ class SocketDummyServerTestCase(unittest.TestCase):
             cls.server_thread.join(0.1)
 
 
+class IPV4SocketDummyServerTestCase(SocketDummyServerTestCase):
+    @classmethod
+    def _start_server(cls, socket_handler):
+        ready_event = threading.Event()
+        cls.server_thread = SocketServerThread(socket_handler=socket_handler,
+                                               ready_event=ready_event,
+                                               host=cls.host)
+        cls.server_thread.USE_IPV6 = False
+        cls.server_thread.start()
+        ready_event.wait(5)
+        if not ready_event.is_set():
+            raise Exception("most likely failed to start server")
+        cls.port = cls.server_thread.port
+
+
+
 class HTTPDummyServerTestCase(unittest.TestCase):
     """ A simple HTTP server that runs when your test class runs
 

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,8 @@ setup(name='urllib3',
               'pyasn1',
               'certifi',
           ],
+          'socks': [
+              'PySocks>=1.5.6,<2.0',
+          ]
       },
       )

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -1,7 +1,7 @@
 import threading
 import socket
 
-from urllib3.contrib import socks_proxy
+from urllib3.contrib import socks
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
 
 from dummyserver.server import DEFAULT_CERTS
@@ -222,7 +222,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'http://16.17.18.19')
 
         self.assertEqual(response.status, 200)
@@ -257,7 +257,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
@@ -269,7 +269,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
             ConnectTimeoutError, pm.request, 'GET', 'http://example.com',
@@ -286,7 +286,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
 
         event.wait()
         self.assertRaises(
@@ -309,7 +309,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
             NewConnectionError, pm.request, 'GET', 'http://example.com',
@@ -343,7 +343,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='user',
+        pm = socks.SOCKSProxyManager(proxy_url, username='user',
                                            password='pass')
         response = pm.request('GET', 'http://16.17.18.19')
 
@@ -362,7 +362,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='user',
+        pm = socks.SOCKSProxyManager(proxy_url, username='user',
                                            password='badpass')
 
         try:
@@ -400,7 +400,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(
+        pm = socks.SOCKSProxyManager(
             proxy_url, source_address=('127.0.0.1', expected_port)
         )
         response = pm.request('GET', 'http://16.17.18.19')
@@ -438,7 +438,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks4://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'http://16.17.18.19')
 
         self.assertEqual(response.status, 200)
@@ -473,7 +473,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks4://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
@@ -492,7 +492,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks4://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
             NewConnectionError, pm.request, 'GET', 'http://example.com',
@@ -524,7 +524,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks4://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='user')
+        pm = socks.SOCKSProxyManager(proxy_url, username='user')
         response = pm.request('GET', 'http://16.17.18.19')
 
         self.assertEqual(response.status, 200)
@@ -540,7 +540,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks4://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='baduser')
+        pm = socks.SOCKSProxyManager(proxy_url, username='baduser')
 
         try:
             pm.request('GET', 'http://example.com', retries=False)
@@ -591,7 +591,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
 
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
-        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'https://localhost')
 
         self.assertEqual(response.status, 200)

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -212,7 +212,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             handler = handle_socks5_negotiation(sock, negotiate=False)
             addr, port = next(handler)
 
-            self.assertEqual(addr, b'http2bin.org')
+            self.assertEqual(addr, b'example.com')
             self.assertTrue(port, 80)
             handler.send(True)
 
@@ -223,7 +223,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
                     break
 
             self.assertTrue(buf.startswith(b'GET / HTTP/1.1'))
-            self.assertTrue(b'Host: http2bin.org' in buf)
+            self.assertTrue(b'Host: example.com' in buf)
 
             sock.sendall(b'HTTP/1.1 200 OK\r\n'
                          b'Server: SocksTestServer\r\n'
@@ -234,7 +234,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
         pm = socks_proxy.SOCKSProxyManager(proxy_url)
-        response = pm.request('GET', 'http://http2bin.org')
+        response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
     def test_connection_timeouts(self):
@@ -248,7 +248,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         pm = socks_proxy.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
-            ConnectTimeoutError, pm.request, 'GET', 'http://http2bin.org',
+            ConnectTimeoutError, pm.request, 'GET', 'http://example.com',
             timeout=0.001, retries=False
         )
         event.set()
@@ -266,7 +266,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
 
         event.wait()
         self.assertRaises(
-            NewConnectionError, pm.request, 'GET', 'http://http2bin.org',
+            NewConnectionError, pm.request, 'GET', 'http://example.com',
             retries=False
         )
 
@@ -288,7 +288,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         pm = socks_proxy.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
-            NewConnectionError, pm.request, 'GET', 'http://http2bin.org',
+            NewConnectionError, pm.request, 'GET', 'http://example.com',
             retries=False
         )
         evt.set()
@@ -342,7 +342,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
                                            password='badpass')
 
         try:
-            pm.request('GET', 'http://http2bin.org', retries=False)
+            pm.request('GET', 'http://example.com', retries=False)
         except NewConnectionError as e:
             self.assertTrue("SOCKS5 authentication failed" in str(e))
         else:
@@ -394,7 +394,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             handler = handle_socks4_negotiation(sock)
             addr, port = next(handler)
 
-            self.assertEqual(addr, b'http2bin.org')
+            self.assertEqual(addr, b'example.com')
             self.assertTrue(port, 80)
             handler.send(True)
 
@@ -405,7 +405,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
                     break
 
             self.assertTrue(buf.startswith(b'GET / HTTP/1.1'))
-            self.assertTrue(b'Host: http2bin.org' in buf)
+            self.assertTrue(b'Host: example.com' in buf)
 
             sock.sendall(b'HTTP/1.1 200 OK\r\n'
                          b'Server: SocksTestServer\r\n'
@@ -416,7 +416,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks4://%s:%s" % (self.host, self.port)
         pm = socks_proxy.SOCKSProxyManager(proxy_url)
-        response = pm.request('GET', 'http://http2bin.org')
+        response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
 
     def test_proxy_rejection(self):
@@ -437,7 +437,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         pm = socks_proxy.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
-            NewConnectionError, pm.request, 'GET', 'http://http2bin.org',
+            NewConnectionError, pm.request, 'GET', 'http://example.com',
             retries=False
         )
         evt.set()
@@ -485,7 +485,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
         pm = socks_proxy.SOCKSProxyManager(proxy_url, username='baduser')
 
         try:
-            pm.request('GET', 'http://http2bin.org', retries=False)
+            pm.request('GET', 'http://example.com', retries=False)
         except NewConnectionError as e:
             self.assertTrue("different user-ids" in str(e))
         else:

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -1,0 +1,492 @@
+import threading
+import socket
+
+from urllib3.contrib import socks_proxy
+from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
+
+from dummyserver.testcase import IPV4SocketDummyServerTestCase
+
+
+SOCKS_NEGOTIATION_NONE = b'\x00'
+SOCKS_NEGOTIATION_PASSWORD = b'\x02'
+
+SOCKS_VERSION_SOCKS4 = b'\x04'
+SOCKS_VERSION_SOCKS5 = b'\x05'
+
+
+def _read_exactly(sock, amt):
+    """
+    Read *exactly* ``amt`` bytes from the socket ``sock``.
+    """
+    data = b''
+
+    while amt > 0:
+        chunk = sock.recv(amt)
+        data += chunk
+        amt -= len(chunk)
+
+    return data
+
+
+def _read_until(sock, char):
+    """
+    Read from the socket until the character is received.
+    """
+    chunks = []
+    while True:
+        chunk = sock.recv(1)
+        chunks.append(chunk)
+        if chunk == char:
+            break
+
+    return b''.join(chunks)
+
+
+def _address_from_socket(sock):
+    """
+    Returns the address from the SOCKS socket
+    """
+    addr_type = sock.recv(1)
+
+    if addr_type == b'\x01':
+        ipv4_addr = _read_exactly(sock, 4)
+        return socket.inet_ntoa(ipv4_addr)
+    elif addr_type == b'\x04':
+        ipv6_addr = _read_exactly(sock, 16)
+        return socket.inet_ntop(socket.AF_INET6, ipv6_addr)
+    elif addr_type == b'\x03':
+        addr_len = ord(sock.recv(1))
+        return _read_exactly(sock, addr_len)
+    else:
+        raise RuntimeError("Unexpected addr type: %r" % addr_type)
+
+
+def handle_socks5_negotiation(sock, negotiate, username=None,
+                              password=None):
+    """
+    Handle the SOCKS5 handshake.
+
+    Returns a generator object that allows us to break the handshake into
+    steps so that the test code can intervene at certain useful points.
+    """
+    received_version = sock.recv(1)
+    assert received_version == SOCKS_VERSION_SOCKS5
+    nmethods = ord(sock.recv(1))
+    methods = _read_exactly(sock, nmethods)
+
+    if negotiate:
+        assert SOCKS_NEGOTIATION_PASSWORD in methods
+        send_data = SOCKS_VERSION_SOCKS5 + SOCKS_NEGOTIATION_PASSWORD
+        sock.sendall(send_data)
+
+        # This is the password negotiation.
+        negotiation_version = sock.recv(1)
+        assert negotiation_version == b'\x01'
+        ulen = ord(sock.recv(1))
+        provided_username = _read_exactly(sock, ulen)
+        plen = ord(sock.recv(1))
+        provided_password = _read_exactly(sock, plen)
+
+        if username == provided_username and password == provided_password:
+            sock.sendall(b'\x01\x00')
+        else:
+            sock.sendall(b'\x01\x01')
+            sock.close()
+            yield False
+            return
+    else:
+        assert SOCKS_NEGOTIATION_NONE in methods
+        send_data = SOCKS_VERSION_SOCKS5 + SOCKS_NEGOTIATION_NONE
+        sock.sendall(send_data)
+
+    # Client sends where they want to go.
+    received_version = sock.recv(1)
+    command = sock.recv(1)
+    reserved = sock.recv(1)
+    addr = _address_from_socket(sock)
+    port = _read_exactly(sock, 2)
+    port = (ord(port[0:1]) << 8) + (ord(port[1:2]))
+
+    # Check some basic stuff.
+    assert received_version == SOCKS_VERSION_SOCKS5
+    assert command == b'\x01'  # Only support connect, not bind.
+    assert reserved == b'\x00'
+
+    # Yield the address port tuple.
+    succeed = yield addr, port
+
+    if succeed:
+        # Hard-coded response for now.
+        response = (
+            SOCKS_VERSION_SOCKS5 + b'\x00\x00\x01\x7f\x00\x00\x01\xea\x60'
+        )
+    else:
+        # Hard-coded response for now.
+        response = SOCKS_VERSION_SOCKS5 + b'\x01\00'
+
+    sock.sendall(response)
+    yield True  # Avoid StopIteration exceptions getting fired.
+
+
+def handle_socks4_negotiation(sock, username=None):
+    """
+    Handle the SOCKS4 handshake.
+
+    Returns a generator object that allows us to break the handshake into
+    steps so that the test code can intervene at certain useful points.
+    """
+    received_version = sock.recv(1)
+    command = sock.recv(1)
+    port = _read_exactly(sock, 2)
+    port = (ord(port[0:1]) << 8) + (ord(port[1:2]))
+    addr = _read_exactly(sock, 4)
+    provided_username = _read_until(sock, b'\x00')[:-1]  # Strip trailing null.
+
+    if addr == b'\x00\x00\x00\x01':
+        # Magic string: means DNS name.
+        addr = _read_until(sock, b'\x00')[:-1]  # Strip trailing null.
+    else:
+        addr = socket.inet_ntoa(addr)
+
+    # Check some basic stuff.
+    assert received_version == SOCKS_VERSION_SOCKS4
+    assert command == b'\x01'  # Only support connect, not bind.
+
+    if username is not None and username != provided_username:
+        sock.sendall(b'\x00\x5d\x00\x00\x00\x00\x00\x00')
+        sock.close()
+        yield False
+        return
+
+    # Yield the address port tuple.
+    succeed = yield addr, port
+
+    if succeed:
+        response = b'\x00\x5a\xea\x60\x7f\x00\x00\x01'
+    else:
+        response = b'\x00\x5b\x00\x00\x00\x00\x00\x00'
+
+    sock.sendall(response)
+    yield True  # Avoid StopIteration exceptions getting fired.
+
+
+class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
+    """
+    Test the SOCKS proxy in SOCKS5 mode.
+    """
+    def test_basic_request(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks5_negotiation(sock, negotiate=False)
+            addr, port = next(handler)
+
+            self.assertEqual(addr, '16.17.18.19')
+            self.assertTrue(port, 80)
+            handler.send(True)
+
+            while True:
+                buf = sock.recv(65535)
+                if buf.endswith(b'\r\n\r\n'):
+                    break
+
+            sock.sendall(b'HTTP/1.1 200 OK\r\n'
+                         b'Server: SocksTestServer\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        response = pm.request('GET', 'http://16.17.18.19')
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.data, b'')
+        self.assertEqual(response.headers['Server'], 'SocksTestServer')
+
+    def test_correct_header_line(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks5_negotiation(sock, negotiate=False)
+            addr, port = next(handler)
+
+            self.assertEqual(addr, b'http2bin.org')
+            self.assertTrue(port, 80)
+            handler.send(True)
+
+            buf = b''
+            while True:
+                buf += sock.recv(65535)
+                if buf.endswith(b'\r\n\r\n'):
+                    break
+
+            self.assertTrue(buf.startswith(b'GET / HTTP/1.1'))
+            self.assertTrue(b'Host: http2bin.org' in buf)
+
+            sock.sendall(b'HTTP/1.1 200 OK\r\n'
+                         b'Server: SocksTestServer\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        response = pm.request('GET', 'http://http2bin.org')
+        self.assertEqual(response.status, 200)
+
+    def test_connection_timeouts(self):
+        event = threading.Event()
+
+        def request_handler(listener):
+            event.wait()
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+
+        self.assertRaises(
+            ConnectTimeoutError, pm.request, 'GET', 'http://http2bin.org',
+            timeout=0.001, retries=False
+        )
+        event.set()
+
+    def test_connection_failure(self):
+        event = threading.Event()
+
+        def request_handler(listener):
+            listener.close()
+            event.set()
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+
+        event.wait()
+        self.assertRaises(
+            NewConnectionError, pm.request, 'GET', 'http://http2bin.org',
+            retries=False
+        )
+
+    def test_proxy_rejection(self):
+        evt = threading.Event()
+
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks5_negotiation(sock, negotiate=False)
+            addr, port = next(handler)
+            handler.send(False)
+
+            evt.wait()
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+
+        self.assertRaises(
+            NewConnectionError, pm.request, 'GET', 'http://http2bin.org',
+            retries=False
+        )
+        evt.set()
+
+    def test_socks_with_password(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks5_negotiation(
+                sock, negotiate=True, username=b'user', password=b'pass'
+            )
+            addr, port = next(handler)
+
+            self.assertEqual(addr, '16.17.18.19')
+            self.assertTrue(port, 80)
+            handler.send(True)
+
+            while True:
+                buf = sock.recv(65535)
+                if buf.endswith(b'\r\n\r\n'):
+                    break
+
+            sock.sendall(b'HTTP/1.1 200 OK\r\n'
+                         b'Server: SocksTestServer\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='user',
+                                           password='pass')
+        response = pm.request('GET', 'http://16.17.18.19')
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.data, b'')
+        self.assertEqual(response.headers['Server'], 'SocksTestServer')
+
+    def test_socks_with_invalid_password(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks5_negotiation(
+                sock, negotiate=True, username=b'user', password=b'pass'
+            )
+            next(handler)
+
+        self._start_server(request_handler)
+        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='user',
+                                           password='badpass')
+
+        try:
+            pm.request('GET', 'http://http2bin.org', retries=False)
+        except NewConnectionError as e:
+            self.assertTrue("SOCKS5 authentication failed" in str(e))
+        else:
+            self.fail("Did not raise")
+
+
+class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
+    """
+    Test the SOCKS proxy in SOCKS4 mode.
+
+    Has relatively fewer tests than the SOCKS5 case, mostly because once the
+    negotiation is done the two cases behave identically.
+    """
+    def test_basic_request(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks4_negotiation(sock)
+            addr, port = next(handler)
+
+            self.assertEqual(addr, '16.17.18.19')
+            self.assertTrue(port, 80)
+            handler.send(True)
+
+            while True:
+                buf = sock.recv(65535)
+                if buf.endswith(b'\r\n\r\n'):
+                    break
+
+            sock.sendall(b'HTTP/1.1 200 OK\r\n'
+                         b'Server: SocksTestServer\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        response = pm.request('GET', 'http://16.17.18.19')
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.headers['Server'], 'SocksTestServer')
+        self.assertEqual(response.data, b'')
+
+    def test_correct_header_line(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks4_negotiation(sock)
+            addr, port = next(handler)
+
+            self.assertEqual(addr, b'http2bin.org')
+            self.assertTrue(port, 80)
+            handler.send(True)
+
+            buf = b''
+            while True:
+                buf += sock.recv(65535)
+                if buf.endswith(b'\r\n\r\n'):
+                    break
+
+            self.assertTrue(buf.startswith(b'GET / HTTP/1.1'))
+            self.assertTrue(b'Host: http2bin.org' in buf)
+
+            sock.sendall(b'HTTP/1.1 200 OK\r\n'
+                         b'Server: SocksTestServer\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+        response = pm.request('GET', 'http://http2bin.org')
+        self.assertEqual(response.status, 200)
+
+    def test_proxy_rejection(self):
+        evt = threading.Event()
+
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks4_negotiation(sock)
+            addr, port = next(handler)
+            handler.send(False)
+
+            evt.wait()
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url)
+
+        self.assertRaises(
+            NewConnectionError, pm.request, 'GET', 'http://http2bin.org',
+            retries=False
+        )
+        evt.set()
+
+    def test_socks4_with_username(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks4_negotiation(sock, username=b'user')
+            addr, port = next(handler)
+
+            self.assertEqual(addr, '16.17.18.19')
+            self.assertTrue(port, 80)
+            handler.send(True)
+
+            while True:
+                buf = sock.recv(65535)
+                if buf.endswith(b'\r\n\r\n'):
+                    break
+
+            sock.sendall(b'HTTP/1.1 200 OK\r\n'
+                         b'Server: SocksTestServer\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
+            sock.close()
+
+        self._start_server(request_handler)
+        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='user')
+        response = pm.request('GET', 'http://16.17.18.19')
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.data, b'')
+        self.assertEqual(response.headers['Server'], 'SocksTestServer')
+
+    def test_socks_with_invalid_username(self):
+        def request_handler(listener):
+            sock = listener.accept()[0]
+
+            handler = handle_socks4_negotiation(sock, username=b'user')
+            next(handler)
+
+        self._start_server(request_handler)
+        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        pm = socks_proxy.SOCKSProxyManager(proxy_url, username='baduser')
+
+        try:
+            pm.request('GET', 'http://http2bin.org', retries=False)
+        except NewConnectionError as e:
+            self.assertTrue("different user-ids" in str(e))
+        else:
+            self.fail("Did not raise")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = flake8-py3, py26, py27, py32, py33, py34, pypy
 [testenv]
 deps= -r{toxinidir}/dev-requirements.txt
 commands=
+    pip install .[socks]
     nosetests []
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning

--- a/urllib3/contrib/socks.py
+++ b/urllib3/contrib/socks.py
@@ -15,6 +15,8 @@ Known Limitations:
 - Currently PySocks does not support IPv6 connections to the SOCKS proxy. Any
   such connection attempt will fail.
 """
+from __future__ import absolute_import
+
 import socks
 
 from socket import error as SocketError, timeout as SocketTimeout

--- a/urllib3/contrib/socks.py
+++ b/urllib3/contrib/socks.py
@@ -17,7 +17,20 @@ Known Limitations:
 """
 from __future__ import absolute_import
 
-import socks
+try:
+    import socks
+except ImportError:
+    import warnings
+    from urllib3.exceptions import DependencyWarning
+
+    warnings.warn((
+        'SOCKS support in urllib3 requires the installation of optional '
+        'dependencies: specifically, PySocks.  For more information, see '
+        'https://urllib3.readthedocs.org/en/latest/contrib.html#socks-proxies'
+        ),
+        DependencyWarning
+    )
+    raise
 
 from socket import error as SocketError, timeout as SocketTimeout
 

--- a/urllib3/contrib/socks.py
+++ b/urllib3/contrib/socks.py
@@ -168,3 +168,5 @@ class SOCKSProxyManager(PoolManager):
         super(SOCKSProxyManager, self).__init__(
             num_pools, headers, **connection_pool_kw
         )
+
+        self.pool_classes_by_scheme = SOCKSProxyManager.pool_classes_by_scheme

--- a/urllib3/contrib/socks_proxy.py
+++ b/urllib3/contrib/socks_proxy.py
@@ -5,6 +5,13 @@ SOCKS support for urllib3
 
 This contrib module contains provisional support for SOCKS proxies from within
 urllib3.
+
+Known Limitations:
+
+- Currently PySocks does not support contacting remote websites via literal
+  IPv6 addresses. Any such connection attempt will fail.
+- Currently PySocks does not support IPv6 connections to the SOCKS proxy. Any
+  such connection attempt will fail.
 """
 import socks
 

--- a/urllib3/contrib/socks_proxy.py
+++ b/urllib3/contrib/socks_proxy.py
@@ -100,11 +100,11 @@ class SOCKSConnection(HTTPConnection):
         return conn
 
 
+# We don't need to duplicate the Verified/Unverified distinction from
+# urllib3/connection.py here because the HTTPSConnection will already have been
+# correctly set to either the Verified or Unverified form by that module. This
+# means the SOCKSHTTPSConnection will automatically be the correct type.
 class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):
-    pass
-
-
-class VerifiedSOCKSHTTPSConnection(SOCKSConnection, VerifiedHTTPSConnection):
     pass
 
 
@@ -113,10 +113,7 @@ class SOCKSHTTPConnectionPool(HTTPConnectionPool):
 
 
 class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):
-    if ssl:
-        ConnectionCls = VerifiedSOCKSHTTPSConnection
-    else:
-        ConnectionCls = SOCKSHTTPSConnection
+    ConnectionCls = SOCKSHTTPSConnection
 
 
 class SOCKSProxyManager(PoolManager):

--- a/urllib3/contrib/socks_proxy.py
+++ b/urllib3/contrib/socks_proxy.py
@@ -4,7 +4,9 @@ SOCKS support for urllib3
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This contrib module contains provisional support for SOCKS proxies from within
-urllib3.
+urllib3. This module supports SOCKS4 (specifically the SOCKS4A variant) and
+SOCKS5. To enable its functionality, either install PySocks or install this
+module with the ``socks`` extra.
 
 Known Limitations:
 

--- a/urllib3/contrib/socks_proxy.py
+++ b/urllib3/contrib/socks_proxy.py
@@ -20,7 +20,7 @@ import socks
 from socket import error as SocketError, timeout as SocketTimeout
 
 from urllib3.connection import (
-    HTTPConnection, HTTPSConnection, VerifiedHTTPSConnection
+    HTTPConnection, HTTPSConnection
 )
 from urllib3.connectionpool import (
     HTTPConnectionPool, HTTPSConnectionPool

--- a/urllib3/contrib/socks_proxy.py
+++ b/urllib3/contrib/socks_proxy.py
@@ -93,7 +93,7 @@ class SOCKSConnection(HTTPConnection):
                     "Failed to establish a new connection: %s" % e
                 )
 
-        except SocketError as e:
+        except SocketError as e:  # Defensive: PySocks should catch all these.
             raise NewConnectionError(
                 self, "Failed to establish a new connection: %s" % e)
 

--- a/urllib3/contrib/socks_proxy.py
+++ b/urllib3/contrib/socks_proxy.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""
+SOCKS support for urllib3
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This contrib module contains provisional support for SOCKS proxies from within
+urllib3.
+"""
+import socks
+
+from socket import error as SocketError, timeout as SocketTimeout
+
+from urllib3.connection import (
+    HTTPConnection, HTTPSConnection, VerifiedHTTPSConnection
+)
+from urllib3.connectionpool import (
+    HTTPConnectionPool, HTTPSConnectionPool
+)
+from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
+from urllib3.poolmanager import PoolManager
+from urllib3.util.url import parse_url
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
+
+
+class SOCKSConnection(HTTPConnection):
+    """
+    A plain-text HTTP connection that connects via a SOCKS proxy.
+    """
+    def __init__(self, *args, **kwargs):
+        self._socks_options = kwargs.pop('_socks_options')
+        super(SOCKSConnection, self).__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        """
+        Establish a new connection via the SOCKS proxy.
+        """
+        # TODO: This is a duplicate of HTTPConnection._new_conn but with a
+        # different callable for create_connection. Consider a refactor that
+        # allows us to strip that out.
+        extra_kw = {}
+        if self.source_address:
+            extra_kw['source_address'] = self.source_address
+
+        if self.socket_options:
+            extra_kw['socket_options'] = self.socket_options
+
+        try:
+            conn = socks.create_connection(
+                (self.host, self.port),
+                proxy_type=self._socks_options['socks_version'],
+                proxy_addr=self._socks_options['proxy_host'],
+                proxy_port=self._socks_options['proxy_port'],
+                proxy_username=self._socks_options['username'],
+                proxy_password=self._socks_options['password'],
+                timeout=self.timeout,
+                **extra_kw
+            )
+
+        except SocketTimeout as e:
+            raise ConnectTimeoutError(
+                self, "Connection to %s timed out. (connect timeout=%s)" %
+                (self.host, self.timeout))
+
+        except SocketError as e:
+            raise NewConnectionError(
+                self, "Failed to establish a new connection: %s" % e)
+
+        return conn
+
+
+class SOCKSHTTPSConnection(SOCKSConnection, HTTPSConnection):
+    pass
+
+
+class VerifiedSOCKSHTTPSConnection(SOCKSConnection, VerifiedHTTPSConnection):
+    pass
+
+
+class SOCKSHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = SOCKSConnection
+
+
+class SOCKSHTTPSConnectionPool(HTTPSConnectionPool):
+    if ssl:
+        ConnectionCls = VerifiedSOCKSHTTPSConnection
+    else:
+        ConnectionCls = SOCKSHTTPSConnection
+
+
+class SOCKSProxyManager(PoolManager):
+    """
+    A version of the urllib3 ProxyManager that routes connections via the
+    defined SOCKS proxy.
+    """
+    pool_classes_by_scheme = {
+        'http': SOCKSHTTPConnectionPool,
+        'https': SOCKSHTTPSConnectionPool,
+    }
+
+    def __init__(self, proxy_url, username=None, password=None,
+                 num_pools=10, headers=None, **connection_pool_kw):
+        parsed = parse_url(proxy_url)
+
+        if parsed.scheme == 'socks5':
+            socks_version = socks.PROXY_TYPE_SOCKS5
+        elif parsed.scheme == 'socks4':
+            socks_version = socks.PROXY_TYPE_SOCKS4
+        else:
+            raise ValueError(
+                "Unable to determine SOCKS version from %s" % proxy_url
+            )
+
+        self.proxy_url = proxy_url
+
+        socks_options = {
+            'socks_version': socks_version,
+            'proxy_host': parsed.host,
+            'proxy_port': parsed.port,
+            'username': username,
+            'password': password,
+        }
+        connection_pool_kw['_socks_options'] = socks_options
+
+        super(SOCKSProxyManager, self).__init__(
+            num_pools, headers, **connection_pool_kw
+        )

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -180,6 +180,14 @@ class SNIMissingWarning(HTTPWarning):
     pass
 
 
+class DependencyWarning(HTTPWarning):
+    """
+    Warned when an attempt is made to import a module with missing optional
+    dependencies.
+    """
+    pass
+
+
 class ResponseNotChunked(ProtocolError, ValueError):
     "Response needs to be chunked in order to read it as chunks."
     pass

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -18,11 +18,6 @@ from .util.retry import Retry
 __all__ = ['PoolManager', 'ProxyManager', 'proxy_from_url']
 
 
-pool_classes_by_scheme = {
-    'http': HTTPConnectionPool,
-    'https': HTTPSConnectionPool,
-}
-
 log = logging.getLogger(__name__)
 
 SSL_KEYWORDS = ('key_file', 'cert_file', 'cert_reqs', 'ca_certs',
@@ -59,6 +54,12 @@ class PoolManager(RequestMethods):
 
     proxy = None
 
+    pool_classes_by_scheme = {
+        'http': HTTPConnectionPool,
+        'https': HTTPSConnectionPool,
+    }
+
+
     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
         RequestMethods.__init__(self, headers)
         self.connection_pool_kw = connection_pool_kw
@@ -81,7 +82,7 @@ class PoolManager(RequestMethods):
         by :meth:`connection_from_url` and companion methods. It is intended
         to be overridden for customization.
         """
-        pool_cls = pool_classes_by_scheme[scheme]
+        pool_cls = self.pool_classes_by_scheme[scheme]
         kwargs = self.connection_pool_kw
         if scheme == 'http':
             kwargs = self.connection_pool_kw.copy()

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -59,7 +59,6 @@ class PoolManager(RequestMethods):
         'https': HTTPSConnectionPool,
     }
 
-
     def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
         RequestMethods.__init__(self, headers)
         self.connection_pool_kw = connection_pool_kw

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -66,8 +66,7 @@ class PoolManager(RequestMethods):
                                            dispose_func=lambda p: p.close())
 
         # Locally set the pool classes so other PoolManagers can override them.
-        if not hasattr(self, 'pool_classes_by_scheme'):
-            self.pool_classes_by_scheme = pool_classes_by_scheme
+        self.pool_classes_by_scheme = pool_classes_by_scheme
 
     def __enter__(self):
         return self

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -110,7 +110,7 @@ except ImportError:
                 )
             self.ciphers = cipher_suite
 
-        def wrap_socket(self, socket, server_hostname=None):
+        def wrap_socket(self, socket, server_hostname=None, server_side=False):
             warnings.warn(
                 'A true SSLContext object is not available. This prevents '
                 'urllib3 from configuring SSL appropriately and may cause '
@@ -125,6 +125,7 @@ except ImportError:
                 'ca_certs': self.ca_certs,
                 'cert_reqs': self.verify_mode,
                 'ssl_version': self.protocol,
+                'server_side': server_side,
             }
             if self.supports_set_ciphers:  # Platform-specific: Python 2.7+
                 return wrap_socket(socket, ciphers=self.ciphers, **kwargs)


### PR DESCRIPTION
@Anorov did fantastic work in #692 but did not have time to go back through and respond to code review, so I've adopted the work done there and refactored it. Credit should be joint between me and @Anorov should this satisfy the bounty: however, @Anorov has previously claimed they don't want the bounty. For that reason, if @Anorov doesn't change their mind and this submission does qualify for it, I'll donate the bounty, in full, to PyLadies. (I don't need it because I'm paid full-time to work on libraries like this.)

This change essentially pulls most of the work done in #692 out into a contrib module. This allows us to avoid having to change too many things in the mainline of urllib3, and also ensures that it is not affected by the requirements to have tests and coverage. This helps us get the work initially off the ground and out into the world.

If we decide to take this change as-is, I'll also volunteer to be "on the hook" for supporting it going forward until such time as I can add sufficient test coverage for it.

Feedback is encouraged!