### PR TITLE
Yet another pass at connection cleanup.

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -284,6 +284,11 @@ class TestConnectionPool(unittest.TestCase):
             self.assertEqual(conn.cert_reqs, 'CERT_REQUIRED')
 
     def test_cleanup_on_extreme_connection_error(self):
+        """
+        This test validates that we clean up properly even on exceptions that
+        we'd not otherwise catch, i.e. those that inherit from BaseException
+        like KeyboardInterrupt or gevent.Timeout. See #805 for more details.
+        """
         class RealBad(BaseException):
             pass
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -630,6 +630,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             if not clean_exit:
                 # We hit some kind of exception, handled or otherwise. We need
                 # to throw the connection away unless explicitly told not to.
+                # Close the connection, set the variable to None, and make sure
+                # we put the None back in the pool to avoid leaking it.
                 conn = conn and conn.close()
                 release_conn = True
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -556,6 +556,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # complains about UnboundLocalError.
         err = None
 
+        # Keep track of whether we cleanly exited the except block. This
+        # ensures we do proper cleanup in finally.
+        clean_exit = False
+
         try:
             # Request a connection from the queue.
             timeout_obj = self._get_timeout(timeout)
@@ -585,10 +589,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                                                  connection=response_conn,
                                                  **response_kw)
 
-            # else:
-            #     The connection will be put back into the pool when
-            #     ``response.release_conn()`` is called (implicitly by
-            #     ``response.read()``)
+            # Everything went great!
+            clean_exit = True
 
         except Empty:
             # Timed out by queue.
@@ -598,22 +600,19 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # Close the connection. If a connection is reused on which there
             # was a Certificate error, the next request will certainly raise
             # another Certificate error.
-            conn = conn and conn.close()
-            release_conn = True
+            clean_exit = False
             raise SSLError(e)
 
         except SSLError:
             # Treat SSLError separately from BaseSSLError to preserve
             # traceback.
-            conn = conn and conn.close()
-            release_conn = True
+            clean_exit = False
             raise
 
         except (TimeoutError, HTTPException, SocketError, ProtocolError) as e:
             # Discard the connection for these exceptions. It will be
             # be replaced during the next _get_conn() call.
-            conn = conn and conn.close()
-            release_conn = True
+            clean_exit = False
 
             if isinstance(e, (SocketError, NewConnectionError)) and self.proxy:
                 e = ProxyError('Cannot connect to proxy.', e)
@@ -628,6 +627,12 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             err = e
 
         finally:
+            if not clean_exit:
+                # We hit some kind of exception, handled or otherwise. We need
+                # to throw the connection away unless explicitly told not to.
+                conn = conn and conn.close()
+                release_conn = True
+
             if release_conn:
                 # Put the connection back to be reused. If the connection is
                 # expired then it will be None, which will get replaced with a


### PR DESCRIPTION
Resolves #805 (again).

This patch ensures that we correctly cleanup connections that fail inside `HTTPConnectionPool.urlopen`, not just ones that fail after opening. This should ensure that weird gevent timeouts during connection setup also correctly eliminate the connection, rather than leaking it.