### PR TITLE
Verify that pyOpenSSL is sufficiently new before injecting

### DIFF
--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -9,29 +9,37 @@ try:
 except ImportError as e:
     raise SkipTest('Could not import PyOpenSSL: %r' % e)
 
-from mock import patch
+from mock import patch, Mock
 
 class TestPyOpenSSLInjection(unittest.TestCase):
     """
     Tests for error handling in pyopenssl's 'inject_into urllib3'
     """
-    def test_inject_validate_fail(self):
+    def test_inject_validate_fail_cryptography(self):
         """
-        Injection should not be supported if we are missing required dependencies.
+        Injection should not be supported if cryptography is too old.
         """
-        successfully_injected = False
         try:
             with patch("cryptography.x509.extensions.Extensions") as mock:
-
-                # The following two lines are what this test intends to test.
-                # The remainder of this function is setup and clean-up logic.
                 del mock.get_extension_for_class
                 self.assertRaises(ImportError, inject_into_urllib3)
-
-                successfully_injected = True
         finally:
-            if successfully_injected:
-                # `inject_into_urllib3` is not supposed to succeed.
-                # If it does, this test should fail, but we should
-                # clean up so that subsequent tests are unaffected.
-                extract_from_urllib3()
+            # `inject_into_urllib3` is not supposed to succeed.
+            # If it does, this test should fail, but we need to
+            # clean up so that subsequent tests are unaffected.
+            extract_from_urllib3()
+
+    def test_inject_validate_fail_pyopenssl(self):
+        """
+        Injection should not be supported if pyOpenSSL is too old.
+        """
+        try:
+            return_val = Mock()
+            del return_val._x509
+            with patch("OpenSSL.crypto.X509", return_value=return_val) as mock:
+                self.assertRaises(ImportError, inject_into_urllib3)
+        finally:
+            # `inject_into_urllib3` is not supposed to succeed.
+            # If it does, this test should fail, but we need to
+            # clean up so that subsequent tests are unaffected.
+            extract_from_urllib3()

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -140,6 +140,14 @@ def _validate_dependencies_met():
         raise ImportError("'cryptography' module missing required functionality.  "
                           "Try upgrading to v1.3.4 or newer.")
 
+    # pyOpenSSL 0.14 and above use cryptography for OpenSSL bindings. The _x509
+    # attribute is only present on those versions.
+    from OpenSSL.crypto import X509
+    x509 = X509()
+    if not hasattr(x509, "_x509"):
+        raise ImportError("'pyOpenSSL' module missing required functionality. "
+                          "Try upgrading to v0.14 or newer.")
+
 
 def _dnsname_to_stdlib(name):
     """

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -136,7 +136,7 @@ def _validate_dependencies_met():
     """
     # Method added in `cryptography==1.1`; not available in older versions
     from cryptography.x509.extensions import Extensions
-    if not hasattr(Extensions, "get_extension_for_class"):
+    if getattr(Extensions, "get_extension_for_class", None) is None:
         raise ImportError("'cryptography' module missing required functionality.  "
                           "Try upgrading to v1.3.4 or newer.")
 
@@ -144,7 +144,7 @@ def _validate_dependencies_met():
     # attribute is only present on those versions.
     from OpenSSL.crypto import X509
     x509 = X509()
-    if not hasattr(x509, "_x509"):
+    if getattr(x509, "_x509", None) is None:
         raise ImportError("'pyOpenSSL' module missing required functionality. "
                           "Try upgrading to v0.14 or newer.")
 


### PR DESCRIPTION
`cryptography` is being checked, but pyOpenSSL is not, which results in issues like https://github.com/kennethreitz/requests/issues/3701

This approach does require doing an allocation of an `X509` object to verify that the expected private attribute is available.

I also modified the tests as the previous attempt to check `successfully_injected` would not work as it was never set to True (when the assertion failed it would jump immediately into the `finally` block). It isn't unsafe to always call `extract_from_urllib3` so now it always does.