### PR TITLE
``PoolManager`` now references the gobal ``key_fn_by_scheme`` dictionary

### DIFF
--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -204,10 +204,9 @@ class TestPoolManager(unittest.TestCase):
         self.assertTrue(conn_pool is other_conn_pool)
 
     def test_default_pool_key_funcs_copy(self):
-        """Assert each PoolManager gets a copy of ``pool_keys_by_scheme``."""
+        """Assert each PoolManager gets a reference to ``key_fn_by_scheme``."""
         p = PoolManager()
-        self.assertEqual(p.key_fn_by_scheme, p.key_fn_by_scheme)
-        self.assertFalse(p.key_fn_by_scheme is key_fn_by_scheme)
+        self.assertTrue(p.key_fn_by_scheme is key_fn_by_scheme)
 
     def test_pools_keyed_with_from_host(self):
         """Assert pools are still keyed correctly with connection_from_host."""
@@ -308,7 +307,7 @@ class TestPoolManager(unittest.TestCase):
         custom_key = namedtuple('CustomKey', HTTPPoolKey._fields + ('my_field',))
         p = PoolManager(10, my_field='barley')
 
-        p.key_fn_by_scheme['http'] = functools.partial(_default_key_normalizer, custom_key)
+        p.key_fn_by_scheme = {'http': functools.partial(_default_key_normalizer, custom_key)}
         p.connection_from_url('http://example.com')
         p.connection_pool_kw['my_field'] = 'wheat'
         p.connection_from_url('http://example.com')

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -71,8 +71,8 @@ def _default_key_normalizer(key_class, request_context):
 
 # A dictionary that maps a scheme to a callable that creates a pool key.
 # This can be used to alter the way pool keys are constructed, if desired.
-# Each PoolManager makes a copy of this dictionary so they can be configured
-# globally here, or individually on the instance.
+# Each PoolManager references this dictionary, so modifying this dictionary
+# results in a change for all PoolManager instances.
 key_fn_by_scheme = {
     'http': functools.partial(_default_key_normalizer, HTTPPoolKey),
     'https': functools.partial(_default_key_normalizer, HTTPSPoolKey),
@@ -123,7 +123,7 @@ class PoolManager(RequestMethods):
         # Locally set the pool classes and keys so other PoolManagers can
         # override them.
         self.pool_classes_by_scheme = pool_classes_by_scheme
-        self.key_fn_by_scheme = key_fn_by_scheme.copy()
+        self.key_fn_by_scheme = key_fn_by_scheme
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Initially for #830, the ``key_fn_by_scheme`` was copied for each
PoolManager instance. This is inconcistent with the
``pool_classes_by_scheme`` instance variable, which is a reference to
the global dictionary. This commit makes the two consistent by making
the ``key_fn_by_scheme`` instance variable a reference to the global
dictionary.