### PR TITLE
PySocks 1.5.7 causes problems with IPv6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='urllib3',
               'certifi',
           ],
           'socks': [
-              'PySocks>=1.5.6,<2.0',
+              'PySocks>=1.5.6,<2.0,!=1.5.7',
           ]
       },
       )


### PR DESCRIPTION
Just spent a few hours chasing this down, but basically the IPv6 support in PySocks 1.5.7 (which, to be clear, I wrote most of) is a bit busted. There's a fix in PySocks master for this, so we don't need to do any extra work, but we should add a blacklist marker for PySocks 1.5.7.