### PR TITLE
Streaming File Uploads

### DIFF
--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -32,7 +32,7 @@ class TestMultipartEncoderGenerator(unittest.TestCase):
         data = b'x' * MEGABYTE  # 1 MB of data
         start_memory = psutil.Process().memory_info().rss
 
-        encoded, _ = encode_multipart_formdata([(b'k', data)], boundary=BOUNDARY)
+        encoded, _ = encode_multipart_formdata([('k', data)], boundary=BOUNDARY)
         end_memory = psutil.Process().memory_info().rss
         self.assertTrue(end_memory <= start_memory + MEGABYTE)
 

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -1,4 +1,5 @@
 import unittest
+import psutil
 
 from urllib3.filepost import (
     encode_multipart_formdata,
@@ -25,6 +26,15 @@ class TestMultipartEncoderGenerator(unittest.TestCase):
             encoded, _ = encode_multipart_formdata(fields, boundary=BOUNDARY)
             encoded = b''.join(encoded)
             self.assertEqual(len(encoded), len(MultipartEncoderGenerator(fields, boundary=BOUNDARY)))
+
+    def test_memory_usage(self):
+        MEGABYTE = 1024 * 1024
+        data = b'x' * MEGABYTE  # 1 MB of data
+        start_memory = psutil.Process().memory_info().rss
+
+        encoded, _ = encode_multipart_formdata([(b'k', data)], boundary=BOUNDARY)
+        end_memory = psutil.Process().memory_info().rss
+        self.assertTrue(end_memory <= start_memory + MEGABYTE)
 
 
 class TestIterfields(unittest.TestCase):

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -15,16 +15,15 @@ BOUNDARY = '!! test boundary !!'
 class TestMultipartEncoderGenerator(unittest.TestCase):
     def test_len(self):
         fieldsets = [
-            #[('k', 'v'), ('k2', 'v2')],
-            #[('k', b'v'), (u('k2'), b'v2')],
-            #[('k', b'v'), (u('k2'), 'v2')],
+            [('k', 'v'), ('k2', 'v2')],
+            [('k', b'v'), (u('k2'), b'v2')],
+            [('k', b'v'), (u('k2'), 'v2')],
             [('foo', b'a'), ('foo', b'b')],
         ]
 
         for fields in fieldsets:
             encoded, _ = encode_multipart_formdata(fields, boundary=BOUNDARY)
             encoded = b''.join(encoded)
-
             self.assertEqual(len(encoded), len(MultipartEncoderGenerator(fields, boundary=BOUNDARY)))
 
 

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -55,7 +55,7 @@ class TestMultipartEncoding(unittest.TestCase):
 
         for fields in fieldsets:
             encoded, _ = encode_multipart_formdata(fields, boundary=BOUNDARY)
-            encoded = encoded.read(4096)
+            encoded = b''.join(encoded)
             self.assertEqual(encoded.count(b(BOUNDARY)), 3)
 
     def test_field_encoding(self):

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -1,6 +1,11 @@
-import unittest
 import psutil
 import io
+import sys
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
 
 from urllib3.filepost import (
     encode_multipart_formdata,

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -15,9 +15,10 @@ BOUNDARY = '!! test boundary !!'
 class TestMultipartEncoderGenerator(unittest.TestCase):
     def test_len(self):
         fieldsets = [
-            [('k', 'v'), ('k2', 'v2')],
-            [('k', b'v'), (u('k2'), b'v2')],
-            [('k', b'v'), (u('k2'), 'v2')],
+            #[('k', 'v'), ('k2', 'v2')],
+            #[('k', b'v'), (u('k2'), b'v2')],
+            #[('k', b'v'), (u('k2'), 'v2')],
+            [('foo', b'a'), ('foo', b'b')],
         ]
 
         for fields in fieldsets:

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -466,8 +466,9 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                                     encode_multipart=True)
         body = r.data.split(b'\r\n')
 
-        encoded_data = encode_multipart_formdata(data)[0]
-        expected_body = encoded_data.split(b'\r\n')
+        encoded = encode_multipart_formdata(data)[0]
+        encoded = b''.join(encoded)
+        expected_body = encoded.split(b'\r\n')
 
         # TODO: Get rid of extra parsing stuff when you can specify
         # a custom boundary to encode_multipart_formdata
@@ -548,10 +549,10 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         boundary = 'foo'
 
         req_data = {'count': 'a' * payload_size}
-        resp_data = encode_multipart_formdata(req_data, boundary=boundary)[0]
+        resp_data = b''.join(encode_multipart_formdata(req_data, boundary=boundary)[0])
 
         req2_data = {'count': 'b' * payload_size}
-        resp2_data = encode_multipart_formdata(req2_data, boundary=boundary)[0]
+        resp2_data = b''.join(encode_multipart_formdata(req2_data, boundary=boundary)[0])
 
         r1 = pool.request('POST', '/echo', fields=req_data, multipart_boundary=boundary, preload_content=False)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -256,6 +256,8 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
         # multipart
         r = self.pool.request('POST', '/echo', fields=fields)
+        print(type(r))
+        print(r.data)
         self.assertEqual(r.data.count(b'name="foo"'), 2)
 
     def test_request_method_body(self):

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -256,8 +256,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
         # multipart
         r = self.pool.request('POST', '/echo', fields=fields)
-        print(type(r))
-        print(r.data)
         self.assertEqual(r.data.count(b'name="foo"'), 2)
 
     def test_request_method_body(self):

--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -58,6 +58,7 @@ from ..request import RequestMethods
 from ..response import HTTPResponse
 from ..util.timeout import Timeout
 from ..util.retry import Retry
+from ..filepost import IterStreamer
 
 try:
     from google.appengine.api import urlfetch
@@ -132,6 +133,11 @@ class AppEngineManager(RequestMethods):
                 **response_kw):
 
         retries = self._get_retries(retries, redirect)
