### PR TITLE
Cleanup request methods.

### DIFF
--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -623,7 +623,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         base_url = 'http://%s:%d' % (self.host, self.port)
 
         # Define some proxy headers.
-        proxy_headers = HTTPHeaderDict({'For The Proxy': 'YEAH!'})
+        proxy_headers = HTTPHeaderDict({'For-The-Proxy': 'YEAH!'})
         proxy = proxy_from_url(base_url, proxy_headers=proxy_headers)
 
         conn = proxy.connection_from_url('http://www.google.com/')
@@ -634,7 +634,7 @@ class TestProxyManager(SocketDummyServerTestCase):
         # FIXME: The order of the headers is not predictable right now. We
         # should fix that someday (maybe when we migrate to
         # OrderedDict/MultiDict).
-        self.assertTrue(b'for the proxy: YEAH!\r\n' in r.data)
+        self.assertTrue(b'for-the-proxy: YEAH!\r\n' in r.data)
 
     def test_retries(self):
         close_event = Event()

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -973,6 +973,40 @@ class TestHeaders(SocketDummyServerTestCase):
         ]
         self.assertEqual(expected_response_headers, actual_response_headers)
 
+    def test_integer_values_are_sent_as_decimal_strings(self):
+        headers = {'Foo': 88}
+        parsed_headers = {}
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            buf = b''
+            while not buf.endswith(b'\r\n\r\n'):
+                buf += sock.recv(65536)
+
+            headers_list = [header for header in buf.split(b'\r\n')[1:] if header]
+
+            for header in headers_list:
+                (key, value) = header.split(b': ')
+                parsed_headers[key.decode('ascii')] = value.decode('ascii')
+
+            sock.send((
+                'HTTP/1.1 204 No Content\r\n'
+                'Content-Length: 0\r\n'
+                '\r\n').encode('utf-8'))
+
+            sock.close()
+
+        self._start_server(socket_handler)
+        expected_headers = {'accept-encoding': 'identity',
+                            'host': '{0}:{1}'.format(self.host, self.port),
+                            'foo': '88'}
+
+        pool = HTTPConnectionPool(self.host, self.port, retries=False)
+        pool.request('GET', '/', headers=HTTPHeaderDict(headers))
+        self.assertEqual(expected_headers, parsed_headers)
+
+
 
 class TestBrokenHeaders(SocketDummyServerTestCase):
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -822,7 +822,7 @@ class HTTPConnection(object):
 
     def request(self, method, url, body=None, headers={}):
         """Send a complete request to the server."""
-        self._send_request(method, url, body, headers)
+        self._send_request(method, url, body, headers.copy())
 
     def _send_request(self, method, url, body, headers):
         # if a prior response has been completed, then forget about it.

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -517,8 +517,6 @@ class HTTPConnection(object):
         )
 
         self.__response = None
-        self._pending_headers = []
-        self._url = None
 
         self._state_machine = h11.Connection(our_role=h11.CLIENT)
 
@@ -836,7 +834,6 @@ class HTTPConnection(object):
         self._method = method
         if not url:
             url = '/'
-        self._url = url
 
         # Honor explicitly requested Host: and Accept-Encoding: headers.
         header_names = frozenset(k.lower() for k in headers)

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -102,21 +102,6 @@ def _headers_to_native_string(headers):
         yield (n, v)
 
 
-def _headers_to_byte_string(headers):
-    """
-    A temporary shim to convert headers we want to send to byte strings, to
-    match the behaviour of httplib. We will reconsider this later in the
-    process.
-    """
-    # TODO: revisit.
-    for n, v in headers:
-        if not isinstance(n, bytes):
-            n = n.encode('latin1')
-        if not isinstance(v, bytes):
-            v = v.encode('latin1')
-        yield (n, v)
-
-
 def _validate_headers(headers):
     """
     A generator that validates headers as they are iterated over and then emits
@@ -601,7 +586,7 @@ class HTTPConnection(object):
             target = target.encode('latin1')
 
         # We need to set the Host header.
-        headers = dict(_headers_to_byte_string(self._tunnel_headers.items()))
+        headers = dict(_validate_headers(self._tunnel_headers.items()))
         if b"host" not in frozenset(k.lower() for k in headers):
             headers[b"host"] = target
 

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -775,10 +775,8 @@ class HTTPConnection(object):
             netloc = parse_url(url).netloc
 
         if netloc:
-            try:
-                netloc_enc = netloc.encode("ascii")
-            except UnicodeEncodeError:
-                netloc_enc = netloc.encode("idna")
+            # TODO: Address IDNs.
+            netloc_enc = netloc.encode("ascii")
             return netloc_enc
         else:
             if self._tunnel_host:
@@ -788,10 +786,8 @@ class HTTPConnection(object):
                 host = self.host
                 port = self.port
 
-            try:
-                host_enc = host.encode("ascii")
-            except UnicodeEncodeError:
-                host_enc = host.encode("idna")
+            # TODO: Address IDNs.
+            host_enc = host.encode("ascii")
 
             # As per RFC 273, IPv6 address should be wrapped with []
             # when used as Host header

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -822,12 +822,11 @@ class HTTPConnection(object):
                 host_enc = host_enc.decode("ascii")
                 return u"%s:%s" % (host_enc, port)
 
-    def request(self, method, url, body=None, headers={},
-                encode_chunked=False):
+    def request(self, method, url, body=None, headers={}):
         """Send a complete request to the server."""
-        self._send_request(method, url, body, headers, encode_chunked)
+        self._send_request(method, url, body, headers)
 
-    def _send_request(self, method, url, body, headers, encode_chunked):
+    def _send_request(self, method, url, body, headers):
         # if a prior response has been completed, then forget about it.
         if self.__response and self.__response.isclosed():
             self.__response = None

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -948,9 +948,8 @@ class HTTPConnection(object):
         Alternative to the common request method, which sends the
         body with chunked encoding and not as one block
         """
-        # TODO: We should be able to merge this method entirely with
-        # request()
         headers = HTTPHeaderDict(headers if headers is not None else {})
+        # TODO: throw exception if we have content-length too.
         if 'transfer-encoding' not in headers:
             headers['Transfer-Encoding'] = 'chunked'
 


### PR DESCRIPTION
This patch removes `putrequest`/`putheader`/`endheaders`, all of which were superfluous to our actual needs. Given that we plan to use a static Request object at some point in the future, we have no need to allow these incremental request building methods, and so we can avoid them entirely and remove several bits of state tracking they enforced.

It also removes a bunch of code. Yay!