### PR TITLE
Update RECENT_DATE to 2016

### DIFF
--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -52,6 +52,8 @@ class TestConnection(unittest.TestCase):
     def test_recent_date(self):
         # This test is to make sure that the RECENT_DATE value
         # doesn't get too far behind what the current date is.
+        # When this test fails update urllib3.connection.RECENT_DATE
+        # according to the rules defined in that file.
         two_years = datetime.timedelta(days=365 * 2)
         self.assertGreater(RECENT_DATE, (datetime.datetime.today() - two_years).date())
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,6 +1,6 @@
 import datetime
 import sys
-if sys.version_info > (2, 6):
+if sys.version_info >= (2, 7):
     import unittest
 else:
     import unittest2 as unittest
@@ -53,7 +53,7 @@ class TestConnection(unittest.TestCase):
         # This test is to make sure that the RECENT_DATE value
         # doesn't get too far behind what the current date is.
         two_years = datetime.timedelta(days=365 * 2)
-        self.assertTrue(RECENT_DATE > (datetime.datetime.today() - two_years).date())
+        self.assertGreater(RECENT_DATE, (datetime.datetime.today() - two_years).date())
 
 
 if __name__ == '__main__':

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 
 import mock
@@ -6,6 +7,7 @@ from urllib3.connection import (
     CertificateError,
     VerifiedHTTPSConnection,
     _match_hostname,
+    RECENT_DATE
 )
 
 
@@ -42,6 +44,12 @@ class TestConnection(unittest.TestCase):
                 'bar', {'subjectAltName': [('DNS', 'foo')]}
             )
             self.assertEqual(e._peer_cert, cert)
+
+    def test_recent_date(self):
+        # This test is to make sure that the RECENT_DATE value
+        # doesn't get too far behind what the current date is.
+        three_years = datetime.timedelta(days=365 * 3)
+        self.assertGreater(RECENT_DATE, (datetime.datetime.today() - three_years).date())
 
 
 if __name__ == '__main__':

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -48,8 +48,8 @@ class TestConnection(unittest.TestCase):
     def test_recent_date(self):
         # This test is to make sure that the RECENT_DATE value
         # doesn't get too far behind what the current date is.
-        three_years = datetime.timedelta(days=365 * 3)
-        self.assertGreater(RECENT_DATE, (datetime.datetime.today() - three_years).date())
+        two_years = datetime.timedelta(days=365 * 2)
+        self.assertGreater(RECENT_DATE, (datetime.datetime.today() - two_years).date())
 
 
 if __name__ == '__main__':

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -53,7 +53,7 @@ class TestConnection(unittest.TestCase):
         # This test is to make sure that the RECENT_DATE value
         # doesn't get too far behind what the current date is.
         two_years = datetime.timedelta(days=365 * 2)
-        self.assertGreater(RECENT_DATE, (datetime.datetime.today() - two_years).date())
+        self.assertTrue(RECENT_DATE > (datetime.datetime.today() - two_years).date())
 
 
 if __name__ == '__main__':

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,5 +1,9 @@
 import datetime
-import unittest
+import sys
+if sys.version_info > (2, 6):
+    import unittest
+else:
+    import unittest2 as unittest
 
 import mock
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -56,11 +56,9 @@ port_by_scheme = {
     'https': 443,
 }
 
-# When updating RECENT_DATE be sure to not
-# update the value to be later than two years
-# in the past and no earlier than 6 months
-# in the past to stay consistent with the
-# history of this value.
+# When updating RECENT_DATE, move it to
+# within two years of the current date, and no
+# earlier than 6 months ago.
 RECENT_DATE = datetime.date(2016, 1, 1)
 
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -56,6 +56,11 @@ port_by_scheme = {
     'https': 443,
 }
 
+# When updating RECENT_DATE be sure to not
+# update the value to be later than two years
+# in the past and no earlier than 6 months
+# in the past to stay consistent with the
+# history of this value.
 RECENT_DATE = datetime.date(2016, 1, 1)
 
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -56,7 +56,7 @@ port_by_scheme = {
     'https': 443,
 }
 
-RECENT_DATE = datetime.date(2014, 1, 1)
+RECENT_DATE = datetime.date(2016, 1, 1)
 
 
 class DummyConnection(object):


### PR DESCRIPTION
This PR resolves #1005 by adding a unit test to allow `RECENT_DATE` to have a maximum of two years of difference between the current date and it's last value.  I also updated `RECENT_DATE` to January 1st, 2016 to refresh the value to a more recent date.

My rationale for these changes are:
- When `RECENT_DATE` was added it was August in 2014 so I figured jumping to 2016 made sense.
- Because this change is coming more than two years after the original `RECENT_DATE` check was added, it should be safe to assume this will not break anyone who's system times fit the original set of rules which would require not more than two-three years difference in system clock time.

The unit test will also make it harder to forget that this value should be updated, hopefully more often than once every two years but I think this is a good compromise, I'm open to suggestions if this should be more/less frequent.