### PR TITLE
Exclude pkginfo 1.3.0 from installation.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ twine==1.5.0
 wheel==0.24.0
 tornado==4.2.1
 PySocks==1.5.6
+pkginfo>=1.0,!=1.3.0


### PR DESCRIPTION
Note that we only require pkginfo *transitively* from twine, so arguably we could be a bit more careful and simply not require twine in Travis, but for now this will do just fine.

Resolves the problem affecting #874. This will affect all our CI jobs until resolved, so let's merge this sharpish. @shazow @sigmavirus24 @haikuginger for review.