### PR TITLE
Cast OpenSSL errors to strings.

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -182,7 +182,7 @@ class WrappedSocket(object):
             if self.suppress_ragged_eofs and e.args == (-1, 'Unexpected EOF'):
                 return b''
             else:
-                raise SocketError(e)
+                raise SocketError(str(e))
         except OpenSSL.SSL.ZeroReturnError as e:
             if self.connection.get_shutdown() == OpenSSL.SSL.RECEIVED_SHUTDOWN:
                 return b''


### PR DESCRIPTION
Resolves #556.

I haven't written any tests for this because of #791. I'll start trying to work on #791 and, if we can get it ironed out quickly, we should block the merge of this behind #791 so that we can actually have a test for this.