### PR TITLE
Use DefaultSelector as context manager.

### DIFF
--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -541,26 +541,6 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         after_fds = len(proc.open_files())
         self.assertEqual(before_fds, after_fds)
 
-    @skipIf(sys.platform == "win32", "psutil.Process.open_files() is unstable on Windows.")
-    def test_wait_read_leaking_fds(self):
-        self.patch_wait_selector()
-        proc = psutil.Process()
-        rd, wr = self.make_socketpair()
-        before_fds = len(proc.open_files())
-        self.assertEqual(0, len(wait.wait_for_read([rd], 0.001)))
-        after_fds = len(proc.open_files())
-        self.assertEqual(before_fds, after_fds)
-
-    @skipIf(sys.platform == "win32", "psutil.Process.open_files() is unstable on Windows.")
-    def test_wait_write_leaking_fds(self):
-        self.patch_wait_selector()
-        proc = psutil.Process()
-        rd, wr = self.make_socketpair()
-        before_fds = len(proc.open_files())
-        self.assertEqual(1, len(wait.wait_for_write([wr], 0.001)))
-        after_fds = len(proc.open_files())
-        self.assertEqual(before_fds, after_fds)
-
     def test_wait_io_close_is_called(self):
         selector = self.SELECTOR()
         self.addCleanup(selector.close)

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -512,7 +512,7 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         class AlarmInterrupt(Exception):
             pass
 
-        def alarm_exception(*_):
+        def alarm_exception(*args):
             raise AlarmInterrupt()
 
         self.set_alarm(SHORT_SELECT, alarm_exception)

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -556,7 +556,7 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         self.assertEqual(err.__repr__(), "<SelectorError errno=1>")
         self.assertEqual(err.__str__(), "<SelectorError errno=1>")
 
-        
+
 class BaseWaitForTestCase(unittest.TestCase, TimerMixin, AlarmMixin):
     SELECTOR = selectors.DefaultSelector
 
@@ -692,20 +692,40 @@ class ScalableSelectorMixin(object):
 
 
 @skipUnless(hasattr(selectors, "SelectSelector"), "Platform doesn't have a SelectSelector")
-class SelectSelectorTestCase(BaseSelectorTestCase, BaseWaitForTestCase):
+class SelectSelectorTestCase(BaseSelectorTestCase):
     SELECTOR = getattr(selectors, "SelectSelector", None)
 
 
 @skipUnless(hasattr(selectors, "PollSelector"), "Platform doesn't have a PollSelector")
-class PollSelectorTestCase(BaseSelectorTestCase, BaseWaitForTestCase, ScalableSelectorMixin):
+class PollSelectorTestCase(BaseSelectorTestCase, ScalableSelectorMixin):
     SELECTOR = getattr(selectors, "PollSelector", None)
 
 
 @skipUnless(hasattr(selectors, "EpollSelector"), "Platform doesn't have an EpollSelector")
-class EpollSelectorTestCase(BaseSelectorTestCase, BaseWaitForTestCase, ScalableSelectorMixin):
+class EpollSelectorTestCase(BaseSelectorTestCase, ScalableSelectorMixin):
     SELECTOR = getattr(selectors, "EpollSelector", None)
 
 
 @skipUnless(hasattr(selectors, "KqueueSelector"), "Platform doesn't have a KqueueSelector")
