### PR TITLE
Changes to support sending a complete response object when 407 errors…

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -10,9 +10,11 @@ from .packages import six
 try:  # Python 3
     from http.client import HTTPConnection as _HTTPConnection
     from http.client import HTTPException  # noqa: unused in this module
+    from http.client import PROXY_AUTHENTICATION_REQUIRED
 except ImportError:
     from httplib import HTTPConnection as _HTTPConnection
     from httplib import HTTPException  # noqa: unused in this module
+    from httplib import PROXY_AUTHENTICATION_REQUIRED
 
 try:  # Compiled with SSL?
     import ssl
@@ -246,9 +248,38 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
 
-    def connect(self):
+    def _tunnel(self):
+        # need to keep proxy server address
+        self._proxy_server = self.host
+        self._proxy_port = self.port
+
+        self._set_hostport(self._tunnel_host, self._tunnel_port)
+        self.send("CONNECT %s:%d HTTP/1.0\r\n" % (self.host, self.port))
+        self._tunnel_headers["Connection"] = "Keep-Alive"
+        for header, value in self._tunnel_headers.iteritems():
+            self.send("%s: %s\r\n" % (header, value))
+        self.send("\r\n")
+        response = self.response_class(self.sock, strict=self.strict,
+                                       method=self._method)
+
+        response.begin()
+
+        # Here we want to handle the connection
+        if response.status == PROXY_AUTHENTICATION_REQUIRED:
+            # All keys must be in title mode (needed by request library)
+            response.headers = {key.title(): value for key, value in response.getheaders()}
+            response.original_sock = self.sock
+
+        elif response.status != 200:
+            self.close()
+            raise socket.error("Tunnel connection failed: %d %s" % (response.status,
+                                                                    response.reason.strip()))
+        return response
+
+    def connect(self, conn=None):
         # Add certificate verification
-        conn = self._new_conn()
+        if not conn:
+            conn = self._new_conn()
 
         resolved_cert_reqs = resolve_cert_reqs(self.cert_reqs)
         resolved_ssl_version = resolve_ssl_version(self.ssl_version)
@@ -261,7 +292,10 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             self.sock = conn
             # Calls self._set_hostport(), so self.host is
             # self._tunnel_host below.
-            self._tunnel()
+            response = self._tunnel()
+            if response.status == PROXY_AUTHENTICATION_REQUIRED:
+                return response
+
             # Mark this connection as not reusable
             self.auto_open = 0
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -559,7 +559,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
             is_new_proxy_conn = self.proxy is not None and not getattr(conn, 'sock', None)
             if is_new_proxy_conn:
-                self._prepare_proxy(conn)
+                proxy_conn_response = self._prepare_proxy(conn)
+                if proxy_conn_response:
+                    return proxy_conn_response
 
             # Make the request on the httplib connection object.
             httplib_response = self._make_request(conn, method, url,
@@ -764,7 +766,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         else:
             set_tunnel(self.host, self.port, self.proxy_headers)
 
-        conn.connect()
+        return conn.connect()
 
     def _new_conn(self):
         """


### PR DESCRIPTION
… is found while doing the CONNECT to proxy. Added a way to stablish a connection using connect over an already connected socket

Trying to connect to a "https" web page using a proxy uses a "HTTP CONNECT" verb to tell the proxy that we want to connect to a https destination.
With "basic authentication" the "CONNECT" is sent with the appropriate headers so the proxy can authenticate the request and do the request to the https web server. (That headers are setup by the requests library)
With "NTLM" we use a plugin (requests-ntlm) that is set as a hook and it is called on every request response. For example: with HTTP, the requests library sends a "GET" to a web page, as a response we get a HTTP-407 that is handled by the plugin hook to do the NTLM negotiation and authentication
In a HTTPS scenario, the first connection to the proxy is being done with the "CONNECT". At that time, requests does not set any authentication header (because it is handled by a plugin) and we get an 407 authentication Error.

This Patch tries to avoid raising an exception on "Proxy Authentication" errors and it sends back a complete http response so it can be handled by the requests-ntlm plugin and reuse an already connected and authenticated socket to do the connection