### PR TITLE
strict parameter is obsolete in python version > 3.4

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -212,7 +212,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         log.info("Starting new HTTP connection (%d): %s",
                  self.num_connections, self.host)
 
-        if sys.version_info <= (3,3):
+        if sys.version_info <= (3, 3):
             conn = self.ConnectionCls(host=self.host, port=self.port,
                                       timeout=self.timeout.connect_timeout,
                                       strict=self.strict, **self.conn_kw)

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -212,9 +212,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         log.info("Starting new HTTP connection (%d): %s",
                  self.num_connections, self.host)
 
-        conn = self.ConnectionCls(host=self.host, port=self.port,
-                                  timeout=self.timeout.connect_timeout,
-                                  strict=self.strict, **self.conn_kw)
+        if sys.version_info <= (3,3):
+            conn = self.ConnectionCls(host=self.host, port=self.port,
+                                      timeout=self.timeout.connect_timeout,
+                                      strict=self.strict, **self.conn_kw)
+        else:
+            conn = self.ConnectionCls(host=self.host, port=self.port,
+                                      timeout=self.timeout.connect_timeout,
+                                      **self.conn_kw)
         return conn
 
     def _get_conn(self, timeout=None):


### PR DESCRIPTION
The strict parameter causes twill to break:

```
In [1]: from twill.commands import *

In [2]: go("http://www.python.org/")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-8620e344db1d> in <module>()
----> 1 go("http://www.python.org/")

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/twill-1.8.0-py3.4.egg/twill/commands.py in go(url)
    108     Visit the URL given.
    109     """
--> 110     browser.go(url)
    111     return browser.get_url()
    112 

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/twill-1.8.0-py3.4.egg/twill/browser.py in go(self, url)
     79         for u in try_urls:
     80             try:
---> 81                 self._journey('open', u)
     82                 success = True
     83                 break

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/twill-1.8.0-py3.4.egg/twill/browser.py in _journey(self, func_name, *args, **kwargs)
    510             auth = None
    511 
--> 512         r = self._session.get(url, auth = auth)
    513 
    514         if _follow_equiv_refresh():

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/sessions.py in get(self, url, **kwargs)
    485 
    486         kwargs.setdefault('allow_redirects', True)
--> 487         return self.request('GET', url, **kwargs)
    488 
    489     def options(self, url, **kwargs):

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/sessions.py in request(self, method, url, params, data, headers, cookies, files, auth, timeout, allow_redirects, proxies, hooks, stream, verify, cert, json)
    473         }
    474         send_kwargs.update(settings)
--> 475         resp = self.send(prep, **send_kwargs)
    476 
    477         return resp

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/sessions.py in send(self, request, **kwargs)
    583 
    584         # Send the request
--> 585         r = adapter.send(request, **kwargs)
    586 
    587         # Total elapsed time of the request (approximately)

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/adapters.py in send(self, request, stream, timeout, verify, cert, proxies)
    401                     decode_content=False,
    402                     retries=self.max_retries,
--> 403                     timeout=timeout
    404                 )
    405 

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py in urlopen(self, method, url, body, headers, retries, redirect, assert_same_host, timeout, pool_timeout, release_conn, chunked, **response_kw)
    564             # Request a connection from the queue.
    565             timeout_obj = self._get_timeout(timeout)
--> 566             conn = self._get_conn(timeout=pool_timeout)
    567 
    568             conn.timeout = timeout_obj.connect_timeout

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py in _get_conn(self, timeout)
    254                 conn = None
    255 
--> 256         return conn or self._new_conn()
    257 
    258     def _put_conn(self, conn):

/home/moritz/projects/twill/venv/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py in _new_conn(self)
    215         conn = self.ConnectionCls(host=self.host, port=self.port,
    216                                   timeout=self.timeout.connect_timeout,
--> 217                                   strict=self.strict, **self.conn_kw)
    218         return conn
    219 
```