### PR TITLE
Adding docs/requirements.txt for readthedocs.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+-r ../dev-requirements.txt
+ndg-httpsclient
+sphinx
+alabaster

--- a/tox.ini
+++ b/tox.ini
@@ -40,10 +40,7 @@ commands=
 [testenv:docs]
 basepython = python2.7
 deps=
-    -r{toxinidir}/dev-requirements.txt
-    ndg-httpsclient
-    sphinx
-    alabaster
+    -r{toxinidir}/docs/requirements.txt
 commands=
     rm -r {toxinidir}/docs/_build
     make -C {toxinidir}/docs html


### PR DESCRIPTION
The rtd config will need to be updated to point to `docs/requirements.txt` instead of `docs-requirements.txt`.

I think/hope this should work.