### PR TITLE
Rewind Seekable Body on Retry/Redirect

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -158,8 +158,12 @@ class TestingApp(RequestHandler):
     def redirect(self, request):
         "Perform a redirect to ``target``"
         target = request.params.get('target', '/')
+        status = request.params.get('status', '303 See Other')
+        if len(status) == 3:
+            status = '%s Redirect' % status.decode('latin-1')
+
         headers = [('Location', target)]
-        return Response(status='303 See Other', headers=headers)
+        return Response(status=status, headers=headers)
 
     def multi_redirect(self, request):
         "Performs a redirect chain based on ``redirect_codes``"

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -873,7 +873,7 @@ class TestRetryAfter(HTTPDummyServerTestCase):
 
 class TestRetryWithTimeout(HTTPDummyServerTestCase):
     def setUp(self):
-        self.pool = HTTPConnectionPool(self.host, self.port, timeout=0.001)
+        self.pool = HTTPConnectionPool(self.host, self.port, timeout=0.1)
 
     def test_retries_put_filehandle(self):
         """HTTP PUT retry with a file-like object should not timeout"""

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1,4 +1,5 @@
 import errno
+import io
 import logging
 import socket
 import sys
@@ -869,6 +870,26 @@ class TestRetryAfter(HTTPDummyServerTestCase):
         delta = time.time() - t
         self.assertEqual(r.status, 200)
         self.assertTrue(delta < 1)
+
+class TestRetryWithTimeout(HTTPDummyServerTestCase):
+    def setUp(self):
+        self.pool = HTTPConnectionPool(self.host, self.port, timeout=0.001)
+
+    def test_retries_put_filehandle(self):
+        """HTTP PUT retry with a file-like object should not timeout"""
+        retry = Retry(total=3, status_forcelist=[418])
+        # httplib reads in 8k chunks; use a larger content length
+        content_length = 65535
+        uploaded_file = io.BytesIO(b'A' * content_length)
+        headers = {'test-name': 'test_put_fileobj',
+                   'Content-Length': str(content_length)}
+        resp = self.pool.urlopen('PUT', '/successful_retry',
+                                 headers=headers,
+                                 retries=retry,
+                                 body=uploaded_file,
+                                 assert_same_host=False, redirect=False)
+        self.assertEqual(resp.status, 200)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -29,6 +29,7 @@ from urllib3.exceptions import (
     ReadTimeoutError,
     ProtocolError,
     NewConnectionError,
+    UnrewindableBodyError,
 )
 from urllib3.packages.six import b, u
 from urllib3.packages.six.moves.urllib.parse import urlencode
@@ -686,8 +687,6 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             self.assertEqual(http.pool.qsize(), http.pool.maxsize)
 
 
-
-
 class TestRetry(HTTPDummyServerTestCase):
     def setUp(self):
         self.pool = HTTPConnectionPool(self.host, self.port)
@@ -871,7 +870,7 @@ class TestRetryAfter(HTTPDummyServerTestCase):
         self.assertEqual(r.status, 200)
         self.assertTrue(delta < 1)
 
-class TestRetryWithTimeout(HTTPDummyServerTestCase):
+class TestFileBodiesOnRetryOrRedirect(HTTPDummyServerTestCase):
     def setUp(self):
         self.pool = HTTPConnectionPool(self.host, self.port, timeout=0.1)
 
@@ -880,8 +879,9 @@ class TestRetryWithTimeout(HTTPDummyServerTestCase):
         retry = Retry(total=3, status_forcelist=[418])
         # httplib reads in 8k chunks; use a larger content length
         content_length = 65535
