### PR TITLE
fix 'bool' object has no attribute 'close'

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -561,7 +561,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # the request doesn't need to know about the connection. Otherwise
             # it will also try to release it and we'll have a double-release
             # mess.
-            response_conn = not release_conn and conn
+            response_conn = conn if not release_conn else None
 
             # Import httplib's response into our own wrapper object
             response = HTTPResponse.from_httplib(httplib_response,

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -252,7 +252,7 @@ class HTTPResponse(io.IOBase):
             # Closing the response may not actually be sufficient to close
             # everything, so if we have a hold of the connection close that
             # too.
-            if self._connection is not None:
+            if self._connection:
                 self._connection.close()
 
             raise
@@ -387,7 +387,7 @@ class HTTPResponse(io.IOBase):
         if not self.closed:
             self._fp.close()
 
-        if self._connection is not None:
+        if self._connection:
             self._connection.close()
 
     @property


### PR DESCRIPTION
HTTPConnectionPool.urlopen may pass connection=False to HTTPResponse when release_conn set to True
which can cause AttributeError: 'bool' object has no attribute 'close'