### PR TITLE
Better handle the IPv6 debacle.

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -299,9 +299,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                     'for details.)'.format(hostname)),
                     SubjectAltNameWarning
                 )
-            asserted_hostname = self.assert_hostname or hostname
-            asserted_hostname = asserted_hostname.strip('[]')
-            match_hostname(cert, asserted_hostname)
+            match_hostname(cert, self.assert_hostname or hostname)
 
         self.is_verified = (resolved_cert_reqs == ssl.CERT_REQUIRED or
                             self.assert_fingerprint is not None)

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -301,11 +301,9 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                 )
 
             # In case the hostname is an IPv6 address, strip the square
-            # brackets from it before using it to validate. This is because
-            # a certificate with an IPv6 address in it won't have square
-            # brackets around that address. Sadly, match_hostname won't do this
-            # for us: it expects the plain host part without any extra work
-            # that might have been done to make it palatable to httplib.
+            # brackets from it before using it to validate. Non IPv6 addresses
+            # should not start/end with square brackets, so this should be
+            # safe.
             asserted_hostname = self.assert_hostname or hostname
             asserted_hostname = asserted_hostname.strip('[]')
             match_hostname(cert, asserted_hostname)

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -299,11 +299,6 @@ class VerifiedHTTPSConnection(HTTPSConnection):
                     'for details.)'.format(hostname)),
                     SubjectAltNameWarning
                 )
-
-            # In case the hostname is an IPv6 address, strip the square
-            # brackets from it before using it to validate. Non IPv6 addresses
-            # should not start/end with square brackets, so this should be
-            # safe.
             asserted_hostname = self.assert_hostname or hostname
             asserted_hostname = asserted_hostname.strip('[]')
             match_hostname(cert, asserted_hostname)

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -69,7 +69,8 @@ class ConnectionPool(object):
         if not host:
             raise LocationValueError("No host specified.")
 
-        self.host = host
+        # httplib doesn't like it when we include brackets in ipv6 addresses
+        self.host = host.strip('[]')
         self.port = port
 
     def __str__(self):

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -70,6 +70,11 @@ class ConnectionPool(object):
             raise LocationValueError("No host specified.")
 
         # httplib doesn't like it when we include brackets in ipv6 addresses
+        # Specifically, if we include brackets but also pass the port then
+        # httplib crazily doubles up the square brackets on the Host header.
+        # Instead, we need to make sure we never pass ``None`` as the port.
+        # However, for backward compatibility reasons we can't actually
+        # *assert* that.
         self.host = host.strip('[]')
         self.port = port
 
@@ -830,6 +835,7 @@ def connection_from_url(url, **kw):
         >>> r = conn.request('GET', '/')
     """
     scheme, host, port = get_host(url)
+    port = port or port_by_scheme.get(scheme, 80)
     if scheme == 'https':
         return HTTPSConnectionPool(host, port=port, **kw)
     else:


### PR DESCRIPTION
This is intended to resolve kennethreitz/requests#3002.

It reverts #708 and #760.

The basic problem originally found in #707 was *actually* because `connection_from_url` would sometimes pass `None` to the connection, which screws up the logic. For that reason, I thought I'd bring in the logic used in `PoolManager.connection_from_url`.