### PR TITLE
Ignore only the unused import error

### DIFF
--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -10,10 +10,10 @@ from .packages import six
 
 try:  # Python 3
     from http.client import HTTPConnection as _HTTPConnection
-    from http.client import HTTPException  # noqa: unused in this module
+    from http.client import HTTPException  # noqa: F401
 except ImportError:
     from httplib import HTTPConnection as _HTTPConnection
-    from httplib import HTTPException  # noqa: unused in this module
+    from httplib import HTTPException  # noqa: F401
 
 try:  # Compiled with SSL?
     import ssl

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -12,7 +12,7 @@ try:  # Python 3
 except ImportError:
     from Queue import LifoQueue, Empty, Full
     # Queue is imported for side effects on MS Windows
-    import Queue as _unused_module_Queue  # noqa: unused
+    import Queue as _unused_module_Queue  # noqa: F401
 
 
 from .exceptions import (


### PR DESCRIPTION
Instead of waiting for Flake8 3.0.2 tonight, we might as well use Flake8's new feature. =D