### PR TITLE
Use time.monotonic if available

### DIFF
--- a/urllib3/util/timeout.py
+++ b/urllib3/util/timeout.py
@@ -11,11 +11,10 @@ from ..exceptions import TimeoutStateError
 _Default = object()
 
 
-def current_time():
-    """
-    Retrieve the current time. This function is mocked out in unit testing.
-    """
-    return time.time()
+# Use time.monotonic if available.
+current_time = time.time
+if hasattr(time, "monotonic"):
+    current_time = time.monotonic
 
 
 class Timeout(object):

--- a/urllib3/util/timeout.py
+++ b/urllib3/util/timeout.py
@@ -12,9 +12,7 @@ _Default = object()
 
 
 # Use time.monotonic if available.
-current_time = time.time
-if hasattr(time, "monotonic"):
-    current_time = time.monotonic
+current_time = getattr(time, "monotonic", time.time)
 
 
 class Timeout(object):


### PR DESCRIPTION
Did the minimum suggested in #694 and started using `time.monotonic` if it's available. Discussion about whether we should vendor any library like `python-monotime` or `monotonic`, but this is a great first step.