### PR TITLE
Allow nested Retry objects in Retry.total

### DIFF
--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -88,6 +88,17 @@ class RetryTest(unittest.TestCase):
         self.assertTrue(Retry(0).raise_on_redirect)
         self.assertFalse(Retry(False).raise_on_redirect)
 
+    def test_retry_total_is_a_retry(self):
+        """ When retry.total is a Retry object, do not fail as before with a
+            "TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'"
+        """
+        retry = Retry(total=5)
+        retry = retry.increment()
+        self.assertEqual(retry.total, 4)
+        retry.total = Retry(total=5)
+        retry = retry.increment()
+        self.assertEqual(retry.total, 4)
+
     def test_retry_read_zero(self):
         """ No second chances on read timeouts, by default """
         error = ReadTimeoutError(None, "/", "read timed out")

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -239,7 +239,7 @@ class Retry(object):
 
         total = self.total
         while hasattr(total, 'total'):
-            total = total.total  ## allow nested Retry objects
+            total = total.total  # allow nested Retry objects
         if total is not None:
             total -= 1
 

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -238,6 +238,8 @@ class Retry(object):
             raise six.reraise(type(error), error, _stacktrace)
 
         total = self.total
+        while hasattr(total, 'total'):
+            total = total.total  ## allow nested Retry objects
         if total is not None:
             total -= 1
 


### PR DESCRIPTION
I had the following exception in the wild:

    TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'

This happened while doing a `pip install` from a `devpi` that was down, causing a `Connection refused` and thus triggering the retry logic of `urllib3`. Seems someone has code like `Retry(r.increment())` or similar – instead of hunting that down, I found it easier and more robust to fix it at the source of the exception, especially since the fix is easy. YMMV.