### PR TITLE
fix encode_multipart_formdata (TypeError: 'float' does not have the buffer interface)

### DIFF
--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -77,7 +77,7 @@ def encode_multipart_formdata(fields, boundary=None):
         writer(body).write(field.render_headers())
         data = field.data
 
-        if isinstance(data, int):
+        if isinstance(data, int) or isinstance(data, float):
             data = str(data)  # Backwards compatibility
 
         if isinstance(data, six.text_type):


### PR DESCRIPTION
Allow request "fields" to have floating point values, otherwise an explicit cast to str is needed while making the request.