### PR TITLE
Disables IPv6 DNS when IPv6 connections are not possible

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,4 @@
-﻿# Contributions to the urllib3 project
+# Contributions to the urllib3 project
 
 ## Creator & Maintainer
 
@@ -191,8 +191,8 @@ In chronological order:
   * Started Recipes documentation and added a recipe about handling concatenated gzip data in HTTP response
 
 * Jesse Shapiro <jesse@jesseshapiro.net>
-  * Working on encoding unicode header parameter names
-  * Making setup.py resilient to ASCII locales
+  * Various character-encoding fixes/tweaks
+  * Disabling IPv6 DNS when IPv6 connections not supported
 
 * David Foster <http://dafoster.net/>
   * Ensure order of request and response headers are preserved.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -3,6 +3,7 @@ import warnings
 import logging
 import unittest
 import ssl
+import socket
 from itertools import chain
 
 from mock import patch, Mock
@@ -28,7 +29,10 @@ from urllib3.exceptions import (
     SSLError,
     SNIMissingWarning,
 )
-
+from urllib3.util.connection import (
+    supported_ip_family,
+    _has_ipv6
+)
 from urllib3.util import is_fp_closed, ssl_
 
 from . import clear_warnings
@@ -442,3 +446,29 @@ class TestUtil(unittest.TestCase):
 
         incorrect = hashlib.sha256(b'xyz').digest()
         self.assertFalse(_const_compare_digest_backport(target, incorrect))
+
+    def test_has_ipv6_disabled_on_compile(self):
+        with patch('socket.has_ipv6', False):
+            self.assertFalse(_has_ipv6('::1'))
+
+    def test_has_ipv6_enabled_but_fails(self):
+        with patch('socket.has_ipv6', True):
+            with patch('socket.socket') as mock:
+                instance = mock.return_value
+                instance.bind = Mock(side_effect=Exception('No IPv6 here!'))
+                self.assertFalse(_has_ipv6('::1'))
+
+    def test_has_ipv6_enabled_and_working(self):
+        with patch('socket.has_ipv6', True):
+            with patch('socket.socket') as mock:
+                instance = mock.return_value
+                instance.bind.return_value = True
+                self.assertTrue(_has_ipv6('::1'))
+
+    def test_ip_family_ipv6_enabled(self):
+        with patch('urllib3.util.connection.HAS_IPV6', True):
+            self.assertEqual(supported_ip_family(), 0)
+
+    def test_ip_family_ipv6_disabled(self):
+        with patch('urllib3.util.connection.HAS_IPV6', False):
+            self.assertEqual(supported_ip_family(), socket.AF_INET)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -30,7 +30,7 @@ from urllib3.exceptions import (
     SNIMissingWarning,
 )
 from urllib3.util.connection import (
-    family_filter,
+    allowed_gai_family,
     _has_ipv6
 )
 from urllib3.util import is_fp_closed, ssl_
@@ -467,8 +467,8 @@ class TestUtil(unittest.TestCase):
 
     def test_ip_family_ipv6_enabled(self):
         with patch('urllib3.util.connection.HAS_IPV6', True):
-            self.assertEqual(family_filter(), 0)
+            self.assertEqual(allowed_gai_family(), socket.AF_UNSPEC)
 
     def test_ip_family_ipv6_disabled(self):
         with patch('urllib3.util.connection.HAS_IPV6', False):
-            self.assertEqual(family_filter(), socket.AF_INET)
+            self.assertEqual(allowed_gai_family(), socket.AF_INET)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -30,7 +30,7 @@ from urllib3.exceptions import (
     SNIMissingWarning,
 )
 from urllib3.util.connection import (
-    supported_ip_family,
+    family_filter,
     _has_ipv6
 )
 from urllib3.util import is_fp_closed, ssl_
@@ -467,8 +467,8 @@ class TestUtil(unittest.TestCase):
 
     def test_ip_family_ipv6_enabled(self):
         with patch('urllib3.util.connection.HAS_IPV6', True):
-            self.assertEqual(supported_ip_family(), 0)
+            self.assertEqual(family_filter(), 0)
 
     def test_ip_family_ipv6_disabled(self):
         with patch('urllib3.util.connection.HAS_IPV6', False):
-            self.assertEqual(supported_ip_family(), socket.AF_INET)
+            self.assertEqual(family_filter(), socket.AF_INET)

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -67,7 +67,7 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
         host = host.strip('[]')
     err = None
 
-    # Using the value from family_filter() in the context of getaddrinfo lets 
+    # Using the value from family_filter() in the context of getaddrinfo lets
     # us select whether to work with IPv4 DNS records, IPv6 records, or both.
     # The original create_connection function always returns all records.
     family = family_filter()
@@ -110,7 +110,7 @@ def _set_socket_options(sock, options):
 
 def family_filter():
     """This function is designed to work in the context of
-    getaddrinfo, where family=0 is the default and will 
+    getaddrinfo, where family=0 is the default and will
     perform a DNS search for both IPv6 and IPv4 records."""
 
     family = socket.AF_INET

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -70,7 +70,7 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     # Using the value from family_filter() in the context of getaddrinfo lets
     # us select whether to work with IPv4 DNS records, IPv6 records, or both.
     # The original create_connection function always returns all records.
-    family = family_filter()
+    family = allowed_gai_family()
 
     for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
         af, socktype, proto, canonname, sa = res
@@ -108,14 +108,14 @@ def _set_socket_options(sock, options):
         sock.setsockopt(*opt)
 
 
-def family_filter():
+def allowed_gai_family():
     """This function is designed to work in the context of
-    getaddrinfo, where family=0 is the default and will
-    perform a DNS search for both IPv6 and IPv4 records."""
+    getaddrinfo, where family=socket.AF_UNSPEC is the default and
+    will perform a DNS search for both IPv6 and IPv4 records."""
 
     family = socket.AF_INET
     if HAS_IPV6:
-        family = 0
+        family = socket.AF_UNSPEC
     return family
 
 

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -67,7 +67,7 @@ def create_connection(address, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
         host = host.strip('[]')
     err = None
 
-    # Using the value from family_filter() in the context of getaddrinfo lets
+    # Using the value from allowed_gai_family() in the context of getaddrinfo lets
     # us select whether to work with IPv4 DNS records, IPv6 records, or both.
     # The original create_connection function always returns all records.
     family = allowed_gai_family()


### PR DESCRIPTION
Fixes #838 

Note that this will only work in cases where either Python has been compiled without IPv6 support or the host has IPv6 networking disabled (an exception is raised when opening a socket to `::1`); beyond that, we have no real way to check IPv6 availability.

Credit where it's due, this is existing code from the test module with unit tests added around it.