### PR TITLE
Correct the import of urljoin for Python 3

### DIFF
--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -42,7 +42,7 @@ from __future__ import absolute_import
 import logging
 import os
 import warnings
-from urlparse import urljoin
+from ..packages.six.moves.urllib.parse import urljoin
 
 from ..exceptions import (
     HTTPError,


### PR DESCRIPTION
At least in Python 3.5.2, this caused cascading breakage down to requests-toolbelt,
used by vdirsyncer. On Py3, urljoin is at urllib.parse.