### PR TITLE
The ``connection_from_*`` methods now accept pool_kwargs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ dev (master)
 * Reduced memory consumption when streaming zlib-compressed responses
   (as opposed to raw deflate streams). (Pull #1129)
 
+* Connection pools now use the entire request context when constructing the
+  pool key. (Pull #1016)
+
+* ``PoolManager.connection_from_*`` methods now accept a new keyword argument,
+  ``pool_kwargs``, which are merged with the existing ``connection_pool_kw``.
+  (Pull #1016)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -1,14 +1,9 @@
-import functools
-from collections import namedtuple
 import sys
 
 from urllib3.poolmanager import (
-    _default_key_normalizer,
-    HTTPPoolKey,
-    HTTPSPoolKey,
+    PoolKey,
     key_fn_by_scheme,
     PoolManager,
-    SSL_KEYWORDS,
 )
 from urllib3 import connection_from_url
 from urllib3.exceptions import (
@@ -138,30 +133,9 @@ class TestPoolManager(unittest.TestCase):
         )
         self.assertTrue(
             all(
-                isinstance(key, HTTPPoolKey)
+                isinstance(key, PoolKey)
                 for key in p.pools.keys())
         )
-
-    def test_http_pool_key_extra_kwargs(self):
-        """Assert non-HTTPPoolKey fields are ignored when selecting a pool."""
-        p = PoolManager()
-        self.addCleanup(p.clear)
-        conn_pool = p.connection_from_url('http://example.com/')
-        p.connection_pool_kw['some_kwarg'] = 'that should be ignored'
-        other_conn_pool = p.connection_from_url('http://example.com/')
-
-        self.assertTrue(conn_pool is other_conn_pool)
-
-    def test_http_pool_key_https_kwargs(self):
-        """Assert HTTPSPoolKey fields are ignored when selecting a HTTP pool."""
-        p = PoolManager()
-        self.addCleanup(p.clear)
-        conn_pool = p.connection_from_url('http://example.com/')
-        for key in SSL_KEYWORDS:
-            p.connection_pool_kw[key] = 'this should be ignored'
-        other_conn_pool = p.connection_from_url('http://example.com/')
-
-        self.assertTrue(conn_pool is other_conn_pool)
 
     def test_https_pool_key_fields(self):
         """Assert the HTTPSPoolKey fields are honored when selecting a pool."""
@@ -204,19 +178,9 @@ class TestPoolManager(unittest.TestCase):
         self.assertTrue(all(pool in conn_pools for pool in dup_pools))
         self.assertTrue(
             all(
-                isinstance(key, HTTPSPoolKey)
+                isinstance(key, PoolKey)
                 for key in p.pools.keys())
         )
-
-    def test_https_pool_key_extra_kwargs(self):
-        """Assert non-HTTPSPoolKey fields are ignored when selecting a pool."""
-        p = PoolManager()
-        self.addCleanup(p.clear)
-        conn_pool = p.connection_from_url('https://example.com/')
-        p.connection_pool_kw['some_kwarg'] = 'that should be ignored'
-        other_conn_pool = p.connection_from_url('https://example.com/')
-
-        self.assertTrue(conn_pool is other_conn_pool)
 
     def test_default_pool_key_funcs_copy(self):
         """Assert each PoolManager gets a copy of ``pool_keys_by_scheme``."""
@@ -265,7 +229,7 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(1, len(p.pools))
         self.assertTrue(pool is other_pool)
-        self.assertTrue(all(isinstance(key, HTTPSPoolKey) for key in p.pools.keys()))
+        self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
     def test_https_connection_from_host_case_insensitive(self):
         """Assert scheme case is ignored when getting the https key class."""
@@ -276,7 +240,7 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(1, len(p.pools))
         self.assertTrue(pool is other_pool)
-        self.assertTrue(all(isinstance(key, HTTPSPoolKey) for key in p.pools.keys()))
+        self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
     def test_https_connection_from_context_case_insensitive(self):
         """Assert scheme case is ignored when getting the https key class."""
@@ -289,7 +253,7 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(1, len(p.pools))
         self.assertTrue(pool is other_pool)
-        self.assertTrue(all(isinstance(key, HTTPSPoolKey) for key in p.pools.keys()))
+        self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
     def test_http_connection_from_url_case_insensitive(self):
         """Assert scheme case is ignored when pooling HTTP connections."""
@@ -299,7 +263,7 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(1, len(p.pools))
         self.assertTrue(pool is other_pool)
-        self.assertTrue(all(isinstance(key, HTTPPoolKey) for key in p.pools.keys()))
+        self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
     def test_http_connection_from_host_case_insensitive(self):
         """Assert scheme case is ignored when getting the https key class."""
@@ -310,7 +274,7 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(1, len(p.pools))
         self.assertTrue(pool is other_pool)
-        self.assertTrue(all(isinstance(key, HTTPPoolKey) for key in p.pools.keys()))
+        self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
     def test_http_connection_from_context_case_insensitive(self):
         """Assert scheme case is ignored when getting the https key class."""
@@ -323,20 +287,84 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(1, len(p.pools))
         self.assertTrue(pool is other_pool)
-        self.assertTrue(all(isinstance(key, HTTPPoolKey) for key in p.pools.keys()))
+        self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
     def test_custom_pool_key(self):
-        """Assert it is possible to define addition pool key fields."""
-        custom_key = namedtuple('CustomKey', HTTPPoolKey._fields + ('my_field',))
-        p = PoolManager(10, my_field='barley')
+        """Assert it is possible to define a custom key function."""
+        p = PoolManager(10)
         self.addCleanup(p.clear)
 
-        p.key_fn_by_scheme['http'] = functools.partial(_default_key_normalizer, custom_key)
-        p.connection_from_url('http://example.com')
-        p.connection_pool_kw['my_field'] = 'wheat'
-        p.connection_from_url('http://example.com')
+        p.key_fn_by_scheme['http'] = lambda x: tuple(x['key'])
+        pool1 = p.connection_from_url(
+            'http://example.com', pool_kwargs={'key': 'value'})
+        pool2 = p.connection_from_url(
+            'http://example.com', pool_kwargs={'key': 'other'})
+        pool3 = p.connection_from_url(
+            'http://example.com', pool_kwargs={'key': 'value', 'x': 'y'})
 
         self.assertEqual(2, len(p.pools))
+        self.assertTrue(pool1 is pool3)
+        self.assertFalse(pool1 is pool2)
+
+    def test_override_pool_kwargs_url(self):
+        """Assert overriding pool kwargs works with connection_from_url."""
+        p = PoolManager(strict=True)
+        pool_kwargs = {'strict': False, 'retries': 100, 'block': True}
+
+        default_pool = p.connection_from_url('http://example.com/')
+        override_pool = p.connection_from_url(
+            'http://example.com/', pool_kwargs=pool_kwargs)
+
+        self.assertTrue(default_pool.strict)
+        self.assertEqual(retry.Retry.DEFAULT, default_pool.retries)
+        self.assertFalse(default_pool.block)
+
+        self.assertFalse(override_pool.strict)
+        self.assertEqual(100, override_pool.retries)
+        self.assertTrue(override_pool.block)
+
+    def test_override_pool_kwargs_host(self):
+        """Assert overriding pool kwargs works with connection_from_host"""
+        p = PoolManager(strict=True)
+        pool_kwargs = {'strict': False, 'retries': 100, 'block': True}
+
+        default_pool = p.connection_from_host('example.com', scheme='http')
+        override_pool = p.connection_from_host('example.com', scheme='http',
+                                               pool_kwargs=pool_kwargs)
+
+        self.assertTrue(default_pool.strict)
+        self.assertEqual(retry.Retry.DEFAULT, default_pool.retries)
+        self.assertFalse(default_pool.block)
+
+        self.assertFalse(override_pool.strict)
+        self.assertEqual(100, override_pool.retries)
+        self.assertTrue(override_pool.block)
+
+    def test_merge_pool_kwargs(self):
+        """Assert _merge_pool_kwargs works in the happy case"""
+        p = PoolManager(strict=True)
+        merged = p._merge_pool_kwargs({'new_key': 'value'})
+        self.assertEqual({'strict': True, 'new_key': 'value'}, merged)
+
+    def test_merge_pool_kwargs_none(self):
+        """Assert false-y values to _merge_pool_kwargs result in defaults"""
+        p = PoolManager(strict=True)
+        merged = p._merge_pool_kwargs({})
+        self.assertEqual(p.connection_pool_kw, merged)
+        merged = p._merge_pool_kwargs(None)
+        self.assertEqual(p.connection_pool_kw, merged)
+
+    def test_merge_pool_kwargs_remove_key(self):
+        """Assert keys can be removed with _merge_pool_kwargs"""
+        p = PoolManager(strict=True)
+        merged = p._merge_pool_kwargs({'strict': None})
+        self.assertTrue('strict' not in merged)
+
+    def test_merge_pool_kwargs_invalid_key(self):
+        """Assert removing invalid keys with _merge_pool_kwargs doesn't break"""
+        p = PoolManager(strict=True)
+        merged = p._merge_pool_kwargs({'invalid_key': None})
+        self.assertEqual(p.connection_pool_kw, merged)
 
 
 if __name__ == '__main__':

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -21,28 +21,40 @@ log = logging.getLogger(__name__)
 SSL_KEYWORDS = ('key_file', 'cert_file', 'cert_reqs', 'ca_certs',
                 'ssl_version', 'ca_cert_dir', 'ssl_context')
 
-# The base fields to use when determining what pool to get a connection from;
-# these do not rely on the ``connection_pool_kw`` and can be determined by the
-# URL and potentially the ``urllib3.connection.port_by_scheme`` dictionary.
-#
-# All custom key schemes should include the fields in this key at a minimum.
-BasePoolKey = collections.namedtuple('BasePoolKey', ('scheme', 'host', 'port'))
+# All known keyword arguments that could be provided to the pool manager, its
+# pools, or the underlying connections. This is used to construct a pool key.
+_key_fields = (
+    'key_scheme',  # str
+    'key_host',  # str
+    'key_port',  # int
+    'key_timeout',  # int or float or Timeout
+    'key_retries',  # int or Retry
+    'key_strict',  # bool
+    'key_block',  # bool
+    'key_source_address',  # str
+    'key_key_file',  # str
+    'key_cert_file',  # str
+    'key_cert_reqs',  # str
+    'key_ca_certs',  # str
+    'key_ssl_version',  # str
+    'key_ca_cert_dir',  # str
+    'key_ssl_context',  # instance of ssl.SSLContext or urllib3.util.ssl_.SSLContext
+    'key_maxsize',  # int
+    'key_headers',  # dict
+    'key__proxy',  # parsed proxy url
+    'key__proxy_headers',  # dict
+    'key_socket_options',  # list of (level (int), optname (int), value (int or str)) tuples
+    'key__socks_options',  # dict
+)
 
-# The fields to use when determining what pool to get a HTTP and HTTPS
-# connection from. All additional fields must be present in the PoolManager's
-# ``connection_pool_kw`` instance variable.
-HTTPPoolKey = collections.namedtuple(
-    'HTTPPoolKey', BasePoolKey._fields + ('timeout', 'retries', 'strict',
-                                          'block', 'source_address')
-)
-HTTPSPoolKey = collections.namedtuple(
-    'HTTPSPoolKey', HTTPPoolKey._fields + SSL_KEYWORDS
-)
+#: The namedtuple class used to construct keys for the connection pool.
+#: All custom key schemes should include the fields in this key at a minimum.
+PoolKey = collections.namedtuple('PoolKey', _key_fields)
 
 
 def _default_key_normalizer(key_class, request_context):
     """
-    Create a pool key of type ``key_class`` for a request.
+    Create a pool key out of a request context dictionary.
 
     According to RFC 3986, both the scheme and host are case-insensitive.
     Therefore, this function normalizes both before constructing the pool
@@ -52,26 +64,44 @@ def _default_key_normalizer(key_class, request_context):
     :param key_class:
         The class to use when constructing the key. This should be a namedtuple
         with the ``scheme`` and ``host`` keys at a minimum.
-
+    :type  key_class: namedtuple
     :param request_context:
         A dictionary-like object that contain the context for a request.
-        It should contain a key for each field in the :class:`HTTPPoolKey`
+    :type  request_context: dict
+
+    :return: A namedtuple that can be used as a connection pool key.
+    :rtype:  PoolKey
     """
-    context = {}
-    for key in key_class._fields:
-        context[key] = request_context.get(key)
+    # Since we mutate the dictionary, make a copy first
+    context = request_context.copy()
     context['scheme'] = context['scheme'].lower()
     context['host'] = context['host'].lower()
+
+    # These are both dictionaries and need to be transformed into frozensets
+    for key in ('headers', '_proxy_headers', '_socks_options'):
+        if key in context and context[key] is not None:
+            context[key] = frozenset(context[key].items())
+
+    # Map the kwargs to the names in the namedtuple - this is necessary since
+    # namedtuples can't have fields starting with '_'.
+    for key in list(context.keys()):
+        context['key_' + key] = context.pop(key)
+
+    # Default to ``None`` for keys missing from the context
+    for field in key_class._fields:
+        if field not in context:
+            context[field] = None
+
     return key_class(**context)
 
 
-# A dictionary that maps a scheme to a callable that creates a pool key.
-# This can be used to alter the way pool keys are constructed, if desired.
-# Each PoolManager makes a copy of this dictionary so they can be configured
-# globally here, or individually on the instance.
+#: A dictionary that maps a scheme to a callable that creates a pool key.
+#: This can be used to alter the way pool keys are constructed, if desired.
+#: Each PoolManager makes a copy of this dictionary so they can be configured
+#: globally here, or individually on the instance.
 key_fn_by_scheme = {
-    'http': functools.partial(_default_key_normalizer, HTTPPoolKey),
-    'https': functools.partial(_default_key_normalizer, HTTPSPoolKey),
+    'http': functools.partial(_default_key_normalizer, PoolKey),
+    'https': functools.partial(_default_key_normalizer, PoolKey),
 }
 
 pool_classes_by_scheme = {
@@ -129,22 +159,32 @@ class PoolManager(RequestMethods):
         # Return False to re-raise any potential exceptions
         return False
 
-    def _new_pool(self, scheme, host, port):
+    def _new_pool(self, scheme, host, port, request_context=None):
         """
-        Create a new :class:`ConnectionPool` based on host, port and scheme.
+        Create a new :class:`ConnectionPool` based on host, port, scheme, and
+        any additional pool keyword arguments.
 
-        This method is used to actually create the connection pools handed out
-        by :meth:`connection_from_url` and companion methods. It is intended
-        to be overridden for customization.
+        If ``request_context`` is provided, it is provided as keyword arguments
+        to the pool class used. This method is used to actually create the
+        connection pools handed out by :meth:`connection_from_url` and
+        companion methods. It is intended to be overridden for customization.
         """
         pool_cls = self.pool_classes_by_scheme[scheme]
-        kwargs = self.connection_pool_kw
-        if scheme == 'http':
-            kwargs = self.connection_pool_kw.copy()
-            for kw in SSL_KEYWORDS:
-                kwargs.pop(kw, None)
+        if request_context is None:
+            request_context = self.connection_pool_kw.copy()
 
-        return pool_cls(host, port, **kwargs)
+        # Although the context has everything necessary to create the pool,
+        # this function has historically only used the scheme, host, and port
+        # in the positional args. When an API change is acceptable these can
+        # be removed.
+        for key in ('scheme', 'host', 'port'):
+            request_context.pop(key, None)
+
+        if scheme == 'http':
+            for kw in SSL_KEYWORDS:
+                request_context.pop(kw, None)
+
+        return pool_cls(host, port, **request_context)
 
     def clear(self):
         """
@@ -155,18 +195,21 @@ class PoolManager(RequestMethods):
         """
         self.pools.clear()
 
-    def connection_from_host(self, host, port=None, scheme='http'):
+    def connection_from_host(self, host, port=None, scheme='http', pool_kwargs=None):
         """
         Get a :class:`ConnectionPool` based on the host, port, and scheme.
 
         If ``port`` isn't given, it will be derived from the ``scheme`` using
-        ``urllib3.connectionpool.port_by_scheme``.
+        ``urllib3.connectionpool.port_by_scheme``. If ``pool_kwargs`` is
+        provided, it is merged with the instance's ``connection_pool_kw``
+        variable and used to create the new connection pool, if one is
+        needed.
         """
 
         if not host:
             raise LocationValueError("No host specified.")
 
-        request_context = self.connection_pool_kw.copy()
+        request_context = self._merge_pool_kwargs(pool_kwargs)
         request_context['scheme'] = scheme or 'http'
         if not port:
             port = port_by_scheme.get(request_context['scheme'].lower(), 80)
@@ -186,9 +229,9 @@ class PoolManager(RequestMethods):
         pool_key_constructor = self.key_fn_by_scheme[scheme]
         pool_key = pool_key_constructor(request_context)
 
-        return self.connection_from_pool_key(pool_key)
+        return self.connection_from_pool_key(pool_key, request_context=request_context)
 
-    def connection_from_pool_key(self, pool_key):
+    def connection_from_pool_key(self, pool_key, request_context=None):
         """
         Get a :class:`ConnectionPool` based on the provided pool key.
 
@@ -204,22 +247,48 @@ class PoolManager(RequestMethods):
                 return pool
 
             # Make a fresh ConnectionPool of the desired type
-            pool = self._new_pool(pool_key.scheme, pool_key.host, pool_key.port)
+            scheme = request_context['scheme']
+            host = request_context['host']
+            port = request_context['port']
+            pool = self._new_pool(scheme, host, port, request_context=request_context)
             self.pools[pool_key] = pool
 
         return pool
 
-    def connection_from_url(self, url):
+    def connection_from_url(self, url, pool_kwargs=None):
         """
-        Similar to :func:`urllib3.connectionpool.connection_from_url` but
-        doesn't pass any additional parameters to the
-        :class:`urllib3.connectionpool.ConnectionPool` constructor.
+        Similar to :func:`urllib3.connectionpool.connection_from_url`.
 
-        Additional parameters are taken from the :class:`.PoolManager`
-        constructor.
+        If ``pool_kwargs`` is not provided and a new pool needs to be
+        constructed, ``self.connection_pool_kw`` is used to initialize
+        the :class:`urllib3.connectionpool.ConnectionPool`. If ``pool_kwargs``
+        is provided, it is used instead. Note that if a new pool does not
+        need to be created for the request, the provided ``pool_kwargs`` are
+        not used.
         """
         u = parse_url(url)
-        return self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
+        return self.connection_from_host(u.host, port=u.port, scheme=u.scheme,
+                                         pool_kwargs=pool_kwargs)
+
+    def _merge_pool_kwargs(self, override):
+        """
+        Merge a dictionary of override values for self.connection_pool_kw.
+
+        This does not modify self.connection_pool_kw and returns a new dict.
+        Any keys in the override dictionary with a value of ``None`` are
+        removed from the merged dictionary.
+        """
+        base_pool_kwargs = self.connection_pool_kw.copy()
+        if override:
+            for key, value in override.items():
+                if value is None:
+                    try:
+                        del base_pool_kwargs[key]
+                    except KeyError:
+                        pass
+                else:
+                    base_pool_kwargs[key] = value
+        return base_pool_kwargs
 
     def urlopen(self, method, url, redirect=True, **kw):
         """
@@ -322,13 +391,13 @@ class ProxyManager(PoolManager):
         super(ProxyManager, self).__init__(
             num_pools, headers, **connection_pool_kw)
 
-    def connection_from_host(self, host, port=None, scheme='http'):
+    def connection_from_host(self, host, port=None, scheme='http', pool_kwargs=None):
         if scheme == "https":
             return super(ProxyManager, self).connection_from_host(
-                host, port, scheme)
+                host, port, scheme, pool_kwargs=pool_kwargs)
 
         return super(ProxyManager, self).connection_from_host(
-            self.proxy.host, self.proxy.port, self.proxy.scheme)
+            self.proxy.host, self.proxy.port, self.proxy.scheme, pool_kwargs=pool_kwargs)
 
     def _set_proxy_headers(self, url, headers=None):
         """


### PR DESCRIPTION
This adds the ability to override the connection pool keyword arguments
used when constructing new pools in the `connection_from_*` methods. A
new keyword argument, `pool_kwargs`, is accepted by methods in
`PoolManager`. This is nice because without it, users that want to
change these arguments (when, say, adjusting SSL configurations) need to
make sure they update the keyword arguments and get a new pool in a
thread-safe manner.

This is a somewhat more invasive version of the patch on https://github.com/kennethreitz/requests/issues/3633 since people (reasonably) were surprised to see the instance's `connection_pool_kw` modified. I'm still not completely pleased with this change for a few reasons:
- If I provide some override `pool_kwargs` and a new pool doesn't need to be created (the `pool_kwargs` aren't fields in the pool key), they will be ignored. That seems like it will surprise users.
- A huge number of methods grew a new kwarg that gets passed down the chain of function calls, which is a little sad.
