### PR TITLE
Fix empty filenames in multipart headers

### DIFF
--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -36,6 +36,15 @@ class TestRequestField(unittest.TestCase):
             'Content-Location: /test\r\n'
             '\r\n')
 
+    def test_make_multipart_empty_filename(self):
+        field = RequestField('somename', 'data', '')
+        field.make_multipart(content_type='application/octet-stream')
+        self.assertEqual(
+            field.render_headers(),
+            'Content-Disposition: form-data; name="somename"; filename=""\r\n'
+            'Content-Type: application/octet-stream\r\n'
+            '\r\n')
+
     def test_render_parts(self):
         field = RequestField('somename', 'data')
         parts = field._render_parts({'name': 'value', 'filename': 'value'})

--- a/urllib3/fields.py
+++ b/urllib3/fields.py
@@ -130,7 +130,7 @@ class RequestField(object):
             iterable = header_parts.items()
 
         for name, value in iterable:
-            if value:
+            if value is not None:
                 parts.append(self._render_part(name, value))
 
         return '; '.join(parts)


### PR DESCRIPTION
Fixes #1015.

I'm not too familiar with using Tox for testing, and I got one error when running the test suite, but it was in some unrelated code (SSL) so I'll just submit this for review for the time being.