### PR TITLE
Remove extra dependencies for PyOpenSSL.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,12 @@ dev (master)
 * ``HTTPResponse`` contains the last ``Retry`` object, which now also
   contains retries history. (Issue #848)
 
-* Timeout can no longer be set as boolean, and must be greater than zero. 
+* Timeout can no longer be set as boolean, and must be greater than zero.
   (PR #924)
+
+* Removed pyasn1 and ndg-httpsclient from dependencies used for PyOpenSSL. We
+  now use cryptography and idna, both of which are already dependencies of
+  PyOpenSSL. (PR #930)
 
 * ... [Short description of non-trivial change.] (Issue #)
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -255,7 +255,7 @@ certificate verification on Python 2 will be installed::
 If you want to install the packages manually, you will need ``pyOpenSSL``,
 ``cryptography``, ``idna``, and ``certifi``.
 
-.. note:: If you are not using Mac OS X or Windows, note that `cryptography
+.. note:: If you are not using macOS or Windows, note that `cryptography
     <https://cryptography.io/en/latest/>`_ requires additional system packages
     to compile. See `building cryptography on Linux
     <https://cryptography.io/en/latest/installation/#building-cryptography-on-linux>`_

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -141,7 +141,7 @@ JSON
 ~~~~
 
 You can sent JSON a request by specifying the encoded data as the ``body``
-argument and setting the ``Content-Type`` header when calling 
+argument and setting the ``Content-Type`` header when calling
 :meth:`~poolmanager.PoolManager.request`::
 
     >>> import json
@@ -210,7 +210,7 @@ and most reliable method is to use the `certifi <https://certifi.io/en/latest>`_
 
 You can also install certifi along with urllib3 by using the ``secure``
 extra::
-    
+
     pip install urllib3[secure]
 
 .. warning:: If you're using Python 2 you may need additional packages. See the :ref:`section below <ssl_py2>` for more details.
@@ -253,11 +253,11 @@ certificate verification on Python 2 will be installed::
     pip install urllib3[secure]
 
 If you want to install the packages manually, you will need ``pyOpenSSL``,
-``ndg-httpsclient``, ``pyasn``, and ``certifi``.
+``cryptography``, ``idna``, and ``certifi``.
 
-.. note:: If you are not using Mac OS X or Windows, note that pyOpenSSL depends
-    on `cryptography <https://cryptography.io/en/latest/>`_ which requires
-    additional system packages to compile. See `building cryptography on Linux
+.. note:: If you are not using Mac OS X or Windows, note that `cryptography
+    <https://cryptography.io/en/latest/>`_ requires additional system packages
+    to compile. See `building cryptography on Linux
     <https://cryptography.io/en/latest/installation/#building-cryptography-on-linux>`_
     for the list of packages required.
 
@@ -320,7 +320,7 @@ instance which lets you specify separate connect and read timeouts::
     ...     'http://httpbin.org/delay/3',
     ...     timeout=urllib3.Timeout(connect=1.0, read=2.0))
     MaxRetryError caused by ReadTimeoutError
-    
+
 
 If you want all requests to be subject to the same timeout, you can specify
 the timeout at the :class:`~urllib3.poolmanager.PoolManager` level::

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ provides-extra =
     socks
 requires-dist =
     pyOpenSSL>=0.13; python_version<="2.7" and extra == 'secure'
-    ndg-httpsclient; python_version<="2.7" and extra == 'secure'
-    pyasn1; python_version<="2.7" and extra == 'secure'
+    cryptography>=1.3.4; python_version<="2.7" and extra == 'secure'
+    idna>=2.0.0; python_version<="2.7" and extra == 'secure'
     certifi; extra == 'secure'
     PySocks>=1.5.6,<2.0; extra == 'socks'

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ provides-extra =
     secure
     socks
 requires-dist =
-    pyOpenSSL>=0.13; python_version<="2.7" and extra == 'secure'
+    pyOpenSSL>=0.14; python_version<="2.7" and extra == 'secure'
     cryptography>=1.3.4; python_version<="2.7" and extra == 'secure'
     idna>=2.0.0; python_version<="2.7" and extra == 'secure'
     certifi; extra == 'secure'

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='urllib3',
       test_suite='test',
       extras_require={
           'secure': [
-              'pyOpenSSL>=0.13',
+              'pyOpenSSL>=0.14',
               'cryptography>=1.3.4',
               'idna>=2.0.0',
               'certifi',

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(name='urllib3',
       extras_require={
           'secure': [
               'pyOpenSSL>=0.13',
-              'ndg-httpsclient',
-              'pyasn1',
+              'cryptography>=1.3.4',
+              'idna>=2.0.0',
               'certifi',
           ],
           'socks': [

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -46,7 +46,7 @@ from __future__ import absolute_import
 import idna
 import OpenSSL.SSL
 from cryptography import x509
-from cryptography.haztmat.backends.openssl import backend as openssl_backend
+from cryptography.hazmat.backends.openssl import backend as openssl_backend
 from cryptography.hazmat.backends.openssl.x509 import _Certificate
 
 from socket import timeout, error as SocketError
@@ -151,14 +151,14 @@ def get_subj_alt_name(peer_cert):
     # Pass the cert to cryptography, which has much better APIs for this.
     # This is technically using private APIs, but should work across all
     # relevant versions until PyOpenSSL gets something proper for this.
-    cert = _Certificate(openssl_backend(), peer_cert._x509)
+    cert = _Certificate(openssl_backend, peer_cert._x509)
 
     # We want to find the SAN extension. Ask Cryptography to locate it (it's
     # faster than looping in Python)
     try:
         ext = cert.extensions.get_extension_for_class(
             x509.SubjectAlternativeName
-        )
+        ).value
     except x509.ExtensionNotFound:
         # No such extension, return the empty list.
         return []
@@ -309,7 +309,7 @@ class WrappedSocket(object):
             'subject': (
                 (('commonName', x509.get_subject().CN),),
             ),
-            'subjectAltName': [get_subj_alt_name(x509)]
+            'subjectAltName': get_subj_alt_name(x509)
         }
 
     def _reuse(self):

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -6,13 +6,16 @@ certificates yourself.
 
 This needs the following packages installed:
 
-* pyOpenSSL (tested with 0.13)
-* ndg-httpsclient (tested with 0.3.2)
-* pyasn1 (tested with 0.1.6)
+* pyOpenSSL (tested with 16.0.0)
+* cryptography (minimum 1.3.4, from pyopenssl)
+* idna (minimum 2.0, from cryptography)
+
+However, pyopenssl depends on cryptography, which depends on idna, so while we
+use all three directly here we end up having relatively few packages required.
 
 You can install them with the following command:
 
-    pip install pyopenssl ndg-httpsclient pyasn1
+    pip install pyopenssl cryptography idna
 
 To activate certificate checking, call
 :func:`~urllib3.contrib.pyopenssl.inject_into_urllib3` from your Python code
@@ -40,15 +43,12 @@ set the ``urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST`` variable.
 """
 from __future__ import absolute_import
 
-try:
-    from ndg.httpsclient.ssl_peer_verification import SUBJ_ALT_NAME_SUPPORT
-    from ndg.httpsclient.subj_alt_name import SubjectAltName as BaseSubjectAltName
-except SyntaxError as e:
-    raise ImportError(e)
-
+import idna
 import OpenSSL.SSL
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.type import univ, constraint
+from cryptography import x509
+from cryptography.haztmat.backends.openssl import backend as openssl_backend
+from cryptography.hazmat.backends.openssl.x509 import _Certificate
+
 from socket import timeout, error as SocketError
 from io import BytesIO
 
@@ -58,16 +58,18 @@ except ImportError:  # Platform-specific: Python 3
     _fileobject = None
     from ..packages.backports.makefile import backport_makefile
 
+import logging
 import ssl
 import select
 import six
+import sys
 
 from .. import util
 
 __all__ = ['inject_into_urllib3', 'extract_from_urllib3']
 
-# SNI only *really* works if we can read the subjectAltName of certificates.
-HAS_SNI = SUBJ_ALT_NAME_SUPPORT
+# SNI always works.
+HAS_SNI = True
 
 # Map from urllib3 to PyOpenSSL compatible parameter-values.
 _openssl_versions = {
@@ -103,6 +105,9 @@ orig_util_HAS_SNI = util.HAS_SNI
 orig_util_SSLContext = util.ssl_.SSLContext
 
 
+log = logging.getLogger(__name__)
+
+
 def inject_into_urllib3():
     'Monkey-patch urllib3 with PyOpenSSL-backed SSL-support.'
 
@@ -123,46 +128,68 @@ def extract_from_urllib3():
     util.ssl_.IS_PYOPENSSL = False
 
 
-# Note: This is a slightly bug-fixed version of same from ndg-httpsclient.
-class SubjectAltName(BaseSubjectAltName):
-    '''ASN.1 implementation for subjectAltNames support'''
+def _dnsname_to_stdlib(name):
+    """
+    Converts a dNSName SubjectAlternativeName field to the form used by the
+    standard library on the given Python version.
 
-    # There is no limit to how many SAN certificates a certificate may have,
-    #   however this needs to have some limit so we'll set an arbitrarily high
-    #   limit.
-    sizeSpec = univ.SequenceOf.sizeSpec + \
-        constraint.ValueSizeConstraint(1, 1024)
+    Cryptography produces a dNSName as a unicode string that was idna-decoded
+    from ASCII bytes. We need to idna-encode that string to get it back, and
+    then on Python 3 we also need to convert to unicode via UTF-8 (the stdlib
+    uses PyUnicode_FromStringAndSize on it, which decodes via UTF-8).
+    """
+    name = idna.encode(name)
+    if sys.version_info >= (3, 0):
+        name = name.decode('utf-8')
+    return name
 
 
-# Note: This is a slightly bug-fixed version of same from ndg-httpsclient.
 def get_subj_alt_name(peer_cert):
-    # Search through extensions
-    dns_name = []
-    if not SUBJ_ALT_NAME_SUPPORT:
-        return dns_name
+    """
+    Given an PyOpenSSL certificate, provides all the subject alternative names.
+    """
+    # Pass the cert to cryptography, which has much better APIs for this.
+    # This is technically using private APIs, but should work across all
+    # relevant versions until PyOpenSSL gets something proper for this.
+    cert = _Certificate(openssl_backend(), peer_cert._x509)
 
-    general_names = SubjectAltName()
-    for i in range(peer_cert.get_extension_count()):
-        ext = peer_cert.get_extension(i)
-        ext_name = ext.get_short_name()
-        if ext_name != b'subjectAltName':
-            continue
+    # We want to find the SAN extension. Ask Cryptography to locate it (it's
+    # faster than looping in Python)
+    try:
+        ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        )
+    except x509.ExtensionNotFound:
+        # No such extension, return the empty list.
+        return []
+    except (x509.DuplicateExtension, x509.UnsupportedExtension,
+            x509.UnsupportedGeneralNameType, UnicodeError) as e:
+        # A problem has been found with the quality of the certificate. Assume
+        # no SAN field is present.
+        log.warning(
+            "A problem was encountered with the certificate that prevented "
+            "urllib3 from finding the SubjectAlternativeName field. This can "
+            "affect certificate validation. The error was %s",
+            e,
+        )
+        return []
 
-        # PyOpenSSL returns extension data in ASN.1 encoded form
-        ext_dat = ext.get_data()
-        decoded_dat = der_decoder.decode(ext_dat,
-                                         asn1Spec=general_names)
+    # We want to return dNSName and iPAddress fields. We need to cast the IPs
+    # back to strings because the match_hostname function wants them as
+    # strings.
+    # Sadly the DNS names need to be idna encoded and then, on Python 3, UTF-8
+    # decoded. This is pretty frustrating, but that's what the standard library
+    # does with certificates, and so we need to attempt to do the same.
+    names = [
+        ('DNS', _dnsname_to_stdlib(name))
+        for name in ext.get_values_for_type(x509.DNSName)
+    ]
+    names.extend(
+        ('IP Address', str(name))
+        for name in ext.get_values_for_type(x509.IPAddress)
+    )
 
-        for name in decoded_dat:
-            if not isinstance(name, SubjectAltName):
-                continue
-            for entry in range(len(name)):
-                component = name.getComponentByPosition(entry)
-                if component.getName() != 'dNSName':
-                    continue
-                dns_name.append(str(component.getComponent()))
-
-    return dns_name
+    return names
 
 
 class WrappedSocket(object):
@@ -282,10 +309,7 @@ class WrappedSocket(object):
             'subject': (
                 (('commonName', x509.get_subject().CN),),
             ),
-            'subjectAltName': [
-                ('DNS', value)
-                for value in get_subj_alt_name(x509)
-            ]
+            'subjectAltName': [get_subj_alt_name(x509)]
         }
 
     def _reuse(self):


### PR DESCRIPTION
Currently to use the pyopenssl contrib module we need to install three dependencies: pyopenssl, ndg-httpsclient, and pyasn1. The latter two dependencies exist *only* to give us the ability to handle the Subject Alternative Name X.509 extension, and are otherwise entirely unrequired.

This PR changes that logic to use cryptography instead. Because PyOpenSSL already depends on cryptography, this has the effect of reducing our actual dependency graph. We still, at a top level, have three dependencies (annoyingly we need `idna`, blame @reaperhulk), but those three top-level dependencies are *already present* in our dependency graph transitively (`pyopenssl` requires `cryptography` requires `idna`), so this has the effect of reducing the number of packages we rely on directly. We also have much better ties to the maintainers of those packages than we do to the maintainers of ndg-httpsclient and pyasn1.