-class KqueueSelectorTestCase(BaseSelectorTestCase, BaseWaitForTestCase, ScalableSelectorMixin):
+class KqueueSelectorTestCase(BaseSelectorTestCase, ScalableSelectorMixin):
+    SELECTOR = getattr(selectors, "KqueueSelector", None)
+
+
+@skipUnless(hasattr(selectors, "SelectSelector"), "Platform doesn't have a SelectSelector")
+class SelectWaitForTestCase(BaseWaitForTestCase):
+    SELECTOR = getattr(selectors, "SelectSelector", None)
+
+
+@skipUnless(hasattr(selectors, "PollSelector"), "Platform doesn't have a PollSelector")
+class PollWaitForTestCase(BaseWaitForTestCase):
+    SELECTOR = getattr(selectors, "PollSelector", None)
+
+
+@skipUnless(hasattr(selectors, "EpollSelector"), "Platform doesn't have an EpollSelector")
+class EpollWaitForTestCase(BaseWaitForTestCase):
+    SELECTOR = getattr(selectors, "EpollSelector", None)
+
+
+@skipUnless(hasattr(selectors, "KqueueSelector"), "Platform doesn't have a KqueueSelector")
+class KqueueWaitForTestCase(BaseWaitForTestCase):
     SELECTOR = getattr(selectors, "KqueueSelector", None)

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -32,8 +32,7 @@ except ImportError:
 
 from urllib3.util import (
     selectors,
-    wait_for_read,
-    wait_for_write
+    wait
 )
 
 HAS_ALARM = hasattr(signal, "alarm")
@@ -139,22 +138,22 @@ class WaitForIOTest(unittest.TestCase, AlarmMixin, TimerMixin):
 
     def test_wait_for_read_single_socket(self):
         rd, wr = self.make_socketpair()
-        self.assertEqual([], wait_for_read(rd, timeout=SHORT_SELECT))
+        self.assertEqual([], wait.wait_for_read(rd, timeout=SHORT_SELECT))
 
     def test_wait_for_read_multiple_socket(self):
         rd, rd2 = self.make_socketpair()
-        self.assertEqual([], wait_for_read([rd, rd2], timeout=SHORT_SELECT))
+        self.assertEqual([], wait.wait_for_read([rd, rd2], timeout=SHORT_SELECT))
 
     def test_wait_for_read_empty(self):
-        self.assertEqual([], wait_for_read([], timeout=SHORT_SELECT))
+        self.assertEqual([], wait.wait_for_read([], timeout=SHORT_SELECT))
 
     def test_wait_for_write_single_socket(self):
         wr, wr2 = self.make_socketpair()
-        self.assertEqual([wr], wait_for_write(wr, timeout=SHORT_SELECT))
+        self.assertEqual([wr], wait.wait_for_write(wr, timeout=SHORT_SELECT))
 
     def test_wait_for_write_multiple_socket(self):
         wr, wr2 = self.make_socketpair()
-        result = wait_for_write([wr, wr2], timeout=SHORT_SELECT)
+        result = wait.wait_for_write([wr, wr2], timeout=SHORT_SELECT)
         # assertItemsEqual renamed in Python 3.x
         if hasattr(self, "assertItemsEqual"):
             self.assertItemsEqual([wr, wr2], result)
@@ -162,17 +161,17 @@ class WaitForIOTest(unittest.TestCase, AlarmMixin, TimerMixin):
             self.assertCountEqual([wr, wr2], result)
 
     def test_wait_for_write_empty(self):
-        self.assertEqual([], wait_for_write([], timeout=SHORT_SELECT))
+        self.assertEqual([], wait.wait_for_write([], timeout=SHORT_SELECT))
 
     def test_wait_for_non_list_iterable(self):
         rd, wr = self.make_socketpair()
         iterable = {'rd': rd}.values()
-        self.assertEqual([], wait_for_read(iterable, timeout=SHORT_SELECT))
+        self.assertEqual([], wait.wait_for_read(iterable, timeout=SHORT_SELECT))
 
     def test_wait_timeout(self):
         rd, wr = self.make_socketpair()
         with self.assertTakesTime(lower=SHORT_SELECT, upper=SHORT_SELECT):
-            wait_for_read([rd], timeout=SHORT_SELECT)
+            wait.wait_for_read([rd], timeout=SHORT_SELECT)
 
     @skipUnless(HAS_ALARM, "Platform doesn't have signal.alarm()")
     def test_interrupt_wait_for_read_no_event(self):
