### PR TITLE
Drop Python 3.2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - TOXENV=flake8-py3
     - TOXENV=py26
     - TOXENV=py27
-    - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=pypy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ dev (master)
 
 * Always use setuptools, no more distutils fallback. (Issue #785)
 
+* Dropped support for Python 3.2. (Issue #786)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8-py3, py26, py27, py32, py33, py34, py35, pypy
+envlist = flake8-py3, py26, py27, py33, py34, py35, pypy
 
 [testenv]
 deps= -r{toxinidir}/dev-requirements.txt
@@ -11,7 +11,7 @@ setenv =
 
 [testenv:gae]
 basepython = python2.7
-deps= 
+deps=
     {[testenv]deps}
     -r{toxinidir}/test/appengine/requirements.txt
 commands=


### PR DESCRIPTION
Goodbye Python 3.2. You will be missed.

Resolves #786.

![](http://www.nato.int/ims/graphics/2009/090327/b090327a.jpg)