### PR TITLE
Fix PyOpenSSL with OpenSSL 1.1.0 (and CVE-2016-9015)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,21 @@ dev (master)
 * ... [Short description of non-trivial change.] (Issue #)
 
 
+1.18.1 (2016-10-27)
+-------------------
+
+* CVE-2016-9015. Users who are using urllib3 version 1.17 or 1.18 along with
+  PyOpenSSL injection and OpenSSL 1.1.0 *must* upgrade to this version. This
+  release fixes a vulnerability whereby urllib3 in the above configuration
+  would silently fail to validate TLS certificates due to erroneously setting
+  invalid flags in OpenSSL's ``SSL_CTX_set_verify`` function. These erroneous
+  flags do not cause a problem in OpenSSL versions before 1.1.0, which
+  interprets the presence of any flag as requesting certificate validation.
+
+  There is no PR for this patch, as it was prepared for simultaneous disclosure
+  and release. The master branch received the same fix in PR #1010.
+
+
 1.18 (2016-09-26)
 -----------------
 

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -8,6 +8,11 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew update || brew update
 
     brew outdated openssl || brew upgrade openssl
+    brew install openssl@1.1
+
+    # We can't use OpenSSL@1.1 for the standard library, because it's
+    # unsupported, but we want it for PyOpenSSL. So use regular openssl here
+    # for now.
     export LDFLAGS="-L$(brew --prefix openssl)/lib"
     export CFLAGS="-I$(brew --prefix openssl)/include"
 

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -9,9 +9,9 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 
-    # Use the good OpenSSL
-    export LDFLAGS="-L$(brew --prefix openssl)/lib"
-    export CFLAGS="-I$(brew --prefix openssl)/include"
+    # Use the good OpenSSL for PyOpenSSL.
+    export LDFLAGS="-L$(brew --prefix openssl@1.1)/lib"
+    export CFLAGS="-I$(brew --prefix openssl@1.1)/include"
 fi
 
 tox

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -471,16 +471,22 @@ class TestHTTPS_TLSv1(HTTPSDummyServerTestCase):
         self._pool = HTTPSConnectionPool(self.host, self.port)
 
     def test_set_ssl_version_to_sslv3(self):
-        self._pool.ssl_version = ssl.PROTOCOL_SSLv3
-        self.assertRaises(SSLError, self._pool.request, 'GET', '/')
+        self.assertEqual(
+            ssl.PROTOCOL_SSLv3,
+            util.ssl_.resolve_ssl_version(ssl.PROTOCOL_SSLv3)
+        )
 
     def test_ssl_version_as_string(self):
-        self._pool.ssl_version = 'PROTOCOL_SSLv3'
-        self.assertRaises(SSLError, self._pool.request, 'GET', '/')
+        self.assertEqual(
+            ssl.PROTOCOL_SSLv3,
+            util.ssl_.resolve_ssl_version("PROTOCOL_SSLv3")
+        )
 
     def test_ssl_version_as_short_string(self):
-        self._pool.ssl_version = 'SSLv3'
-        self.assertRaises(SSLError, self._pool.request, 'GET', '/')
+        self.assertEqual(
+            ssl.PROTOCOL_SSLv3,
+            util.ssl_.resolve_ssl_version("SSLv3")
+        )
 
     def test_discards_connection_on_sslerror(self):
         self._pool.cert_reqs = 'CERT_REQUIRED'

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -375,7 +375,8 @@ class PyOpenSSLContext(object):
     @verify_mode.setter
     def verify_mode(self, value):
         self._ctx.set_verify(
-            _stdlib_to_openssl_verify[value], _verify_callback
+            _stdlib_to_openssl_verify[value],
+            _verify_callback
         )
 
     def set_default_verify_paths(self):

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -88,12 +88,15 @@ try:
 except AttributeError:
     pass
 
-_openssl_verify = {
+_stdlib_to_openssl_verify = {
     ssl.CERT_NONE: OpenSSL.SSL.VERIFY_NONE,
     ssl.CERT_OPTIONAL: OpenSSL.SSL.VERIFY_PEER,
     ssl.CERT_REQUIRED:
         OpenSSL.SSL.VERIFY_PEER + OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT,
 }
+_openssl_to_stdlib_verify = dict(
+    (v, k) for k, v in _stdlib_to_openssl_verify.items()
+)
 
 #: The list of supported SSL/TLS cipher suites.
 DEFAULT_SSL_CIPHER_LIST = util.ssl_.DEFAULT_CIPHERS.encode('ascii')
@@ -367,11 +370,13 @@ class PyOpenSSLContext(object):
 
     @property
     def verify_mode(self):
-        return self._ctx.get_verify_mode()
+        return _openssl_to_stdlib_verify[self._ctx.get_verify_mode()]
 
     @verify_mode.setter
     def verify_mode(self, value):
-        self._ctx.set_verify(value, _verify_callback)
+        self._ctx.set_verify(
+            _stdlib_to_openssl_verify[value], _verify_callback
+        )
 
     def set_default_verify_paths(self):
         self._ctx.set_default_verify_paths()
@@ -440,7 +445,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
     if keyfile:
         ctx.use_privatekey_file(keyfile)
     if cert_reqs != ssl.CERT_NONE:
-        ctx.set_verify(_openssl_verify[cert_reqs], _verify_callback)
+        ctx.set_verify(_stdlib_to_openssl_verify[cert_reqs], _verify_callback)
     if ca_certs or ca_cert_dir:
         try:
             ctx.load_verify_locations(ca_certs, ca_cert_dir)


### PR DESCRIPTION
This PR provides a number of fixes to the PyOpenSSL contrib module to allow that module to work with OpenSSL 1.1.0.

While working on this PR I stumbled across a security vulnerability that was introduced in urllib3 1.17 (by me 😥). Happily, this vulnerability affects only those using the PyOpenSSL contrib module with OpenSSL 1.1.0. Unhappily, it's still a real vulnerability. This fix was backported to 1.18 and shipped in 1.18.1 as commit c32cdbc16a9634fa0f8c829d1270301570158715. It is present in this PR as well but in a more comprehensive form along with a number of other testing fixes. The vulnerability has been given the identifier CVE-2016-9015. A lengthy explanation of the vulnerability can be found on the [oss-security mailing list](http://www.openwall.com/lists/oss-security/2016/10/27/6).

I've coordinated with our downstream repackagers, who are not affected by this vulnerability, and with a representative of the Requests team (in this case, myself), who are also not affected by this vulnerability: all of those constituencies are using urllib3 1.16. I have also coordinated with the OpenSSL team.

This patch requires a few more things before it can be merged into the master branch. Specifically, it requires enhancement of our Travis environment to test with OpenSSL 1.1.0. Probably this is most easily done on the OS X builders, which can have Homebrew install the newer OpenSSL version so we can link PyOpenSSL against it.