### PR TITLE
Add ResponseCls class attr to HTTPConnectionPool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ dev (master)
   
 * Retain ``release_conn` state across retries. (Issue #866)
 
+* Add customizable ``HTTPConnectionPool.ResponseCls``, which defaults to
+  ``HTTPResponse`` but can be replaced with a subclass.
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -169,6 +169,7 @@ In chronological order:
 * Jordan Moldow <https://github.com/jmoldow>
   * Fix low-level exceptions leaking from ``HTTPResponse.stream()``.
   * Bugfix for ``ConnectionPool.urlopen(release_conn=False)``.
+  * Creation of ``HTTPConnectionPool.ResponseCls``.
 
 * Predrag Gruevski <https://github.com/obi1kenobi>
   * Made cert digest comparison use a constant-time algorithm.

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -163,6 +163,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
     scheme = 'http'
     ConnectionCls = HTTPConnection
+    ResponseCls = HTTPResponse
 
     def __init__(self, host, port=None, strict=False,
                  timeout=Timeout.DEFAULT_TIMEOUT, maxsize=1, block=False,
@@ -600,10 +601,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             response_conn = conn if not release_conn else None
 
             # Import httplib's response into our own wrapper object
-            response = HTTPResponse.from_httplib(httplib_response,
-                                                 pool=self,
-                                                 connection=response_conn,
-                                                 **response_kw)
+            response = self.ResponseCls.from_httplib(httplib_response,
+                                                     pool=self,
+                                                     connection=response_conn,
+                                                     **response_kw)
 
             # Everything went great!
             clean_exit = True


### PR DESCRIPTION
This attribute defaults to `HTTPResponse`, but developers can subclass `HTTPConnectionPool` and substitute their own `HTTPResponse` subclass, as long as it has valid `from_httplib()` and `__init__()` methods, with compatible method signatures.