### PR TITLE
Lower log levels from connectionpool.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ dev (master)
 * Implemented ``enforce_content_length`` to enable exceptions when
   incomplete data chunks are received. (PR #949)
 
+* Dropped connection start, dropped connection reset, redirect, forced retry,
+  and new HTTPS connection log levels to DEBUG, from INFO. (PR #967)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -209,7 +209,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         """
         self.num_connections += 1
         log.debug("Starting new HTTP connection (%d): %s",
-                 self.num_connections, self.host)
+                  self.num_connections, self.host)
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
                                   timeout=self.timeout.connect_timeout,
@@ -804,7 +804,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         """
         self.num_connections += 1
         log.debug("Starting new HTTPS connection (%d): %s",
-                 self.num_connections, self.host)
+                  self.num_connections, self.host)
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:
             raise SSLError("Can't connect to HTTPS URL because the SSL "


### PR DESCRIPTION
Supersedes #926. Adds nothing but an updated merge and a changelog entry.