@@ -181,7 +180,7 @@ class WaitForIOTest(unittest.TestCase, AlarmMixin, TimerMixin):
         self.set_alarm(SHORT_SELECT, lambda *args: None)
 
         with self.assertTakesTime(lower=LONG_SELECT, upper=LONG_SELECT):
-            self.assertEqual([], wait_for_read(rd, timeout=LONG_SELECT))
+            self.assertEqual([], wait.wait_for_read(rd, timeout=LONG_SELECT))
 
     @skipUnless(HAS_ALARM, "Platform doesn't have signal.alarm()")
     def test_interrupt_wait_for_read_with_event(self):
@@ -190,7 +189,7 @@ class WaitForIOTest(unittest.TestCase, AlarmMixin, TimerMixin):
         self.set_alarm(SHORT_SELECT, lambda *args: wr.send(b'x'))
 
         with self.assertTakesTime(lower=SHORT_SELECT, upper=SHORT_SELECT):
-            self.assertEqual([rd], wait_for_read(rd, timeout=LONG_SELECT))
+            self.assertEqual([rd], wait.wait_for_read(rd, timeout=LONG_SELECT))
         self.assertEqual(rd.recv(1), b'x')
 
 
@@ -584,7 +583,7 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         class AlarmInterrupt(Exception):
             pass
 
-        def alarm_exception(*args):
+        def alarm_exception(*_):
             raise AlarmInterrupt()
 
         self.set_alarm(SHORT_SELECT, alarm_exception)
@@ -612,6 +611,34 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         s.close()
         after_fds = len(proc.open_files())
         self.assertEqual(before_fds, after_fds)
+
+    @skipIf(sys.platform == "win32", "psutil.Process.open_files() is unstable on Windows.")
+    def test_wait_read_leaking_fds(self):
+        old_selector = wait.DefaultSelector
+        wait.DefaultSelector = self.SELECTOR
+        self.addCleanup(setattr, wait, "DefaultSelector", old_selector)
+
+        proc = psutil.Process()
+        rd, wr = self.make_socketpair()
+        before_fds = len(proc.open_files())
+        self.assertEqual(0, len(wait.wait_for_read([rd], 0.001)))
+        after_fds = len(proc.open_files())
+        self.assertEqual(before_fds, after_fds)
+
+    @skipIf(sys.platform == "win32", "psutil.Process.open_files() is unstable on Windows.")
+    def test_wait_write_leaking_fds(self):
+        old_selector = wait.DefaultSelector
+        wait.DefaultSelector = self.SELECTOR
+        self.addCleanup(setattr, wait, "DefaultSelector", old_selector)
+
+        proc = psutil.Process()
+        rd, wr = self.make_socketpair()
+        before_fds = len(proc.open_files())
+        self.assertEqual(1, len(wait.wait_for_write([wr], 0.001)))
+        after_fds = len(proc.open_files())
+        self.assertEqual(before_fds, after_fds)
+
+
 
 
 class ScalableSelectorMixin(object):

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -1,6 +1,5 @@
 from __future__ import with_statement
 import errno
-import mock
 import os
 import psutil
 import signal

--- a/urllib3/util/wait.py
+++ b/urllib3/util/wait.py
@@ -19,11 +19,11 @@ def _wait_for_io_events(socks, events, timeout=None):
         # Otherwise it might be a non-list iterable.
         else:
             socks = list(socks)
-    selector = DefaultSelector()
-    for sock in socks:
-        selector.register(sock, events)
-    return [key[0].fileobj for key in
-            selector.select(timeout) if key[1] & events]
+    with DefaultSelector() as selector:
+        for sock in socks:
+            selector.register(sock, events)
+        return [key[0].fileobj for key in
+                selector.select(timeout) if key[1] & events]
 
 
 def wait_for_read(socks, timeout=None):


### PR DESCRIPTION
PR for #1046, uses the selector as a context manager to ensure that it is properly cleaned up.