### PR TITLE
Make HTTPResponse.stream() work with _fp of non-HTTPResponse type (eg StringIO)

### DIFF
--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -196,6 +196,14 @@ class ResponseNotChunked(ProtocolError, ValueError):
     pass
 
 
+class BodyNotHttplibCompatible(AssertionError, ValueError):
+    """
+    Body should be httplib.HTTPResponse like (have an fp attribute which
+    returns raw chunks) for read_chunked().
+    """
+    pass
+
+
 class IncompleteRead(HTTPError, httplib_IncompleteRead):
     """
     Response length doesn't match expected Content-Length

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -196,7 +196,7 @@ class ResponseNotChunked(ProtocolError, ValueError):
     pass
 
 
-class BodyNotHttplibCompatible(AssertionError, ValueError):
+class BodyNotHttplibCompatible(HTTPError):
     """
     Body should be httplib.HTTPResponse like (have an fp attribute which
     returns raw chunks) for read_chunked().


### PR DESCRIPTION
Previously urllib's HTTPResponse would work correctly with any file like object. The 3rd party project requests_mock takes advantage of this by passing in a StringIO instance as the body (see: http://git.openstack.org/cgit/openstack/requests-mock/tree/requests_mock/response.py#n166 ). With the addition of chunked streaming in https://github.com/shazow/urllib3/commit/f21c2a2b73e4256ba2787f8470dbee6872987d2d stream() now assumes for chunked responses that if body is file-like then it is httplib.HTTPResponse-like breaking requests_mock.

This patch adds a guard in stream() to fall back to the old behaviour (delegate to the underlying file-like object as for unchunked responses) and another one to read_chunked() (fail early with an explicit error message).

Please let me know if there's any improvements I should make to get this merged or if you think this fix belongs elsewhere.