-        uploaded_file = io.BytesIO(b'A' * content_length)
-        headers = {'test-name': 'test_put_fileobj',
+        data = b'A' * content_length
+        uploaded_file = io.BytesIO(data)
+        headers = {'test-name': 'test_retries_put_filehandle',
                    'Content-Length': str(content_length)}
         resp = self.pool.urlopen('PUT', '/successful_retry',
                                  headers=headers,
@@ -891,19 +891,37 @@ class TestRetryWithTimeout(HTTPDummyServerTestCase):
         self.assertEqual(resp.status, 200)
 
     def test_redirect_put_file(self):
-        '''PUT with file object should work with a redirection response'''
+        """PUT with file object should work with a redirection response"""
         retry = Retry(total=3, status_forcelist=[418])
         # httplib reads in 8k chunks; use a larger content length
         content_length = 65535
-        uploaded_file = io.BytesIO(b'A' * content_length)
-        headers = {'test-name': 'test_redirect_put_fileobj_timeout',
+        data = b'A' * content_length
+        uploaded_file = io.BytesIO(data)
+        headers = {'test-name': 'test_redirect_put_file',
                    'Content-Length': str(content_length)}
-        resp = self.pool.urlopen('PUT', '/redirect?target=/successful_retry',
+        resp = self.pool.urlopen('PUT', '/echo',
                                  headers=headers,
                                  retries=retry,
                                  body=uploaded_file,
                                  assert_same_host=False, redirect=True)
         self.assertEqual(resp.status, 200)
+        self.assertEqual(resp.data, data)
+
+    def test_redirect_with_failed_tell(self):
+        """Abort request if failed to get a position from tell()"""
+        class BadTellObject(io.BytesIO):
+
+            def tell(self):
+                raise IOError
+
+        body = BadTellObject(b'the data')
+        url = '/redirect?target=/successful_retry'
+        headers = {'Content-Length': '8'}
+        try:
+            resp = self.pool.urlopen('PUT', url, headers=headers, body=body)
+            self.fail('PUT successful despite failed rewind.')
+        except UnrewindableBodyError as e:
+            self.assertTrue('Unable to rewind request body' in str(e))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -890,6 +890,20 @@ class TestRetryWithTimeout(HTTPDummyServerTestCase):
                                  assert_same_host=False, redirect=False)
         self.assertEqual(resp.status, 200)
 
+    def test_redirect_put_file(self):
+        '''PUT with file object should work with a redirection response'''
+        retry = Retry(total=3, status_forcelist=[418])
+        # httplib reads in 8k chunks; use a larger content length
+        content_length = 65535
+        uploaded_file = io.BytesIO(b'A' * content_length)
+        headers = {'test-name': 'test_redirect_put_fileobj_timeout',
+                   'Content-Length': str(content_length)}
+        resp = self.pool.urlopen('PUT', '/redirect?target=/successful_retry',
+                                 headers=headers,
+                                 retries=retry,
+                                 body=uploaded_file,
+                                 assert_same_host=False, redirect=True)
+        self.assertEqual(resp.status, 200)
 
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -532,6 +532,11 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             encoding. Otherwise, urllib3 will send the body using the standard
             content-length form. Defaults to False.
 
+        :param int body_pos:
+            Position to seek to in file-like body in the event of a retry or
+            redirect. Typically this won't need to be set because urllib3 will
+            auto-populate the value when needed.
+
         :param \**response_kw:
             Additional parameters are passed to
             :meth:`urllib3.response.HTTPResponse.from_httplib`

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -239,3 +239,8 @@ class HeaderParsingError(HTTPError):
     def __init__(self, defects, unparsed_data):
         message = '%s, unparsed data: %r' % (defects or 'Unknown', unparsed_data)
         super(HeaderParsingError, self).__init__(message)
+
+
+class UnrewindableBodyError(HTTPError):
+    "urllib3 encountered an error when trying to rewind a body"
+    pass


### PR DESCRIPTION
This is picking up where #459 left off. There are two commits in the first pass on this PR, one (40a110c) with a bare bones (unsafe) fix for the issue that @joneskoo was hitting, and another (ae7d799) with a fuller port of Requests implementation.

I'm on the fence about whether the second is overkill. If we decide to go down that route though, I still need to add individual testing for `rewind_body`.
