### PR TITLE
Improve doc around Retry.status_forcelist and Retry.method_whitelist

### DIFF
--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -148,6 +148,21 @@ class RetryTest(unittest.TestCase):
         self.assertFalse(retry.is_forced_retry('GET', status_code=400))
         self.assertTrue(retry.is_forced_retry('GET', status_code=418))
 
+        # String status codes are not matched.
+        retry = Retry(total=1, status_forcelist=['418'])
+        self.assertFalse(retry.is_forced_retry('GET', status_code=418))
+
+    def test_method_whitelist_with_status_forcelist(self):
+        # Falsey method_whitelist means to retry on any method.
+        retry = Retry(status_forcelist=[500], method_whitelist=None)
+        self.assertTrue(retry.is_forced_retry('GET', status_code=500))
+        self.assertTrue(retry.is_forced_retry('POST', status_code=500))
+
+        # Criteria of method_whitelist and status_forcelist are ANDed.
+        retry = Retry(status_forcelist=[500], method_whitelist=['POST'])
+        self.assertFalse(retry.is_forced_retry('GET', status_code=500))
+        self.assertTrue(retry.is_forced_retry('POST', status_code=500))
+
     def test_exhausted(self):
         self.assertFalse(Retry(0).is_exhausted())
         self.assertTrue(Retry(-1).is_exhausted())

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -80,11 +80,15 @@ class Retry(object):
         Set of uppercased HTTP method verbs that we should retry on.
 
         By default, we only retry on methods which are considered to be
-        indempotent (multiple requests with the same parameters end with the
+        idempotent (multiple requests with the same parameters end with the
         same state). See :attr:`Retry.DEFAULT_METHOD_WHITELIST`.
 
+        Set to a ``False`` value to retry on any verb.
+
     :param iterable status_forcelist:
-        A set of HTTP status codes that we should force a retry on.
+        A set of integer HTTP status codes that we should force a retry on.
+        A retry is initiated if the request method is in ``method_whitelist``
+        and the response status code is in ``status_forcelist``.
 
         By default, this is disabled with ``None``.
 


### PR DESCRIPTION
I got confused by some ambiguities in the doc for the Retry class, so I propose these improvements. I've backed it up with a few more tests.