### PR TITLE
Handling errors around Unicode encoding differently

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -190,5 +190,8 @@ In chronological order:
 * Shige Takeda <smtakeda@gmail.com>
   * Started Recipes documentation and added a recipe about handling concatenated gzip data in HTTP response
 
+* Jesse Shapiro <jesse@jesseshapiro.net>
+  * Working on encoding unicode header parameter names
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -33,7 +33,6 @@ def setUp():
     clear_warnings()
     warnings.simplefilter('ignore', HTTPWarning)
 
-
 def onlyPy26OrOlder(test):
     """Skips this test unless you are on Python2.6.x or earlier."""
 
@@ -63,6 +62,17 @@ def onlyPy279OrNewer(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python 2.7.9+ to run".format(name=test.__name__)
         if sys.version_info < (2, 7, 9):
+            raise SkipTest(msg)
+        return test(*args, **kwargs)
+    return wrapper
+
+def onlyPy2(test):
+    """Skips this test unless you are on Python 2.x"""
+
+    @functools.wraps(test)
+    def wrapper(*args, **kwargs):
+        msg = "{name} requires Python 2.x to run".format(name=test.__name__)
+        if six.PY3:
             raise SkipTest(msg)
         return test(*args, **kwargs)
     return wrapper

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -2,6 +2,7 @@ import unittest
 
 from urllib3.fields import guess_content_type, RequestField
 from urllib3.packages.six import u, PY3
+from .. import onlyPy2
 
 
 class TestRequestField(unittest.TestCase):
@@ -48,8 +49,8 @@ class TestRequestField(unittest.TestCase):
         param = field._render_part('filename', u('n\u00e4me'))
         self.assertEqual(param, "filename*=utf-8''n%C3%A4me")
 
+    @onlyPy2
     def test_render_unicode_bytes_py2(self):
-        if not PY3:
-            field = RequestField('somename', 'data')
-            param = field._render_part('filename', 'n\xc3\xa4me')
-            self.assertEqual(param, "filename*=utf-8''n%C3%A4me")
+        field = RequestField('somename', 'data')
+        param = field._render_part('filename', 'n\xc3\xa4me')
+        self.assertEqual(param, "filename*=utf-8''n%C3%A4me")

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -2,7 +2,7 @@ import unittest
 
 from urllib3.fields import guess_content_type, RequestField
 from urllib3.packages.six import u, PY3
-from .. import onlyPy2
+from . import onlyPy2
 
 
 class TestRequestField(unittest.TestCase):

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -1,7 +1,7 @@
 import unittest
 
 from urllib3.fields import guess_content_type, RequestField
-from urllib3.packages.six import u
+from urllib3.packages.six import u, PY3
 
 
 class TestRequestField(unittest.TestCase):
@@ -47,3 +47,9 @@ class TestRequestField(unittest.TestCase):
         field = RequestField('somename', 'data')
         param = field._render_part('filename', u('n\u00e4me'))
         self.assertEqual(param, "filename*=utf-8''n%C3%A4me")
+
+    def test_render_unicode_bytes_py2(self):
+        if not PY3:
+            field = RequestField('somename', 'data')
+            param = field._render_part('filename', 'n\xc3\xa4me')
+            self.assertEqual(param, "filename*=utf-8''n%C3%A4me")

--- a/urllib3/fields.py
+++ b/urllib3/fields.py
@@ -40,7 +40,7 @@ def format_header_param(name, value):
             pass
         else:
             return result
-    if not six.PY3 and isinstance(value, unicode):  # Python 2:
+    if not six.PY3 and isinstance(value, six.text_type):  # Python 2:
         value = value.encode('utf-8')
     value = email.utils.encode_rfc2231(value, 'utf-8')
     value = '%s*=%s' % (name, value)

--- a/urllib3/fields.py
+++ b/urllib3/fields.py
@@ -36,11 +36,11 @@ def format_header_param(name, value):
         result = '%s="%s"' % (name, value)
         try:
             result.encode('ascii')
-        except UnicodeEncodeError:
+        except (UnicodeEncodeError, UnicodeDecodeError):
             pass
         else:
             return result
-    if not six.PY3:  # Python 2:
+    if not six.PY3 and isinstance(value, unicode):  # Python 2:
         value = value.encode('utf-8')
     value = email.utils.encode_rfc2231(value, 'utf-8')
     value = '%s*=%s' % (name, value)


### PR DESCRIPTION
Fixes #793; allows unicode characters to come in in the form of a Python 2 bytes/string object without uncaught exceptions.