### PR TITLE
Fix broken link for AppEngine warning

### DIFF
--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -111,7 +111,7 @@ class AppEngineManager(RequestMethods):
         warnings.warn(
             "urllib3 is using URLFetch on Google App Engine sandbox instead "
             "of sockets. To use sockets directly instead of URLFetch see "
-            "http://urllib3.readthedocs.io/en/latest/reference/urllib3.contrib.html.",
+            "https://urllib3.readthedocs.io/en/latest/reference/urllib3.contrib.html.",
             AppEnginePlatformWarning)
 
         RequestMethods.__init__(self, headers)

--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -111,7 +111,7 @@ class AppEngineManager(RequestMethods):
         warnings.warn(
             "urllib3 is using URLFetch on Google App Engine sandbox instead "
             "of sockets. To use sockets directly instead of URLFetch see "
-            "https://urllib3.readthedocs.io/en/latest/contrib.html.",
+            "http://urllib3.readthedocs.io/en/latest/reference/urllib3.contrib.html.",
             AppEnginePlatformWarning)
 
         RequestMethods.__init__(self, headers)


### PR DESCRIPTION
Fixes the broken link in the AppEngine warning (Issue #1027)