### PR TITLE
HTTPResponse.closed consistency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ dev (master)
 * Accept ``iPAddress`` subject alternative name fields in TLS certificates.
   (Issue #258)
 
+* Fixed consistency of ``HTTPResponse.closed`` between Python 2 and 3.
+  (Issue #977)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -482,10 +482,10 @@ class HTTPResponse(io.IOBase):
     def closed(self):
         if self._fp is None:
             return True
+        elif hasattr(self._fp, 'isclosed'):
+            return self._fp.isclosed()
         elif hasattr(self._fp, 'closed'):
             return self._fp.closed
-        elif hasattr(self._fp, 'isclosed'):  # Python 2
-            return self._fp.isclosed()
         else:
             return True
 


### PR DESCRIPTION
Right now `urllib3.response.HTTPResponse.closed` returns different values based on Python version. This addresses the issue by preferring the more specific `isclosed` to `io`'s `closed` attr. See #977 for more details.