### PR TITLE
Fix doc syntax in user-guide.rst

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -31,7 +31,7 @@ HTTP verb::
     >>> r = http.request(
     ...     'POST',
     ...     'http://httpbin.org/post',
-    ...     fields={'hello: 'world'})
+    ...     fields={'hello': 'world'})
 
 The :ref:`request_data` section covers sending other kinds of requests data,
 including JSON, files, and binary data.


### PR DESCRIPTION
This PR fixes a syntax error in `user-guide.rst` documentation.