### PR TITLE
Create connection pool keys by scheme

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -197,5 +197,8 @@ In chronological order:
 * David Foster <http://dafoster.net/>
   * Ensure order of request and response headers are preserved.
 
+* Jeremy Cline <jeremy@jcline.org>
+  * Added connection pool keys by scheme
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -53,12 +53,13 @@ the ``key_fn_by_scheme`` instance variable on :class:`.PoolManager`.
 
 .. doctest ::
 
+    >>> import functools
     >>> from collections import namedtuple
     >>> from urllib3.poolmanager import PoolManager, HTTPPoolKey
     >>> from urllib3.poolmanager import default_key_normalizer as normalizer
     >>> CustomKey = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
     >>> manager = PoolManager(10, source_address='127.0.0.1')
-    >>> manager.key_fn_by_scheme['http'] = lambda context: normalizer(context, CustomKey)
+    >>> manager.key_fn_by_scheme['http'] = functools.partial(normalizer, CustomKey)
     >>> manager.connection_from_url('http://example.com')
     >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
     >>> manager.connection_from_url('http://example.com')

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -28,6 +28,41 @@ so you don't have to.
     >>> conn.num_requests
     3
 
+A :class:`.PoolManager` will create a new :doc:`ConnectionPool <pools>`
+when no :doc:`ConnectionPools <pools>` exist with a matching pool key.
+The pool key is derived using the requested URL and the current values
+of the ``connection_pool_kw`` instance variable on :class:`.PoolManager`.
+
+The keys in ``connection_pool_kw`` used when deriving the key are
+configurable. For example, by default the ``source_address`` key is not
+considered.
+
+.. doctest ::
+
+    >>> from urllib3.poolmanager import PoolManager
+    >>> manager = PoolManager(10, source_address='127.0.0.1')
+    >>> manager.connection_from_url('http://example.com')
+    >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
+    >>> manager.connection_from_url('http://example.com')
+    >>> len(manager.pools)
+    1
+
+To make the pool manager create new pools when the value of
+``source_address`` changes, you can define a custom pool key.
+
+.. doctest ::
+
+    >>> from collections import namedtuple
+    >>> from urllib3.poolmanager import PoolManager, HTTPPoolKey
+    >>> CustomKey = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
+    >>> manager = PoolManager(10, source_address='127.0.0.1')
+    >>> manager.pool_keys_by_scheme['http'] = CustomKey
+    >>> manager.connection_from_url('http://example.com')
+    >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
+    >>> manager.connection_from_url('http://example.com')
+    >>> len(manager.pools)
+    2
+
 The API of a :class:`.PoolManager` object is similar to that of a
 :doc:`ConnectionPool <pools>`, so they can be passed around interchangeably.
 
@@ -58,6 +93,12 @@ API
 ---
 
     .. autoclass:: PoolManager
+       :inherited-members:
+    .. autoclass:: BasePoolKey
+       :inherited-members:
+    .. autoclass:: HTTPPoolKey
+       :inherited-members:
+    .. autoclass:: HTTPSPoolKey
        :inherited-members:
 
 ProxyManager

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -48,15 +48,17 @@ considered.
     1
 
 To make the pool manager create new pools when the value of
-``source_address`` changes, you can define a custom pool key.
+``source_address`` changes, you can define a custom pool key and alter
+the ``pool_key_funcs_by_scheme`` instance variable on :class:`.PoolManager`.
 
 .. doctest ::
 
     >>> from collections import namedtuple
     >>> from urllib3.poolmanager import PoolManager, HTTPPoolKey
+    >>> from urllib3.poolmanager import default_key_normalizer as normalizer
     >>> CustomKey = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
     >>> manager = PoolManager(10, source_address='127.0.0.1')
-    >>> manager.pool_keys_by_scheme['http'] = CustomKey
+    >>> manager.pool_key_funcs_by_scheme['http'] = lambda context: normalizer(context, CustomKey)
     >>> manager.connection_from_url('http://example.com')
     >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
     >>> manager.connection_from_url('http://example.com')

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -49,7 +49,7 @@ considered.
 
 To make the pool manager create new pools when the value of
 ``source_address`` changes, you can define a custom pool key and alter
-the ``pool_key_funcs_by_scheme`` instance variable on :class:`.PoolManager`.
+the ``key_fn_by_scheme`` instance variable on :class:`.PoolManager`.
 
 .. doctest ::
 
@@ -58,7 +58,7 @@ the ``pool_key_funcs_by_scheme`` instance variable on :class:`.PoolManager`.
     >>> from urllib3.poolmanager import default_key_normalizer as normalizer
     >>> CustomKey = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
     >>> manager = PoolManager(10, source_address='127.0.0.1')
