### PR TITLE
use dunder slots for Url class slots variable

### DIFF
--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -13,7 +13,7 @@ class Url(namedtuple('Url', url_attrs)):
     :func:`parse_url`. Both the scheme and host are normalized as they are
     both case-insensitive according to RFC 3986.
     """
-    slots = ()
+    __slots__ = ()
 
     def __new__(cls, scheme=None, auth=None, host=None, port=None, path=None,
                 query=None, fragment=None):


### PR DESCRIPTION
From the python [`namedtuple`](https://docs.python.org/2.7/library/collections.html#collections.namedtuple) documentation:

> The subclass shown above sets `__slots__` to an empty tuple. This helps keep memory requirements low by preventing the creation of instance dictionaries.

Was this the intent for the `slots` variable in `Url` class also?