### PR TITLE
Skip invalid headers

### DIFF
--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -314,8 +314,10 @@ class HTTPHeaderDict(MutableMapping):
 
         for line in message.headers:
             if line.startswith((' ', '\t')):
-                key, value = headers[-1]
-                headers[-1] = (key, value + '\r\n' + line.rstrip())
+                if headers:
+                # If the first header is an invalid one, then just drop it.
+                    key, value = headers[-1]
+                    headers[-1] = (key, value + '\r\n' + line.rstrip())
                 continue
 
             key, value = line.split(':', 1)

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -316,6 +316,7 @@ class HTTPHeaderDict(MutableMapping):
             if line.startswith((' ', '\t')):
                 if headers:
                 # If the first header is an invalid one, then just drop it.
+                # This mimic Python 3.
                     key, value = headers[-1]
                     headers[-1] = (key, value + '\r\n' + line.rstrip())
                 continue


### PR DESCRIPTION
In cases where a header starts with whitespace, and that header does not immediately follow another header, drop that header. This imitates the treatment Python3 gives to these headers natively. Fixes #950.