-    >>> manager.pool_key_funcs_by_scheme['http'] = lambda context: normalizer(context, CustomKey)
+    >>> manager.key_fn_by_scheme['http'] = lambda context: normalizer(context, CustomKey)
     >>> manager.connection_from_url('http://example.com')
     >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
     >>> manager.connection_from_url('http://example.com')

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -34,21 +34,21 @@ The pool key is derived using the requested URL and the current values
 of the ``connection_pool_kw`` instance variable on :class:`.PoolManager`.
 
 The keys in ``connection_pool_kw`` used when deriving the key are
-configurable. For example, by default the ``source_address`` key is not
+configurable. For example, by default the ``my_field`` key is not
 considered.
 
 .. doctest ::
 
     >>> from urllib3.poolmanager import PoolManager
-    >>> manager = PoolManager(10, source_address='127.0.0.1')
+    >>> manager = PoolManager(10, my_field='wheat')
     >>> manager.connection_from_url('http://example.com')
-    >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
+    >>> manager.connection_pool_kw['my_field'] = 'barley'
     >>> manager.connection_from_url('http://example.com')
     >>> len(manager.pools)
     1
 
 To make the pool manager create new pools when the value of
-``source_address`` changes, you can define a custom pool key and alter
+``my_field`` changes, you can define a custom pool key and alter
 the ``key_fn_by_scheme`` instance variable on :class:`.PoolManager`.
 
 .. doctest ::
@@ -57,11 +57,11 @@ the ``key_fn_by_scheme`` instance variable on :class:`.PoolManager`.
     >>> from collections import namedtuple
     >>> from urllib3.poolmanager import PoolManager, HTTPPoolKey
     >>> from urllib3.poolmanager import default_key_normalizer as normalizer
-    >>> CustomKey = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
-    >>> manager = PoolManager(10, source_address='127.0.0.1')
+    >>> CustomKey = namedtuple('CustomKey', HTTPPoolKey._fields + ('my_field',))
+    >>> manager = PoolManager(10, my_field='wheat')
     >>> manager.key_fn_by_scheme['http'] = functools.partial(normalizer, CustomKey)
     >>> manager.connection_from_url('http://example.com')
-    >>> manager.connection_pool_kw['source_address'] = '127.0.0.2'
+    >>> manager.connection_pool_kw['my_field'] = 'barley'
     >>> manager.connection_from_url('http://example.com')
     >>> len(manager.pools)
     2

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -1,3 +1,4 @@
+import functools
 import unittest
 from collections import namedtuple
 
@@ -304,10 +305,7 @@ class TestPoolManager(unittest.TestCase):
         custom_key = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
         p = PoolManager(10, source_address='127.0.0.1')
 
-        def new_key_func(context):
-            return _default_key_normalizer(context, custom_key)
-
-        p.key_fn_by_scheme['http'] = new_key_func
+        p.key_fn_by_scheme['http'] = functools.partial(_default_key_normalizer, custom_key)
         p.connection_from_url('http://example.com')
         p.connection_pool_kw['source_address'] = '127.0.0.2'
         p.connection_from_url('http://example.com')

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -1,6 +1,6 @@
 import unittest
 
-from urllib3.poolmanager import PoolManager, SSL_KEYWORDS
+from urllib3.poolmanager import PoolManager
 from urllib3 import connection_from_url
 from urllib3.exceptions import (
     ClosedPoolError,
@@ -95,20 +95,16 @@ class TestPoolManager(unittest.TestCase):
             'ca_certs': '/root/path_to_pem',
             'ssl_version': 'SSLv23_METHOD',
         }
-        p = PoolManager(5)
+        p = PoolManager(5, **ssl_kw)
         conns = []
         conns.append(
-            p.connection_from_host(
-                'example.com', 443, scheme='https', ssl_kwargs=ssl_kw
-            )
+            p.connection_from_host('example.com', 443, scheme='https')
         )
 
         for k in ssl_kw:
