### PR TITLE
Show certificate when there is a hostname mismatch

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,0 +1,48 @@
+import unittest
+
+import mock
+
+from urllib3.connection import (
+    CertificateError,
+    VerifiedHTTPSConnection,
+    _match_hostname,
+)
+
+
+class TestConnection(unittest.TestCase):
+    """
+    Tests in this suite should not make any network requests or connections.
+    """
+    def test_match_hostname_no_cert(self):
+        cert = None
+        asserted_hostname = 'foo'
+        self.assertRaises(ValueError, _match_hostname, cert, asserted_hostname)
+
+    def test_match_hostname_empty_cert(self):
+        cert = {}
+        asserted_hostname = 'foo'
+        self.assertRaises(ValueError, _match_hostname, cert, asserted_hostname)
+
+    def test_match_hostname_match(self):
+        cert = {'subjectAltName': [('DNS', 'foo')]}
+        asserted_hostname = 'foo'
+        _match_hostname(cert, asserted_hostname)
+
+    def test_match_hostname_mismatch(self):
+        cert = {'subjectAltName': [('DNS', 'foo')]}
+        asserted_hostname = 'bar'
+        try:
+            with mock.patch('urllib3.connection.log.error') as mock_log:
+                _match_hostname(cert, asserted_hostname)
+        except CertificateError as e:
+            self.assertEqual(str(e), "hostname 'bar' doesn't match 'foo'")
+            mock_log.assert_called_once_with(
+                'Certificate did not match expected hostname: %s. '
+                'Certificate: %s',
+                'bar', {'subjectAltName': [('DNS', 'foo')]}
+            )
+            self.assertEqual(e._peer_cert, cert)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -307,6 +307,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.is_verified = (resolved_cert_reqs == ssl.CERT_REQUIRED or
                             self.assert_fingerprint is not None)
 
+
 def _match_hostname(cert, asserted_hostname):
     try:
         match_hostname(cert, asserted_hostname)


### PR DESCRIPTION
I am getting a hostname mismatch error for one of three servers in a pool so I am suspecting that one server has an invalid certificate.

    requests.exceptions.SSLError: hostname '10.10.194.37' doesn't match u'vault.service.trouper'

by itself is not much info to go on. It would be nice to see the server certificate that was presented.

I found that it was surprisingly difficult to see the server certificate, so I decided to see if urllib3 could show the certificate.

With this, urllib3 logs an error with the certificate just before raising the exception:

```
ERROR:requests.packages.urllib3.connection:Certificate did not match expected hostname: 10.10.194.38.
Certificate: {'subjectAltName': (('IP Address', '127.0.0.1'), ('IP Address', '10.10.194.36'), ('IP Address', '10.10.194.37'), ('IP Address', '10.10.194.38')),
'notBefore': u'Mar 17 01:18:27 2016 GMT', 'serialNumber': u'9BFDB58B08E7DCCA', 'notAfter': 'Mar 15 01:18:27 2026 GMT', 'version': 3L,
'subject': ((('countryName', u'US'),), (('stateOrProvinceName', u'California'),), (('localityName', u'Palo Alto'),), (('organizationName', u'DevOps'),), (('commonName', u'vault
```

which allows me to check whether the server is presenting the correct certificate.

I also add the certificate to the exception that is raised so that client code can inspect it.