### PR TITLE
Correct docstring for Retry backoff factor

### DIFF
--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -89,12 +89,14 @@ class Retry(object):
         By default, this is disabled with ``None``.
 
     :param float backoff_factor:
-        A backoff factor to apply between attempts. urllib3 will sleep for::
+        A backoff factor to apply between attempts after the second try
+        (most errors are resolved immediately by a second try without a
+        delay). urllib3 will sleep for::
 
             {backoff factor} * (2 ^ ({number of total retries} - 1))
 
         seconds. If the backoff_factor is 0.1, then :func:`.sleep` will sleep
-        for [0.1s, 0.2s, 0.4s, ...] between retries. It will never be longer
+        for [0.0s, 0.2s, 0.4s, ...] between retries. It will never be longer
         than :attr:`Retry.BACKOFF_MAX`.
 
         By default, backoff is disabled (set to 0).


### PR DESCRIPTION
Correct the docstring for the backoff_factor argument to the Retry object, to reflect the fact that a wait is not applied before the second try, as per issue #847 