### PR TITLE
[WIP] Experimental code for cert validation in OS X and Windows

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -283,12 +283,12 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         ctx.use_certificate_file(certfile)
     if keyfile:
         ctx.use_privatekey_file(keyfile)
-    if cert_reqs != ssl.CERT_NONE:
-        ctx.set_verify(_openssl_verify[cert_reqs], _verify_callback)
     if trust_system:
         ca_certs = None
         ca_cert_dir = None
     if not trust_system or platform.system() not in ('Darwin', 'Windows'):
+        if cert_reqs != ssl.CERT_NONE:
+            ctx.set_verify(_openssl_verify[cert_reqs], _verify_callback)
         if ca_certs or ca_cert_dir:
             try:
                 ctx.load_verify_locations(ca_certs, ca_cert_dir)


### PR DESCRIPTION
This is related to kennethreitz/requests#2966.

This change makes it possible to trust the system certificate store explicitly on systems that would like to. The goal is to have this be a cross-platform way to solve the problem, so that Windows and OS X aren't left out in the cold in this kind of world. The goal here is to divide the world into two sets of users:
- Non-Windows and Non-OS X users. These users are assumed to be using OpenSSL, configured appropriately, such that `set_default_verify_paths` will work correctly for them. In that instance, if `trust_system` is `True`, they will automatically use OpenSSL with the system cert stores.
- Windows and OS X users. These users cannot use `set_default_verify_paths` because those platforms have their own, complex, certificate stores that do not and cannot interface properly with OpenSSL. These platforms will therefore need to use certitude to validate their trust stores: essentially, they'll pass the X509 cert chain to certitude which will call into the relevant system functions to do the validation.

This is very much WIP right now, and there are the following limitations:
1. We need to bikeshed the API a bit.
2. This has made `ssl_wrap_socket` a bit crazy: we may want to factor it out a bit to keep the code cleaner.
3. certitude doesn't work on Windows yet.

However, feedback would be appreciated.
