### PR TITLE
New PyOpenSSL requires bytes for cipher list.

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -98,7 +98,7 @@ _openssl_verify = {
         OpenSSL.SSL.VERIFY_PEER + OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
 }
 
-DEFAULT_SSL_CIPHER_LIST = util.ssl_.DEFAULT_CIPHERS
+DEFAULT_SSL_CIPHER_LIST = util.ssl_.DEFAULT_CIPHERS.encode('ascii')
 
 # OpenSSL will only write 16K at a time
 SSL_WRITE_BLOCKSIZE = 16384


### PR DESCRIPTION
PyOpenSSL is planning to add urllib3 as a tested project to make sure that changes there don't break here (that's really convenient and very kind of @hynek). I should note that we only managed to get here because we added PyOpenSSL to our own testing matrix in #795, which is a change I'm feeling increasingly good about!

The current master (and therefore next release) of PyOpenSSL currently works fine with urllib3 *except* that it emits a deprecation warning when we pass a `str` as the default cipher list. This change fixes that warning, brings our PyOpenSSL tests back to green against the current PyOpenSSL master, and allows the merging of pyca/pyopenssl#446.