### PR TITLE
adding in rfc3986 to encode unicode URIs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ wheel==0.24.0
 tornado==4.2.1
 PySocks==1.5.6
 pkginfo>=1.0,!=1.3.0
+rfc3986==0.3.1

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -109,6 +109,21 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         self.assertEqual(r.status, 303)
 
+    def test_unicode_url_parsing(self):
+        http = PoolManager()
+
+        url = ('%s/取得する' % self.base_url).encode('utf-8')
+        r = http.request('GET', url)
+        self.assertEqual(r.status, 200)
+
+    def test_unicode_location_url(self):
+        http = PoolManager()
+
+        url = ('%s/取得する' % self.base_url).encode('utf-8')
+        r = http.request('GET', '%s/redirect' % self.base_url, fields={'target': url},
+                         retries=Retry(total=None, redirect=1, raise_on_redirect=False))
+        self.assertEqual(r.status, 200)
+
     def test_raise_on_status(self):
         http = PoolManager()
 

--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 from collections import namedtuple
 
-from ..exceptions import LocationParseError
+import rfc3986
 
+from ..exceptions import LocationParseError
 
 url_attrs = ['scheme', 'auth', 'host', 'port', 'path', 'query', 'fragment']
 
@@ -150,6 +151,8 @@ def parse_url(url):
     if not url:
         # Empty
         return Url()
+
+    url = rfc3986.uri_reference(url).unsplit()
 
     scheme = None
     auth = None


### PR DESCRIPTION
This addresses #952 and adds urlencoding described in RFC3986 to `Url`s when they're created.

* I'd like to test that the URL used for `r` at the end of `test_unicode_location_url` is in fact '/取得する' but can't find a way to access the URL for the `Request`. Is there a way for me to check that from the `HTTPresponse` object?