### PR TITLE
Hide a confusing "getresponse() got an unexpected keyword argument 'b…

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -383,8 +383,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         try:
             try:  # Python 2.7, use buffering of HTTP responses
                 httplib_response = conn.getresponse(buffering=True)
-            except TypeError:  # Python 2.6 and older
-                httplib_response = conn.getresponse()
+            except TypeError:  # Python 2.6 and older, Python 3
+                try:
+                    httplib_response = conn.getresponse()
+                except Exception as e:
+                    # Remove the TypeError from the exception chain in Python 3;
+                    # otherwise it looks like a programming error was the cause.
+                    six.raise_from(e, None)
         except (SocketTimeout, BaseSSLError, SocketError) as e:
             self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
             raise


### PR DESCRIPTION
…uffering'" error

Remove the TypeError from the exception chain in Python 3; otherwise it
looks like a programming error was the cause. A quick google search of
the above phrase shows I was not the only one.

Here is how a connection timeout looks like before this patch:

    urllib3.PoolManager().request('GET', 'google.com:81', retries=False, timeout=1)

    Traceback (most recent call last):
    File "/home/ran/src/urllib3/urllib3/connectionpool.py", line 385, in _make_request
        httplib_response = conn.getresponse(buffering=True)
    TypeError: getresponse() got an unexpected keyword argument 'buffering'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
    File "/home/ran/src/urllib3/urllib3/connectionpool.py", line 387, in _make_request
        httplib_response = conn.getresponse()
    File "/usr/lib/python3.5/http/client.py", line 1174, in getresponse
        response.begin()
    File "/usr/lib/python3.5/http/client.py", line 282, in begin
        version, status, reason = self._read_status()
    File "/usr/lib/python3.5/http/client.py", line 243, in _read_status
        line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
    File "/usr/lib/python3.5/socket.py", line 575, in readinto
        return self._sock.recv_into(b)
    socket.timeout: timed out

    [snip]

After, the first part is gone, and only the real cause is shown.

In Python2, exceptions are not chained automatically so there is no
difference.