-            ssl_kw[k] = 'newval'
+            p.connection_pool_kw[k] = 'newval'
             conns.append(
-                p.connection_from_host(
-                    'example.com', 443, scheme='https', ssl_kwargs=ssl_kw
-                )
+                p.connection_from_host('example.com', 443, scheme='https')
             )
 
         self.assertTrue(

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -2,10 +2,10 @@ import unittest
 from collections import namedtuple
 
 from urllib3.poolmanager import (
-    default_key_normalizer,
+    _default_key_normalizer,
     HTTPPoolKey,
     HTTPSPoolKey,
-    pool_key_funcs_by_scheme,
+    key_fn_by_scheme,
     PoolManager,
     SSL_KEYWORDS,
 )
@@ -203,8 +203,8 @@ class TestPoolManager(unittest.TestCase):
     def test_default_pool_key_funcs_copy(self):
         """Assert each PoolManager gets a copy of ``pool_keys_by_scheme``."""
         p = PoolManager()
-        self.assertEqual(p.pool_key_funcs_by_scheme, p.pool_key_funcs_by_scheme)
-        self.assertFalse(p.pool_key_funcs_by_scheme is pool_key_funcs_by_scheme)
+        self.assertEqual(p.key_fn_by_scheme, p.key_fn_by_scheme)
+        self.assertFalse(p.key_fn_by_scheme is key_fn_by_scheme)
 
     def test_pools_keyed_with_from_host(self):
         """Assert pools are still keyed correctly with connection_from_host."""
@@ -305,9 +305,9 @@ class TestPoolManager(unittest.TestCase):
         p = PoolManager(10, source_address='127.0.0.1')
 
         def new_key_func(context):
-            return default_key_normalizer(context, custom_key)
+            return _default_key_normalizer(context, custom_key)
 
-        p.pool_key_funcs_by_scheme['http'] = new_key_func
+        p.key_fn_by_scheme['http'] = new_key_func
         p.connection_from_url('http://example.com')
         p.connection_pool_kw['source_address'] = '127.0.0.2'
         p.connection_from_url('http://example.com')

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -104,6 +104,7 @@ class TestPoolManager(unittest.TestCase):
             'retries': retry.Retry(total=6, connect=2),
             'block': True,
             'strict': True,
+            'source_address': '127.0.0.1',
         }
         p = PoolManager()
         conn_pools = [
@@ -156,6 +157,7 @@ class TestPoolManager(unittest.TestCase):
             'retries': retry.Retry(total=6, connect=2),
             'block': True,
             'strict': True,
+            'source_address': '127.0.0.1',
             'key_file': '/root/totally_legit.key',
             'cert_file': '/root/totally_legit.crt',
             'cert_reqs': 'CERT_REQUIRED',
@@ -302,12 +304,13 @@ class TestPoolManager(unittest.TestCase):
         self.assertTrue(all(isinstance(key, HTTPPoolKey) for key in p.pools.keys()))
 
     def test_custom_pool_key(self):
-        custom_key = namedtuple('CustomKey', HTTPPoolKey._fields + ('source_address',))
-        p = PoolManager(10, source_address='127.0.0.1')
+        """Assert it is possible to define addition pool key fields."""
+        custom_key = namedtuple('CustomKey', HTTPPoolKey._fields + ('my_field',))
+        p = PoolManager(10, my_field='barley')
 
         p.key_fn_by_scheme['http'] = functools.partial(_default_key_normalizer, custom_key)
         p.connection_from_url('http://example.com')
-        p.connection_pool_kw['source_address'] = '127.0.0.2'
+        p.connection_pool_kw['my_field'] = 'wheat'
         p.connection_from_url('http://example.com')
 
         self.assertEqual(2, len(p.pools))

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -5,6 +5,7 @@ from urllib3.poolmanager import (
     pool_keys_by_scheme,
     HTTPPoolKey,
     HTTPSPoolKey,
+    SSL_KEYWORDS,
 )
 from urllib3 import connection_from_url
 from urllib3.exceptions import (
@@ -131,6 +132,16 @@ class TestPoolManager(unittest.TestCase):
         p = PoolManager()
         conn_pool = p.connection_from_url('http://example.com/')
         p.connection_pool_kw['some_kwarg'] = 'that should be ignored'
+        other_conn_pool = p.connection_from_url('http://example.com/')
+
+        self.assertTrue(conn_pool is other_conn_pool)
+
+    def test_http_pool_key_https_kwargs(self):
+        """Assert HTTPSPoolKey fields are ignored when selecting a HTTP pool."""
+        p = PoolManager()
+        conn_pool = p.connection_from_url('http://example.com/')
+        for key in SSL_KEYWORDS:
+            p.connection_pool_kw[key] = 'this should be ignored'
         other_conn_pool = p.connection_from_url('http://example.com/')
 
         self.assertTrue(conn_pool is other_conn_pool)

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -1,11 +1,17 @@
 import unittest
 
-from urllib3.poolmanager import PoolManager
+from urllib3.poolmanager import (
+    PoolManager,
+    pool_keys_by_scheme,
+    HTTPPoolKey,
+    HTTPSPoolKey,
+)
 from urllib3 import connection_from_url
 from urllib3.exceptions import (
     ClosedPoolError,
     LocationValueError,
 )
+from urllib3.util import retry, timeout
 
 
 class TestPoolManager(unittest.TestCase):
@@ -87,7 +93,108 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(len(p.pools), 0)
 
-    def test_pools_keyed_on_ssl_arguments_from_host(self):
+    def test_http_pool_key_fields(self):
+        """Assert the HTTPPoolKey fields are honored when selecting a pool."""
+        connection_pool_kw = {
+            'timeout': timeout.Timeout(3.14),
+            'retries': retry.Retry(total=6, connect=2),
+            'block': True,
+            'strict': True,
+        }
+        p = PoolManager()
+        conn_pools = [
+            p.connection_from_url('http://example.com/'),
+            p.connection_from_url('http://example.com:8000/'),
+            p.connection_from_url('http://other.example.com/'),
+        ]
+
+        for key, value in connection_pool_kw.items():
+            p.connection_pool_kw[key] = value
+            conn_pools.append(p.connection_from_url('http://example.com/'))
+
+        self.assertTrue(
+            all(
+                x is not y
+                for i, x in enumerate(conn_pools)
+                for j, y in enumerate(conn_pools)
+                if i != j
+            )
+        )
+        self.assertTrue(
+            all(
+                isinstance(key, HTTPPoolKey)
+                for key in p.pools.keys())
+        )
+
+    def test_http_pool_key_extra_kwargs(self):
+        """Assert non-HTTPPoolKey fields are ignored when selecting a pool."""
+        p = PoolManager()
+        conn_pool = p.connection_from_url('http://example.com/')
+        p.connection_pool_kw['some_kwarg'] = 'that should be ignored'
+        other_conn_pool = p.connection_from_url('http://example.com/')
+
+        self.assertTrue(conn_pool is other_conn_pool)
+
+    def test_https_pool_key_fields(self):
+        """Assert the HTTPSPoolKey fields are honored when selecting a pool."""
+        connection_pool_kw = {
+            'timeout': timeout.Timeout(3.14),
+            'retries': retry.Retry(total=6, connect=2),
+            'block': True,
+            'strict': True,
+            'key_file': '/root/totally_legit.key',
+            'cert_file': '/root/totally_legit.crt',
+            'cert_reqs': 'CERT_REQUIRED',
+            'ca_certs': '/root/path_to_pem',
+            'ssl_version': 'SSLv23_METHOD',
+        }
+        p = PoolManager()
+        conn_pools = [
+            p.connection_from_url('https://example.com/'),
+            p.connection_from_url('https://example.com:4333/'),
+            p.connection_from_url('https://other.example.com/'),
+        ]
+        # Asking for a connection pool with the same key should give us an
+        # existing pool.
+        dup_pools = []
+
+        for key, value in connection_pool_kw.items():
+            p.connection_pool_kw[key] = value
+            conn_pools.append(p.connection_from_url('https://example.com/'))
+            dup_pools.append(p.connection_from_url('https://example.com/'))
+
+        self.assertTrue(
+            all(
+                x is not y
+                for i, x in enumerate(conn_pools)
+                for j, y in enumerate(conn_pools)
+                if i != j
+            )
+        )
+        self.assertTrue(all(pool in conn_pools for pool in dup_pools))
+        self.assertTrue(
+            all(
+                isinstance(key, HTTPSPoolKey)
+                for key in p.pools.keys())
+        )
+
+    def test_https_pool_key_extra_kwargs(self):
+        """Assert non-HTTPSPoolKey fields are ignored when selecting a pool."""
+        p = PoolManager()
+        conn_pool = p.connection_from_url('https://example.com/')
+        p.connection_pool_kw['some_kwarg'] = 'that should be ignored'
+        other_conn_pool = p.connection_from_url('https://example.com/')
+
+        self.assertTrue(conn_pool is other_conn_pool)
+
+    def test_default_pool_keys_copy(self):
+        """Assert each PoolManager gets a copy of ``pool_keys_by_scheme``."""
+        p = PoolManager()
+        self.assertEqual(p.pool_keys_by_scheme, pool_keys_by_scheme)
+        self.assertFalse(p.pool_keys_by_scheme is pool_keys_by_scheme)
+
+    def test_pools_keyed_with_from_host(self):
+        """Assert pools are still keyed correctly with connection_from_host."""
         ssl_kw = {
             'key_file': '/root/totally_legit.key',
             'cert_file': '/root/totally_legit.crt',
@@ -106,31 +213,6 @@ class TestPoolManager(unittest.TestCase):
             conns.append(
                 p.connection_from_host('example.com', 443, scheme='https')
             )
-
-        self.assertTrue(
-            all(
-                x is not y
-                for i, x in enumerate(conns)
-                for j, y in enumerate(conns)
-                if i != j
-            )
-        )
-
-    def test_pools_keyed_on_ssl_arguments_from_url(self):
-        ssl_kw = {
-            'key_file': '/root/totally_legit.key',
-            'cert_file': '/root/totally_legit.crt',
-            'cert_reqs': 'CERT_REQUIRED',
-            'ca_certs': '/root/path_to_pem',
-            'ssl_version': 'SSLv23_METHOD',
-        }
-        p = PoolManager(5, **ssl_kw)
-        conns = []
-        conns.append(p.connection_from_url('https://example.com/'))
-
-        for k in ssl_kw:
-            p.connection_pool_kw[k] = 'newval'
-            conns.append(p.connection_from_url('https://example.com/'))
 
         self.assertTrue(
             all(

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -36,8 +36,8 @@ BasePoolKey = collections.namedtuple('BasePoolKey', ('scheme', 'host', 'port'))
 # connection from. All additional fields must be present in the PoolManager's
 # ``connection_pool_kw`` instance variable.
 HTTPPoolKey = collections.namedtuple(
-    'HTTPPoolKey', BasePoolKey._fields + ('timeout', 'retries',
-                                          'strict', 'block')
+    'HTTPPoolKey', BasePoolKey._fields + ('timeout', 'retries', 'strict',
+                                          'block', 'source_address')
 )
 HTTPSPoolKey = collections.namedtuple(
     'HTTPSPoolKey', HTTPPoolKey._fields + SSL_KEYWORDS

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import collections
+import functools
 import logging
 
 try:  # Python 3
@@ -43,7 +44,7 @@ HTTPSPoolKey = collections.namedtuple(
 )
 
 
-def _default_key_normalizer(request_context, key_class):
+def _default_key_normalizer(key_class, request_context):
     """
     Create a pool key of type ``key_class`` for a request.
 
@@ -52,13 +53,13 @@ def _default_key_normalizer(request_context, key_class):
     key for an HTTPS request. If you wish to change this behaviour, provide
     alternate callables to ``key_fn_by_scheme``.
 
-    :param request_context:
-        A dictionary-like object that contain the context for a request.
-        It should contain a key for each field in the :class:`HTTPPoolKey`
-
     :param key_class:
         The class to use when constructing the key. This should be a namedtuple
         with the ``scheme`` and ``host`` keys at a minimum.
+
+    :param request_context:
+        A dictionary-like object that contain the context for a request.
+        It should contain a key for each field in the :class:`HTTPPoolKey`
     """
     context = {}
     for key in key_class._fields:
@@ -73,8 +74,8 @@ def _default_key_normalizer(request_context, key_class):
 # Each PoolManager makes a copy of this dictionary so they can be configured
 # globally here, or individually on the instance.
 key_fn_by_scheme = {
-    'http': lambda context: _default_key_normalizer(context, HTTPPoolKey),
-    'https': lambda context: _default_key_normalizer(context, HTTPSPoolKey),
+    'http': functools.partial(_default_key_normalizer, HTTPPoolKey),
+    'https': functools.partial(_default_key_normalizer, HTTPSPoolKey),
 }
 
 pool_classes_by_scheme = {

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -202,11 +202,7 @@ class PoolManager(RequestMethods):
         :class:`urllib3.connectionpool.ConnectionPool` can be chosen for it.
         """
         u = parse_url(url)
-        request_context = self.connection_pool_kw.copy()
-        request_context['scheme'] = u.scheme or 'http'
-        request_context['port'] = u.port or port_by_scheme.get(u.scheme, 80)
-        request_context['host'] = u.host
-        conn = self.connection_from_context(request_context)
+        conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
 
         kw['assert_same_host'] = False
         kw['redirect'] = False


### PR DESCRIPTION
This commit modifies how the PoolManager stores and retrieves ``ConnectionPool`` objects for later use. It adds a new instance variable to the class, ``pool_keys_by_scheme``, which allows a user to define a list of fields from ``connection_pool_kw`` to consider (by scheme) when storing and retrieving pools.

This is my first stab at addressing the feedback from PR #751. It may or (much more likely) may not be what everyone had in mind, so I thought I would make a pull request before spending too much time polishing. Thanks for taking a look!