### PR TITLE
only normalize http(s) urls

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -111,7 +111,10 @@ class TestUtil(unittest.TestCase):
             self.assertRaises(LocationParseError, get_host, location)
 
     def test_host_normalization(self):
-        """Asserts the scheme and host is normalized to lower-case."""
+        """
+        Asserts the scheme and hosts with a normalizable scheme are
+        converted to lower-case.
+        """
         url_host_map = {
             # Hosts
             'HTTP://GOOGLE.COM/mail/': ('http', 'google.com', None),
@@ -125,6 +128,9 @@ class TestUtil(unittest.TestCase):
                 'http', '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]', 8000),
             'HTTPS://[1080:0:0:0:8:800:200c:417A]/index.html': (
                 'https', '[1080:0:0:0:8:800:200c:417a]', None),
+            'abOut://eXamPlE.com?info=1': ('about', 'eXamPlE.com', None),
+            'http+UNIX://%2fvar%2frun%2fSOCKET/path': (
+                'http+unix', '%2fvar%2frun%2fSOCKET', None),
         }
         for url, expected_host in url_host_map.items():
             returned_host = get_host(url)

--- a/urllib3/util/url.py
+++ b/urllib3/util/url.py
@@ -6,6 +6,10 @@ from ..exceptions import LocationParseError
 
 url_attrs = ['scheme', 'auth', 'host', 'port', 'path', 'query', 'fragment']
 
+# We only want to normalize urls with an HTTP(S) scheme.
+# urllib3 infers URLs without a scheme (None) to be http.
+NORMALIZABLE_SCHEMES = ('http', 'https', None)
+
 
 class Url(namedtuple('Url', url_attrs)):
     """
@@ -21,7 +25,7 @@ class Url(namedtuple('Url', url_attrs)):
             path = '/' + path
         if scheme:
             scheme = scheme.lower()
-        if host:
+        if host and scheme in NORMALIZABLE_SCHEMES:
             host = host.lower()
         return super(Url, cls).__new__(cls, scheme, auth, host, port, path,
                                        query, fragment)


### PR DESCRIPTION
This is a proposed solution for #1080. We'll now restrict our host lower-casing to only schemes we've noted to be "normalizable".