### PR TITLE
ConnectionPool apply lowercasing to host

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -275,6 +275,11 @@ class TestConnectionPool(unittest.TestCase):
         self.assertRaises(ClosedPoolError, pool._get_conn)
         self.assertRaises(Empty, old_pool_queue.get, block=False)
 
+    def test_mixed_case_url(self):
+        pool = HTTPConnectionPool('Example.com')
+        response = pool.request('GET', "http://Example.com")
+        self.assertEqual(response.status, 200)
+
     def test_absolute_url(self):
         c = connection_from_url('http://google.com:80')
         self.assertEqual(

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -73,7 +73,7 @@ class ConnectionPool(object):
         # Instead, we need to make sure we never pass ``None`` as the port.
         # However, for backward compatibility reasons we can't actually
         # *assert* that.
-        self.host = host.strip('[]')
+        self.host = host.strip('[]').lower()
         self.port = port
 
     def __str__(self):


### PR DESCRIPTION
Fixes #1032 by applying `lower()` to all hosts that are given to the `ConnectionPool`.