### PR TITLE
Normalize the scheme and host in the URL parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ dev (master)
 * Used URLFetch default timeout on AppEngine, rather than hardcoding our own.
   (Issue #858)
 
+* Normalize the scheme and host in the URL parser (Issue #833)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -300,6 +300,16 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         except MaxRetryError as e:
             self.assertEqual(type(e.reason), ConnectTimeoutError)
 
+    def test_scheme_host_case_insensitive(self):
+        """Assert that upper-case schemes and hosts are normalized."""
+        http = proxy_from_url(self.proxy_url.upper())
+
+        r = http.request('GET', '%s/' % self.http_url.upper())
+        self.assertEqual(r.status, 200)
+
+        r = http.request('GET', '%s/' % self.https_url.upper())
+        self.assertEqual(r.status, 200)
+
 
 class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
 

--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -10,7 +10,8 @@ url_attrs = ['scheme', 'auth', 'host', 'port', 'path', 'query', 'fragment']
 class Url(namedtuple('Url', url_attrs)):
     """
     Datastructure for representing an HTTP URL. Used as a return value for
-    :func:`parse_url`.
+    :func:`parse_url`. Both the scheme and host are normalized as they are
+    both case-insensitive according to RFC 3986.
     """
     slots = ()
 
@@ -18,6 +19,10 @@ class Url(namedtuple('Url', url_attrs)):
                 query=None, fragment=None):
         if path and not path.startswith('/'):
             path = '/' + path
+        if scheme:
+            scheme = scheme.lower()
+        if host:
+            host = host.lower()
         return super(Url, cls).__new__(cls, scheme, auth, host, port, path,
                                        query, fragment)
 


### PR DESCRIPTION
I don't know that this is the most rigorous way to fix the problem of case-sensitivity, but it seemed like a nice centralized place to normalize things.

According to RFC 3986, the scheme and the host portion of the authority
in a URI are case-insensitive. ``urllib3`` uses the scheme in particular
as a key for various dictionaries, and oddly-cased schemes can break
this. This patch modifies the Url class to normalize both the scheme and
host.

fixes #833