### PR TITLE
adding in exception for booleans and zero values in timeouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ dev (master)
 * ``HTTPResponse`` contains the last ``Retry`` object, which now also
   contains retries history. (Issue #848)
 
+* Timeout can no longer be set as boolean, and must be greater than zero. 
+  (PR #924)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -206,5 +206,8 @@ In chronological order:
   * History list to Retry object.
   * HTTPResponse contains the last Retry object.
 
+* Nate Prewitt <nate.prewitt@gmail.com>
+  * Ensure timeouts are not booleans and greater than zero.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -304,15 +304,29 @@ class TestUtil(unittest.TestCase):
         except ValueError as e:
             self.assertTrue('less than' in str(e))
 
-        # Booleans are allowed also by socket.settimeout and converted to the
-        # equivalent float (1.0 for True, 0.0 for False)
-        Timeout(connect=False, read=True)
+        try:
+            Timeout(connect=False)
+            self.fail("boolean values should throw exception")
+        except ValueError as e:
+            self.assertTrue('cannot be a boolean' in str(e))
+
+        try:
+            Timeout(read=True)
+            self.fail("boolean values should throw exception")
+        except ValueError as e:
+            self.assertTrue('cannot be a boolean' in str(e))
+
+        try:
+            Timeout(connect=0)
+            self.fail("value <= 0 should throw exception")
+        except ValueError as e:
+            self.assertTrue('less than or equal' in str(e))
 
         try:
             Timeout(read="foo")
             self.fail("string value should not be allowed")
         except ValueError as e:
-            self.assertTrue('int or float' in str(e))
+            self.assertTrue('int, float or None' in str(e))
 
 
     @patch('urllib3.util.timeout.current_time')

--- a/urllib3/util/timeout.py
+++ b/urllib3/util/timeout.py
@@ -111,8 +111,8 @@ class Timeout(object):
         :param name: The name of the timeout attribute to validate. This is
             used to specify in error messages.
         :return: The validated and casted version of the given value.
-        :raises ValueError: If the type is not an integer or a float, or if it
-            is a numeric value less than zero.
+        :raises ValueError: If it is a numeric value less than or equal to
+            zero, or the type is not an integer, float, or None.
         """
         if value is _Default:
             return cls.DEFAULT_TIMEOUT
@@ -120,20 +120,23 @@ class Timeout(object):
         if value is None or value is cls.DEFAULT_TIMEOUT:
             return value
 
+        if isinstance(value, bool):
+            raise ValueError("Timeout cannot be a boolean value. It must "
+                             "be an int, float or None.")
         try:
             float(value)
         except (TypeError, ValueError):
             raise ValueError("Timeout value %s was %s, but it must be an "
-                             "int or float." % (name, value))
+                             "int, float or None." % (name, value))
 
         try:
-            if value < 0:
+            if value <= 0:
                 raise ValueError("Attempted to set %s timeout to %s, but the "
                                  "timeout cannot be set to a value less "
-                                 "than 0." % (name, value))
+                                 "than or equal to 0." % (name, value))
         except TypeError:  # Python 3
             raise ValueError("Timeout value %s was %s, but it must be an "
-                             "int or float." % (name, value))
+                             "int, float or None." % (name, value))
 
         return value
 


### PR DESCRIPTION
This should fix the issue addressed in kennethreitz/requests#2699 where boolean values passed to the `timeout` parameter are being evaluated at 1.0 and 0.0. This also addresses the issue of `timeout=0` opening a non-blocking socket.