### PR TITLE
Override Content-Type when setting body fields

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -131,6 +131,10 @@ class TestingApp(RequestHandler):
     def upload(self, request):
         "Confirm that the uploaded file conforms to specification"
         # FIXME: This is a huge broken mess
+        content_type = request.headers.get('Content-Type', '')
+        if 'multipart/form-data' not in content_type:
+            return Response('Wrong content type: {}'.format(content_type),
+                            status='400 Bad Request')
         param = request.params.get('upload_param', 'myfile').decode('ascii')
         filename = request.params.get('upload_filename', '').decode('utf-8')
         size = int(request.params.get('upload_size', '0'))

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -245,6 +245,19 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         r = self.pool.request('POST', '/upload', fields=fields)
         self.assertEqual(r.status, 200, r.data)
 
+    def test_upload_with_janky_ct_header(self):
+        data = "I'm in ur multipart form-data, hazing a cheezburgr"
+        fields = {
+            'upload_param': 'filefield',
+            'upload_filename': 'lolcat.txt',
+            'upload_size': len(data),
+            'filefield': ('lolcat.txt', data),
+        }
+        headers = {'Content-Type': 'NOT REAL PLEASE OVERRIDE ME'}
+        r = self.pool.request('POST', '/upload', fields=fields, headers=headers)
+        # We should override the fake Content-Type header when we do our multipart magic
+        self.assertEqual(r.status, 200, r.data)
+
     def test_one_name_multiple_values(self):
         fields = [
             ('foo', 'a'),

--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -130,7 +130,7 @@ class RequestMethods(object):
         if headers is None:
             headers = self.headers
 
-        extra_kw = {'headers': {}}
+        extra_kw = {'headers': headers.copy()}
 
         if fields:
             if 'body' in urlopen_kw:
@@ -143,9 +143,8 @@ class RequestMethods(object):
                 body, content_type = urlencode(fields), 'application/x-www-form-urlencoded'
 
             extra_kw['body'] = body
-            extra_kw['headers'] = {'Content-Type': content_type}
+            extra_kw['headers'].update({'Content-Type': content_type})
 
-        extra_kw['headers'].update(headers)
         extra_kw.update(urlopen_kw)
 
         return self.urlopen(method, url, **extra_kw)


### PR DESCRIPTION
Fixes an issue spotted while working on #885 - if the user passes a `Content-Type` header explicitly, then we'll leave it alone when setting up body-encoded fields. This corrects for that; we'll override with the appropriate header for what we implemented.