### PR TITLE
Remove absolute import.

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -60,7 +60,7 @@ try:  # Platform-specific: Python 2
     from socket import _fileobject
 except ImportError:  # Platform-specific: Python 3
     _fileobject = None
-    from urllib3.packages.backports.makefile import backport_makefile
+    from ..packages.backports.makefile import backport_makefile
 
 import ssl
 import select


### PR DESCRIPTION
This absolute import breaks vendorizing urllib3: see kennethreitz/requests#3006.