### PR TITLE
Differentiate socks5h from socks5 and socks4a from socks4

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -215,5 +215,8 @@ In chronological order:
 * Seth Michael Larson <sethmichaellarson@protonmail.com>
   * Created selectors backport that supports PEP 475.
 
+* Tom White <s6yg1ez3@mail2tor.com>
+  * Made SOCKS handler differentiate socks5h from socks5 and socks4a from socks4.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -1,4 +1,4 @@
-import unittest
+import sys
 import socket
 import threading
 from nose.plugins.skip import SkipTest
@@ -12,6 +12,11 @@ from dummyserver.server import (
 )
 from dummyserver.handlers import TestingApp
 from dummyserver.proxy import ProxyHandler
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
 
 
 def consume_socket(sock, chunks=65536):

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -236,12 +236,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             handler = handle_socks5_negotiation(sock, negotiate=False)
             addr, port = next(handler)
 
-            # We're not using assertIn because the tests need to pass under the
-            # old Python 2.6
-            if not addr in ['127.0.0.1', '::1']:
-                raise self.failureException(
-                    "Requested address is %s, 127.0.0.1 or ::1 expected" %
-                    safe_repr(addr))
+            self.assertIn(addr, ['127.0.0.1', '::1'])
             self.assertTrue(port, 80)
             handler.send(True)
 

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -236,7 +236,12 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             handler = handle_socks5_negotiation(sock, negotiate=False)
             addr, port = next(handler)
 
-            self.assertIn(addr, ['127.0.0.1', '::1'])
+            # We're not using assertIn because the tests need to pass under the
+            # old Python 2.6
+            if not addr in ['127.0.0.1', '::1']:
+                raise self.failureException(
+                    "Requested address is %s, 127.0.0.1 or ::1 expected" %
+                    safe_repr(addr))
             self.assertTrue(port, 80)
             handler.send(True)
 

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -256,7 +256,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
@@ -268,7 +268,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             event.wait()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
@@ -285,7 +285,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             event.set()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
 
         event.wait()
@@ -308,7 +308,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
@@ -361,7 +361,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
             next(handler)
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url, username='user',
                                            password='badpass')
 
@@ -472,7 +472,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'http://example.com')
         self.assertEqual(response.status, 200)
@@ -491,7 +491,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
 
         self.assertRaises(
@@ -539,7 +539,7 @@ class TestSOCKS4Proxy(IPV4SocketDummyServerTestCase):
             next(handler)
 
         self._start_server(request_handler)
-        proxy_url = "socks4://%s:%s" % (self.host, self.port)
+        proxy_url = "socks4a://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url, username='baduser')
 
         try:
@@ -590,7 +590,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
             tls.close()
 
         self._start_server(request_handler)
-        proxy_url = "socks5://%s:%s" % (self.host, self.port)
+        proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url)
         response = pm.request('GET', 'https://localhost')
 

--- a/urllib3/contrib/socks.py
+++ b/urllib3/contrib/socks.py
@@ -83,6 +83,7 @@ class SOCKSConnection(HTTPConnection):
                 proxy_port=self._socks_options['proxy_port'],
                 proxy_username=self._socks_options['username'],
                 proxy_password=self._socks_options['password'],
+                proxy_rdns=self._socks_options['rdns'],
                 timeout=self.timeout,
                 **extra_kw
             )
@@ -153,8 +154,16 @@ class SOCKSProxyManager(PoolManager):
 
         if parsed.scheme == 'socks5':
             socks_version = socks.PROXY_TYPE_SOCKS5
+            rdns = False
+        elif parsed.scheme == 'socks5h':
+            socks_version = socks.PROXY_TYPE_SOCKS5
+            rdns = True
         elif parsed.scheme == 'socks4':
             socks_version = socks.PROXY_TYPE_SOCKS4
+            rdns = False
+        elif parsed.scheme == 'socks4a':
+            socks_version = socks.PROXY_TYPE_SOCKS4
+            rdns = True
         else:
             raise ValueError(
                 "Unable to determine SOCKS version from %s" % proxy_url
@@ -168,6 +177,7 @@ class SOCKSProxyManager(PoolManager):
             'proxy_port': parsed.port,
             'username': username,
             'password': password,
+            'rdns': rdns
         }
         connection_pool_kw['_socks_options'] = socks_options
 


### PR DESCRIPTION
In the proxy string, socks5h:// and socks4a:// mean that the hostname is
to be resolved by the socks server.  socks5:// and socks4:// mean the
hostname is to be resolved locally.

Fix #1035
