### PR TITLE
Disallow superscripts on digit checks

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -34,6 +34,7 @@ from urllib3.util.connection import (
     _has_ipv6
 )
 from urllib3.util import is_fp_closed, ssl_
+from urllib3.packages import six
 
 from . import clear_warnings
 
@@ -95,6 +96,8 @@ class TestUtil(unittest.TestCase):
             'http://google.com:foo',
             'http://::1/',
             'http://::1:80/',
+            'http://google.com:-80',
+            six.u('http://google.com:\xb2\xb2'),  # \xb2 = ^2
         ]
 
         for location in invalid_host:

--- a/urllib3/util/retry.py
+++ b/urllib3/util/retry.py
@@ -4,6 +4,7 @@ import logging
 from collections import namedtuple
 from itertools import takewhile
 import email
+import re
 
 from ..exceptions import (
     ConnectTimeoutError,
@@ -205,7 +206,8 @@ class Retry(object):
         return min(self.BACKOFF_MAX, backoff_value)
 
     def parse_retry_after(self, retry_after):
-        if retry_after.isdigit():
+        # Whitespace: https://tools.ietf.org/html/rfc7230#section-3.2.4
+        if re.match(r"^\s*[0-9]+\s*$", retry_after):
             seconds = int(retry_after)
         else:
             retry_date_tuple = email.utils.parsedate(retry_after)

--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -189,10 +189,14 @@ def parse_url(url):
             host = _host
 
         if port:
-            # If given, ports must be integers.
+            # If given, ports must be integers. No whitespace, no plus or
+            # minus prefixes, no non-integer digits such as ^2 (superscript).
             if not port.isdigit():
                 raise LocationParseError(url)
-            port = int(port)
+            try:
+                port = int(port)
+            except ValueError:
+                raise LocationParseError(url)
         else:
             # Blank ports are cool, too. (rfc3986#section-3.2.3)
             port = None


### PR DESCRIPTION
`isdigit()` lets other things besides 0-9 to pass, for example ².

An alternative to the fixes here would be to use e.g. `re.match(r"^[0-9]+$", ...)`, but that's slower.

With this change to `parse_retry_after`, a slight behavioral change is introduced: it starts to accept values surrounded by whitespace (not sure if they can end up here in usual use cases), and prefixed by `+` or `-`. Previously negative values raised `InvalidHeader`, now they get truncated to 0. Previously + prefixed values raised `InvalidHeader`, now they are accepted and the + ignored. If you feel these are issues that should be kept as they were, let me know and I'll adjust that change.