### PR TITLE
update timeout warning and default value on App Engine

### DIFF
--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -224,10 +224,11 @@ class AppEngineManager(RequestMethods):
         if timeout is Timeout.DEFAULT_TIMEOUT:
             return None  # Defer to URLFetch's default.
         if isinstance(timeout, Timeout):
-            if timeout._read is not timeout._connect:
+            if timeout._read is not None or timeout._connect is not None:
                 warnings.warn(
                     "URLFetch does not support granular timeout settings, "
-                    "reverting to total timeout.", AppEnginePlatformWarning)
+                    "reverting to total or default URLFetch timeout.",
+                    AppEnginePlatformWarning)
             return timeout.total
         return timeout
 

--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -222,7 +222,7 @@ class AppEngineManager(RequestMethods):
 
     def _get_absolute_timeout(self, timeout):
         if timeout is Timeout.DEFAULT_TIMEOUT:
-            return 5  # 5s is the default timeout for URLFetch.
+            return None  # Defer to URLFetch's default.
         if isinstance(timeout, Timeout):
             if timeout._read is not timeout._connect:
                 warnings.warn(


### PR DESCRIPTION
motivated by sigmavirus24/requests-toolbelt#146. cc @jonparrott.