### PR TITLE
Support a concatenated gzip data

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -55,7 +55,12 @@ class GzipDecoder(object):
     def decompress(self, data):
         if not data:
             return data
-        return self._obj.decompress(data)
+        ret = self._obj.decompress(data)
+        while len(self._obj.unused_data) > 0:
+            unused_data = self._obj.unused_data
+            self._obj = zlib.decompressobj(16 + zlib.MAX_WBITS)
+            ret += self._obj.decompress(unused_data)
+        return ret
 
 
 def _get_decoder(mode):


### PR DESCRIPTION
Currently `requests`/`urllib3` doesn't support a concatenated gzip data. Only the first gz content is extracted. Here is an reproducible test case.

1.Create a text file `abc.txt` including three lines of data:

```
1
2
3
```

2.Update `GzipSimpleHttpServer` 
https://github.com/smtakeda/GzipSimpleHTTPServer/commit/68506651620840ba15cc6f60b4d15a3e7719b8c9

3.Launch `GzipSimpleHttpServer`

```
python GzipSimpleHTTPServer.py 8001
```

4.Run this:

```
import requests
ret = requests.get('http://localhost:8001/abc.txt')
print(ret.text)
```

You'll get `1` only, since `zlib.decompress` stops decoding at the end of the first gz data.

The proposed fix is feed https://docs.python.org/3/library/zlib.html#zlib.Decompress.unused_data into a new `Decompress` object until no `unused_data` is observed.
