### PR TITLE
Always use setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 import os
 import re
 
-try:
-    import setuptools  # noqa: unused
-except ImportError:
-    pass  # No 'develop' command, oh well.
 
 base_path = os.path.dirname(__file__)
 


### PR DESCRIPTION
Using distutils instead of setuptools is discouraged, it doesn't properly add all of the metadata that Python packaging requires. In addition, in 2016 you are almost certainly guaranteed to have setuptools exist on a user's machine.