### PR TITLE
Fix Flake8 E305 errors

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -327,6 +327,7 @@ def _parse_header(line):
         pdict[name] = value
     return key, pdict
 
+
 # TODO: make the following conditional as soon as we know a version
 #       which does not require this fix.
 #       See https://github.com/facebook/tornado/issues/868

--- a/dummyserver/proxy.py
+++ b/dummyserver/proxy.py
@@ -129,6 +129,7 @@ def run_proxy(port, start_ioloop=True):
     if start_ioloop:
         ioloop.start()
 
+
 if __name__ == '__main__':
     port = 8888
     if len(sys.argv) > 1:

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -72,6 +72,7 @@ def _has_ipv6(host):
         sock.close()
     return has_ipv6
 
+
 # Some systems may have IPv6 support but DNS may not be configured
 # properly. We can not count that localhost will resolve to ::1 on all
 # systems. See https://github.com/shazow/urllib3/pull/611 and

--- a/urllib3/__init__.py
+++ b/urllib3/__init__.py
@@ -70,6 +70,7 @@ def add_stderr_logger(level=logging.DEBUG):
     logger.debug('Added a stderr logging handler to logger: %s', __name__)
     return handler
 
+
 # ... Clean up.
 del NullHandler
 

--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -126,4 +126,5 @@ def _has_ipv6(host):
         sock.close()
     return has_ipv6
 
+
 HAS_IPV6 = _has_ipv6('::1')

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -251,6 +251,7 @@ class BaseSelector(object):
     def __exit__(self, *args):
         self.close()
 
+
 # Almost all platforms have select.select()
 if hasattr(select, "select"):
     class SelectSelector(BaseSelector):


### PR DESCRIPTION
Fixes #1038. Flake8 3.1.1 now checks E305 which enforces proper spacing after function and class definitions and we had a handful lying around.