### PR TITLE
Cause a Travis failure if there are warnings in the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=gae
+    - TOXENV=docs
 # https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
   include:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = '-W'
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ basepython = python2.7
 deps=
     -r{toxinidir}/docs/requirements.txt
 commands=
-    rm -r {toxinidir}/docs/_build
+    rm -rf {toxinidir}/docs/_build
     make -C {toxinidir}/docs html
 whitelist_externals=
     make


### PR DESCRIPTION
I’ve tried to set up a docs job on Travis that will fail if there are problems in the docs build.

There weren’t any errors already (hooray!) so I’ve introduced a deliberate consistency bug. Hopefully the build will fail!