### PR TITLE
Allow PyPy 5.3 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,6 @@ matrix:
       env: TOXENV=py35
     - python: pypy-5.3
       env: TOXENV=pypy
+  allow_failures:
+  - python: pypy-5.3
 sudo: false


### PR DESCRIPTION
Since it's addition, our Travis builds have become very unstable and
this job seems to be implicated in most of those builds. Until we can
stabilize this particular build job, let's allow it to fail to avoid
having to continuously retry the build on Travis.