### PR TITLE
Close the underlying connection when closing a response.

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -436,6 +436,13 @@ class TestSocketClosing(SocketDummyServerTestCase):
     def test_closing_response_actually_closes_connection(self):
         done_closing = Event()
         complete = Event()
+        # The insane use of this variable here is to get around the fact that
+        # Python 2.6 does not support returning a value from Event.wait(). This
+        # means we can't tell if an event timed out, so we can't use the timing
+        # out of the 'complete' event to determine the success or failure of
+        # the test. Python 2 also doesn't have the nonlocal statement, so we
+        # can't write directly to this variable, only mutate it. Hence: list.
+        successful = []
 
         def socket_handler(listener):
             sock = listener.accept()[0]
@@ -457,6 +464,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             sock.settimeout(1)
             new_data = sock.recv(65536)
             self.assertFalse(new_data)
+            successful.append(True)
             sock.close()
             complete.set()
 
@@ -468,8 +476,8 @@ class TestSocketClosing(SocketDummyServerTestCase):
         response.close()
 
         done_closing.set()  # wait until the socket in our pool gets closed
-        completed = complete.wait(timeout=1)
-        if not completed:
+        complete.wait(timeout=1)
+        if not successful:
             self.fail("Timed out waiting for connection close")
 
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -387,6 +387,9 @@ class HTTPResponse(io.IOBase):
         if not self.closed:
             self._fp.close()
 
+        if self._connection is not None:
+            self._connection.close()
+
     @property
     def closed(self):
         if self._fp is None:


### PR DESCRIPTION
If the connection is still on the response object, closing the response should assume the connection is busted and close that too.

Resolves #779.