### PR TITLE
fixing incorrect message for IncompleteRead

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 dev (master)
 ------------
 
+* Fixed incorrect message for IncompleteRead exception. (PR #973)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1108,7 +1108,11 @@ class TestBadContentLength(SocketDummyServerTestCase):
         # Read "good" data before we try to read again.
         # This won't trigger till generator is exhausted.
         next(data)
-        self.assertRaises(ProtocolError, next, data)
+        try:
+            next(data)
+            self.assertFail()
+        except ProtocolError as e:
+            self.assertTrue('12 bytes read, 10 more expected' in str(e))
 
         done_event.set()
 

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -205,9 +205,11 @@ class IncompleteRead(HTTPError, httplib_IncompleteRead):
     reads.
     """
     def __init__(self, partial, expected):
-        message = ('IncompleteRead(%i bytes read, '
-                   '%i more expected)' % (partial, expected))
-        httplib_IncompleteRead.__init__(self, message)
+        super(IncompleteRead, self).__init__(partial, expected)
+
+    def __repr__(self):
+        return ('IncompleteRead(%i bytes read, '
+                '%i more expected)' % (self.partial, self.expected))
 
 
 class InvalidHeader(HTTPError):


### PR DESCRIPTION
I missed this during one of the final reviews when we changed urllib3's `IncompleteRead` from using `HTTPError` to httplib's `IncompleteRead` constructor. This is currently producing an incorrect length based on the `message` length rather than the ints we're passing in.

I updated the test to catch this and overwrote httplib's `__repr__` to create the correct message.
