### PR TITLE
dummyserver: raise syn backlog

### DIFF
--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -120,7 +120,7 @@ class SocketServerThread(threading.Thread):
         self.port = sock.getsockname()[1]
 
         # Once listen() returns, the server socket is ready
-        sock.listen(0)
+        sock.listen(1)
 
         if self.ready_event:
             self.ready_event.set()


### PR DESCRIPTION
If the client thread called connect() by the time the server thread
actually accept()ed connections, the client got a connection refused
error.