### PR TITLE
Introduce IPv6 zone identifier support.

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -49,6 +49,16 @@ class TestConnectionPool(unittest.TestCase):
             ('http://google.com/', 'http://google.com:80/abracadabra'),
             ('https://google.com:443/', 'https://google.com/abracadabra'),
             ('https://google.com/', 'https://google.com:443/abracadabra'),
+            ('http://[2607:f8b0:4005:805::200e%25eth0]/',
+             'http://[2607:f8b0:4005:805::200e%eth0]/'
+            ),
+            ('https://[2607:f8b0:4005:805::200e%25eth0]:443/',
+             'https://[2607:f8b0:4005:805::200e%eth0]:443/'
+            ),
+            ('http://[::1]/', 'http://[::1]'),
+            ('http://[2001:558:fc00:200:f816:3eff:fef9:b954%lo]/',
+             'http://[2001:558:fc00:200:f816:3eff:fef9:b954%25lo]'
+            ),
         ]
 
         for a, b in same_host:
@@ -70,6 +80,9 @@ class TestConnectionPool(unittest.TestCase):
             ('https://google.com:80', 'http://google.com'),
             ('https://google.com:443', 'http://google.com'),
             ('http://google.com:80', 'https://google.com'),
+            # Zone identifiers are unique connection end points and should
+            # never be equivalent.
+            ('http://[dead::beef]', 'https://[dead::beef%en5]/'),
         ]
 
         for a, b in not_same_host:

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -67,13 +67,7 @@ class ConnectionPool(object):
         if not host:
             raise LocationValueError("No host specified.")
 
-        # httplib doesn't like it when we include brackets in ipv6 addresses
-        # Specifically, if we include brackets but also pass the port then
-        # httplib crazily doubles up the square brackets on the Host header.
-        # Instead, we need to make sure we never pass ``None`` as the port.
-        # However, for backward compatibility reasons we can't actually
-        # *assert* that.
-        self.host = host.strip('[]')
+        self.host = _ipv6_host(host)
         self.port = port
 
     def __str__(self):
@@ -437,6 +431,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # TODO: Add optional support for socket.gethostbyname checking.
         scheme, host, port = get_host(url)
+
+        host = _ipv6_host(host)
 
         # Use explicit default port for comparison when none is given
         if self.port and not port:
@@ -869,3 +865,22 @@ def connection_from_url(url, **kw):
         return HTTPSConnectionPool(host, port=port, **kw)
     else:
         return HTTPConnectionPool(host, port=port, **kw)
+
+
+def _ipv6_host(host):
+    """
+    Process IPv6 address literals
+    """
+
+    # httplib doesn't like it when we include brackets in IPv6 addresses
+    # Specifically, if we include brackets but also pass the port then
+    # httplib crazily doubles up the square brackets on the Host header.
+    # Instead, we need to make sure we never pass ``None`` as the port.
+    # However, for backward compatibility reasons we can't actually
+    # *assert* that.  See http://bugs.python.org/issue28539
+    #
+    # Also if an IPv6 address literal has a zone identifier, the
+    # percent sign might be URIencoded, convert it back into ASCII
+    if host.startswith('[') and host.endswith(']'):
+        host = host.replace('%25', '%').strip('[]')
+    return host

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -68,7 +68,7 @@ class ConnectionPool(object):
         if not host:
             raise LocationValueError("No host specified.")
 
-        self.host = _ipv6_host(host)
+        self.host = _ipv6_host(host).lower()
         self.port = port
 
     def __str__(self):
@@ -433,7 +433,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # TODO: Add optional support for socket.gethostbyname checking.
         scheme, host, port = get_host(url)
 
-        host = _ipv6_host(host)
+        host = _ipv6_host(host).lower()
 
         # Use explicit default port for comparison when none is given
         if self.port and not port:


### PR DESCRIPTION
In addition to stripping IPv6 address literals in connection pools, process IPv6 address literals which might have URI encoded zone identifiers specified in RFC-6874.

See also kennethreitz/requests#1985