+
+        # Because Google AppEngine only takes 10MB requests
+        # having a streaming upload makes less of an impact.
+        if isinstance(body, IterStreamer):
+            body = b''.join(body)
 
         try:
             follow_redirects = (

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -19,17 +19,6 @@ def choose_boundary():
     return uuid4().hex
 
 
-def integer_display_length(integer):
-    """
-    Gets the length of an integer if it were a string.
-    :param integer: Integer to get the length for.
-    :return: Number of characters required to display the integer.
-    """
-    if not integer:
-        return 1
-    return int(math.log10(abs(integer))) + (1 if integer > 0 else 2)
-
-
 def iter_field_objects(fields):
     """
     Iterate over fields.
@@ -72,11 +61,11 @@ def get_content_type(filename):
     return mimetypes.guess_type(filename)[0] or 'application/octet-stream'
 
 
-def encode(str):
-    if isinstance(str, six.text_type):
-        return str.encode('utf-8')
+def encode(string):
+    if isinstance(string, six.text_type):
+        return string.encode('utf-8')
     else:
-        return str
+        return string
 
 
 def file_size(fp):
@@ -168,7 +157,7 @@ class MultipartEncoderGenerator(object):
             if hasattr(data, '__len__'):
                 size += len(data)
             elif isinstance(data, six.integer_types):
-                size += integer_display_length(data)
+                size += len(str(data))
             elif hasattr(data, 'seek'):
                 size += file_size(data)
             elif hasattr(data, 'read'):

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -59,8 +59,10 @@ def get_content_type(filename):
 
 
 def encode(string):
-    if isinstance(string, (str, six.text_type)):
+    if isinstance(string, six.text_type):
         return string.encode('utf-8')
+    elif isinstance(string, str):
+        return string
     else:
         return string
 

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -165,7 +165,10 @@ class MultipartEncoderGenerator(object):
             else:
                 size += len(encode(u(data)))  # Hope for the best
 
-        return size + sum(encode(len(chunk)) for chunk in iter(MultipartEncoderGenerator(empty_fields, boundary=self.boundary)))
+        empty_multipart = MultipartEncoderGenerator(empty_fields, boundary=self.boundary)
+        empty_size = sum(encode(len(chunk)) for chunk in empty_multipart)
+
+        return size + empty_size
 
     def __iter__(self):
         for field in self.fields:
@@ -173,7 +176,10 @@ class MultipartEncoderGenerator(object):
             yield encode(u('--%s\r\n' % (self.boundary)))
             yield encode(field.render_headers())
 
-            if isinstance(data, (str, six.text_type)):
+            if isinstance(data, bytes):
+                yield data
+
+            elif isinstance(data, (str, six.text_type)):
                 yield encode(data)
 
             elif isinstance(data, six.integer_types):

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -1,12 +1,19 @@
 from __future__ import absolute_import
 import codecs
+import mimetypes
 
+import math
 from uuid import uuid4
 from io import BytesIO
 
 from .packages import six
-from .packages.six import b
+from .packages.six import b, u
 from .fields import RequestField
+
+try:
+    from cStringIO import StringIO
+except:
+    from StringIO import StringIO
 
 writer = codecs.lookup('utf-8')[3]
 
@@ -16,6 +23,17 @@ def choose_boundary():
     Our embarrassingly-simple replacement for mimetools.choose_boundary.
     """
     return uuid4().hex
+
+
+def integer_display_length(integer):
+    """
+    Gets the length of an integer if it were a string.
+    :param integer: Integer to get the length for.
+    :return: Number of characters required to display the integer.
+    """
+    if not integer:
+        return 1
+    return int(math.log10(abs(integer))) + (1 if integer > 0 else 2)
 
 
 def iter_field_objects(fields):
@@ -56,39 +74,170 @@ def iter_fields(fields):
     return ((k, v) for k, v in fields)
 
 
-def encode_multipart_formdata(fields, boundary=None):
+def get_content_type(filename):
+    return mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
+
+def encode(str):
+    if isinstance(str, six.text_type):
+        return str.encode('utf-8')
+    else:
+        return str
+
+
+def file_size(fp):
+    pos = fp.tell()
+    fp.seek(0, 2)
+    size = fp.tell()
+    fp.seek(pos)
+    return size-pos
+
+
+class IterStreamer(object):
     """
-    Encode a dictionary of ``fields`` using the multipart/form-data MIME format.
-
-    :param fields:
-        Dictionary of fields or list of (key, :class:`~urllib3.fields.RequestField`).
-
-    :param boundary:
-        If not specified, then a random boundary will be generated using
-        :func:`mimetools.choose_boundary`.
+    File-like streaming iterator.
     """
-    body = BytesIO()
-    if boundary is None:
-        boundary = choose_boundary()
+    def __init__(self, generator):
+        self.generator = generator
+        self.iterator = iter(generator)
+        self.leftover = b''
 
-    for field in iter_field_objects(fields):
-        body.write(b('--%s\r\n' % (boundary)))
+    def __len__(self):
+        return self.generator.__len__()
 
-        writer(body).write(field.render_headers())
-        data = field.data
+    def __iter__(self):
+        return self.iterator
 
-        if isinstance(data, int):
-            data = str(data)  # Backwards compatibility
+    def next(self):
+        next = self.iterator.next()
+        return next
 
-        if isinstance(data, six.text_type):
-            writer(body).write(data)
-        else:
-            body.write(data)
+    def read(self, size=None):
+        data = self.leftover
+        count = len(self.leftover)
+        try:
+            while count < size:
+                chunk = self.next()
+                data += chunk
+                count += len(chunk)
+        except StopIteration:
+            pass
 
-        body.write(b'\r\n')
+        if count > size:
+            self.leftover = data[size:]
 
-    body.write(b('--%s--\r\n' % (boundary)))
+        return data[:size]
 
-    content_type = str('multipart/form-data; boundary=%s' % boundary)
 
-    return body.getvalue(), content_type
+class MultipartEncoderGenerator(object):
+    """
+    Generator yielding chunk-by-chunk streaming data from fields, with proper
+    headers and boundary separators along the way. This is useful for streaming
+    large files as iterators without loading the entire data body into memory.
+
+    ``fields`` is a dictionary where the parameter name is the key and the value
+    is either a (filename, data) tuple or just data.
+
+    The data can be a unicode string, an iterator producing strings, or a file-like
+    object. File-like objects are read ``chunk_size`` bytes at a time.
+
+    If no ``boundary`` is specified then a random one is used.
+    """
+    def __init__(self, fields, boundary=None, chunk_size=8192):
+        self.fields = [field for field in iter_field_objects(fields)]
+        self.chunk_size = chunk_size
+        self.boundary = boundary or choose_boundary()
+
+    def get_content_type(self):
+        return 'multipart/form-data; boundary=%s' % self.boundary
+
+    def __len__(self):
+        """
+        Figure out the expected body size by iterating over the fields as if they
+        contained empty files, while accumulating the value file sizes as
+        efficiently as we can.
+        """
+        empty_fields = {}
+        size = 0
+        for field in self.fields:
+            name = field._name
+            data = field.data
+            filename = field._filename
+
+            if filename is not None:
+                empty_fields[name] = (filename, '')
+            else:
+                empty_fields[name] = ''
+
+            if hasattr(data, '__len__'):
+                size += len(data)
+            elif isinstance(data, six.integer_types):
+                size += integer_display_length(data)
+            elif hasattr(data, 'seek'):
+                size += file_size(data)
+            elif hasattr(data, 'read'):
+                size += len(data.read())  # This is undesired
+            elif hasattr(data, '__iter__'):
+                size += sum(len(chunk) for chunk in data)  # This is also undesired
+            else:
+                size += len(u(data))  # Hope for the best
+
+        return size + sum(len(chunk) for chunk in iter(MultipartEncoderGenerator(empty_fields, boundary=self.boundary)))
+
+    def __iter__(self):
+        for field in self.fields:
+            data = field.data
+            yield encode(u('--%s\r\n' % (self.boundary)))
+            yield encode(field.render_headers())
+
+            if isinstance(data, (str, six.text_type)):
+                yield encode(data)
+
+            elif isinstance(data, six.integer_types):
+                # Handle integers for backwards compatibility
+                yield encode(str(data))
+
+            elif hasattr(data, 'read'):
+                # Stream from a file-like object
+                while True:
+                    chunk = data.read(self.chunk_size)
+                    if not chunk:
+                        break
+                    yield encode(chunk)
+
+            elif hasattr(data, '__iter__'):
+                # Stream from an iterator
+                for chunk in data:
+                    yield encode(chunk)
+
+            else:
+                # Hope for the best
+                yield encode(u(data))
+
+            yield encode(u('\r\n'))
+
+        yield encode(u('--%s--\r\n' % (self.boundary)))
+
+
+def encode_multipart_formdata(fields, boundary=None, chunk_size=8192):
+    """
+    ``fields`` is a dictionary where the parameter name is the key and the value
+    is either a (filename, data) tuple or just data. Data can be a string, file-like
+    object, or iterator.
+
+    Example:
+        fields = {
+            'foo': 'bar',
+            'upload_file': ('file.txt', 'data'),
+            'huge_huge': ('video.mpg', fp),
+            'hihihi_42_times': ('hi' for i in xrange(42)),
+        }
+
+    File-like objects are read ``chunk_size`` bytes at a time.
+
+    If no ``boundary`` is given, a random one is chosen.
+
+    See MultipartEncoderGenerator for more details.
+    """
+    stream = MultipartEncoderGenerator(fields, boundary=boundary, chunk_size=chunk_size)
+    return IterStreamer(stream), stream.get_content_type()

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -140,7 +140,7 @@ class MultipartEncoderGenerator(object):
         contained empty files, while accumulating the value file sizes as
         efficiently as we can.
         """
-        empty_fields = {}
+        empty_fields = []
         size = 0
         for field in self.fields:
             name = field._name
@@ -148,24 +148,24 @@ class MultipartEncoderGenerator(object):
             filename = field._filename
 
             if filename is not None:
-                empty_fields[name] = (filename, '')
+                empty_fields.append((name, (filename, '')))
             else:
-                empty_fields[name] = ''
+                empty_fields.append((name, ''))
 
             if hasattr(data, '__len__'):
-                size += len(data)
+                size += len(encode(data))
             elif isinstance(data, six.integer_types):
                 size += len(str(data))
             elif hasattr(data, 'seek'):
                 size += file_size(data)
             elif hasattr(data, 'read'):
-                size += len(data.read())  # This is undesired
+                size += len(encode(data.read()))  # This is undesired
             elif hasattr(data, '__iter__'):
-                size += sum(len(chunk) for chunk in data)  # This is also undesired
+                size += sum(len(encode(chunk)) for chunk in data)  # This is also undesired
             else:
-                size += len(u(data))  # Hope for the best
+                size += len(encode(u(data)))  # Hope for the best
 
-        return size + sum(len(chunk) for chunk in iter(MultipartEncoderGenerator(empty_fields, boundary=self.boundary)))
+        return size + sum(encode(len(chunk)) for chunk in iter(MultipartEncoderGenerator(empty_fields, boundary=self.boundary)))
 
     def __iter__(self):
         for field in self.fields:

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -214,7 +214,7 @@ def encode_multipart_formdata(fields, boundary=None, chunk_size=8192):
 
     :param fields:
         Dictionary of fields or list of (key, :class:`~urllib3.fields.RequestField`).
-    
+
     :param boundary:
         If not specified, then a random boundary will be generated using
         :func:`mimetools.choose_boundary`.

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -61,8 +61,6 @@ def get_content_type(filename):
 def encode(string):
     if isinstance(string, six.text_type):
         return string.encode('utf-8')
-    elif isinstance(string, str):
-        return string
     else:
         return string
 

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -210,23 +210,12 @@ class MultipartEncoderGenerator(object):
 
 def encode_multipart_formdata(fields, boundary=None, chunk_size=8192):
     """
-    ``fields`` is a dictionary where the parameter name is the key and the value
-    is either a (filename, data) tuple or just data. Data can be a string, file-like
-    object, or iterator.
-
-    Example:
-        fields = {
-            'foo': 'bar',
-            'upload_file': ('file.txt', 'data'),
-            'huge_huge': ('video.mpg', fp),
-            'hihihi_42_times': ('hi' for i in xrange(42)),
-        }
-
-    File-like objects are read ``chunk_size`` bytes at a time.
-
-    If no ``boundary`` is given, a random one is chosen.
-
-    See MultipartEncoderGenerator for more details.
+    Encode a dictionary of ``fields`` using the multipart/form-data MIME format.
+    :param fields:
+        Dictionary of fields or list of (key, :class:`~urllib3.fields.RequestField`).
+    :param boundary:
+        If not specified, then a random boundary will be generated using
+        :func:`mimetools.choose_boundary`.
     """
     stream = MultipartEncoderGenerator(fields, boundary=boundary, chunk_size=chunk_size)
     return IterStreamer(stream), stream.get_content_type()

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -54,10 +54,6 @@ def iter_fields(fields):
     return ((k, v) for k, v in fields)
 
 
-def get_content_type(filename):
-    return mimetypes.guess_type(filename)[0] or 'application/octet-stream'
-
-
 def encode(string):
     if isinstance(string, six.text_type):
         return string.encode('utf-8')

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 import codecs
 import mimetypes
-
-import math
 from uuid import uuid4
 
 from .packages import six

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -211,8 +211,10 @@ class MultipartEncoderGenerator(object):
 def encode_multipart_formdata(fields, boundary=None, chunk_size=8192):
     """
     Encode a dictionary of ``fields`` using the multipart/form-data MIME format.
+
     :param fields:
         Dictionary of fields or list of (key, :class:`~urllib3.fields.RequestField`).
+    
     :param boundary:
         If not specified, then a random boundary will be generated using
         :func:`mimetools.choose_boundary`.

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -103,8 +103,10 @@ class IterStreamer(object):
         return self.iterator
 
     def next(self):
-        next = self.iterator.next()
-        return next
+        return six.next(self.iterator)
+
+    def __next__(self):
+        return self.next()
 
     def read(self, size=None):
         data = self.leftover

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import codecs
-import mimetypes
 from uuid import uuid4
 
 from .packages import six

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -4,7 +4,6 @@ import mimetypes
 from uuid import uuid4
 
 from .packages import six
-from .packages.six import u
 from .fields import RequestField
 
 writer = codecs.lookup('utf-8')[3]
@@ -60,7 +59,7 @@ def get_content_type(filename):
 
 
 def encode(string):
-    if isinstance(string, six.text_type):
+    if isinstance(string, (str, six.text_type)):
         return string.encode('utf-8')
     else:
         return string
@@ -163,7 +162,7 @@ class MultipartEncoderGenerator(object):
             elif hasattr(data, '__iter__'):
                 size += sum(len(encode(chunk)) for chunk in data)  # This is also undesired
             else:
-                size += len(encode(u(data)))  # Hope for the best
+                size += len(encode(data))  # Hope for the best
 
         empty_multipart = MultipartEncoderGenerator(empty_fields, boundary=self.boundary)
         empty_size = sum(encode(len(chunk)) for chunk in empty_multipart)
@@ -173,7 +172,7 @@ class MultipartEncoderGenerator(object):
     def __iter__(self):
         for field in self.fields:
             data = field.data
-            yield encode(u('--%s\r\n' % (self.boundary)))
+            yield encode('--%s\r\n' % (self.boundary))
             yield encode(field.render_headers())
 
             if isinstance(data, bytes):
@@ -201,11 +200,11 @@ class MultipartEncoderGenerator(object):
 
             else:
                 # Hope for the best
-                yield encode(u(data))
+                yield encode(data)
 
-            yield encode(u('\r\n'))
+            yield encode('\r\n')
 
-        yield encode(u('--%s--\r\n' % (self.boundary)))
+        yield encode('--%s--\r\n' % (self.boundary))
 
 
 def encode_multipart_formdata(fields, boundary=None, chunk_size=8192):

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -4,16 +4,10 @@ import mimetypes
 
 import math
 from uuid import uuid4
-from io import BytesIO
 
 from .packages import six
-from .packages.six import b, u
+from .packages.six import u
 from .fields import RequestField
-
-try:
-    from cStringIO import StringIO
-except:
-    from StringIO import StringIO
 
 writer = codecs.lookup('utf-8')[3]
 


### PR DESCRIPTION
Took the work that was done a long time ago on the branch `filepost-stream` and brought it up to speed with the current API for filepost and fields modules, made it Python 2 and 3 compatible, added a test for memory usage and converted the current tests to use the new filepost iterator.

More tests to exercise each possible type of file-like or streamable object that can be passed into filepost will be created after this type of structure is approved and still wanted in urllib3.

I don't know if this behavior is still desired within urllib3 or as @sigmavirus24 has mentioned using code from requests-toolbelt.

Relevant issues: #51 #624

(CI failed because of random read timeout on Mac OS + Python 3.3)