### PR TITLE
tests: Q&D skip network dependant tests when network is unavailable

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -114,6 +114,10 @@ def requires_network(test):
             raise
     return wrapper
 
+def get_exception_message(e):
+    if getattr(e, "message", None) is not None:
+        return getattr(e, "message")
+    return e.args[0]
 
 class _ListHandler(logging.Handler):
     def __init__(self):

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -19,6 +19,7 @@ from urllib3.exceptions import (
     HostChangedError,
     LocationValueError,
     MaxRetryError,
+    NewConnectionError,
     ProtocolError,
     SSLError,
     TimeoutError,
@@ -31,6 +32,9 @@ from ssl import SSLError as BaseSSLError
 
 from dummyserver.server import DEFAULT_CA
 
+from nose import SkipTest
+
+from test import get_exception_message
 
 class TestConnectionPool(unittest.TestCase):
     """
@@ -277,7 +281,13 @@ class TestConnectionPool(unittest.TestCase):
 
     def test_mixed_case_url(self):
         pool = HTTPConnectionPool('Example.com')
-        response = pool.request('GET', "http://Example.com")
+        try:
+            response = pool.request('GET', "http://Example.com")
+        except MaxRetryError as e:
+            if isinstance(e.reason, NewConnectionError):
+                if get_exception_message(e).find("failure in name resolution") >= 0:
+                    raise SkipTest("No network")
+            raise
         self.assertEqual(response.status, 200)
 
     def test_absolute_url(self):

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -3,16 +3,19 @@ import socket
 import unittest
 
 from nose.tools import timed
+from nose import SkipTest
 
 from dummyserver.testcase import HTTPDummyProxyTestCase, IPv6HTTPDummyProxyTestCase
 from dummyserver.server import (
     DEFAULT_CA, DEFAULT_CA_BAD, get_unreachable_address)
-from .. import TARPIT_HOST
+from .. import (TARPIT_HOST,
+                get_exception_message,
+)
 
 from urllib3._collections import HTTPHeaderDict
 from urllib3.poolmanager import proxy_from_url, ProxyManager
 from urllib3.exceptions import (
-    MaxRetryError, SSLError, ProxyError, ConnectTimeoutError)
+    MaxRetryError, SSLError, ProxyError, ConnectTimeoutError, NewConnectionError)
 from urllib3.connectionpool import connection_from_url, VerifiedHTTPSConnection
 
 
@@ -282,23 +285,32 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     @timed(0.5)
     def test_https_proxy_timeout(self):
-        https = proxy_from_url('https://{host}'.format(host=TARPIT_HOST))
+        https = proxy_from_url('https://{host}'.format(host=TARPIT_HOST), retries=False)
         try:
             https.request('GET', self.http_url, timeout=0.001)
             self.fail("Failed to raise retry error.")
-        except MaxRetryError as e:
-           self.assertEqual(type(e.reason), ConnectTimeoutError)
-
+        except ProxyError as e:
+            for a in e.args:
+                if isinstance(a, NewConnectionError) and get_exception_message(a).find("unreachable") >= 0:
+                    raise SkipTest("No network")
+            raise
+        except ConnectTimeoutError:
+            self.assertTrue(True)
 
     @timed(0.5)
     def test_https_proxy_pool_timeout(self):
         https = proxy_from_url('https://{host}'.format(host=TARPIT_HOST),
-                               timeout=0.001)
+                               timeout=0.001, retries=False)
         try:
             https.request('GET', self.http_url)
             self.fail("Failed to raise retry error.")
-        except MaxRetryError as e:
-            self.assertEqual(type(e.reason), ConnectTimeoutError)
+        except ProxyError as e:
+            for a in e.args:
+                if isinstance(a, NewConnectionError) and get_exception_message(a).find("unreachable") >= 0:
+                    raise SkipTest("No network")
+            raise
+        except ConnectTimeoutError:
+            self.assertTrue(True)
 
     def test_scheme_host_case_insensitive(self):
         """Assert that upper-case schemes and hosts are normalized."""


### PR DESCRIPTION
A proper fix would be to bring the socket.{gai,}error in
NewConnectionError, but i'm not willing to undertake this refactoring.