### PR TITLE
Add fast path for system call wrapper on Python 3.5+

### DIFF
--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -8,9 +8,11 @@
 import errno
 import math
 import select
+import socket
+import sys
 from collections import namedtuple, Mapping
-
 import time
+
 try:
     monotonic = time.monotonic
 except (AttributeError, ImportError):  # Python 3.3<
@@ -49,61 +51,77 @@ def _fileobj_to_fd(fileobj):
         raise ValueError("Invalid file descriptor: {0}".format(fd))
     return fd
 
-
-def _syscall_wrapper(func, recalc_timeout, *args, **kwargs):
-    """ Wrapper function for syscalls that could fail due to EINTR.
-    All functions should be retried if there is time left in the timeout
-    in accordance with PEP 475. """
-    timeout = kwargs.get("timeout", None)
-    if timeout is None:
-        expires = None
-        recalc_timeout = False
-    else:
-        timeout = float(timeout)
-        if timeout < 0.0:  # Timeout less than 0 treated as no timeout.
-            expires = None
-        else:
-            expires = monotonic() + timeout
-
-    args = list(args)
-    if recalc_timeout and "timeout" not in kwargs:
-        raise ValueError(
-            "Timeout must be in args or kwargs to be recalculated")
-
-    result = _SYSCALL_SENTINEL
-    while result is _SYSCALL_SENTINEL:
+# Determine which function to use to wrap system calls because Python 3.5+
+# already handles the case when system calls are interrupted.
+if sys.version_info >= (3, 5):
+    def _syscall_wrapper(func, _, *args, **kwargs):
+        """ This is the short-circuit version of the below logic
+        because in Python 3.5+ all system calls automatically restart
+        and recalculate their timeouts. """
         try:
-            result = func(*args, **kwargs)
-        # OSError is thrown by select.select
-        # IOError is thrown by select.epoll.poll
-        # select.error is thrown by select.poll.poll
-        # Aren't we thankful for Python 3.x rework for exceptions?
+            return func(*args, **kwargs)
         except (OSError, IOError, select.error) as e:
-            # select.error wasn't a subclass of OSError in the past.
             errcode = None
             if hasattr(e, "errno"):
                 errcode = e.errno
             elif hasattr(e, "args"):
                 errcode = e.args[0]
-
-            # Also test for the Windows equivalent of EINTR.
-            is_interrupt = (errcode == errno.EINTR or (hasattr(errno, "WSAEINTR") and
-                                                       errcode == errno.WSAEINTR))
-
-            if is_interrupt:
-                if expires is not None:
-                    current_time = monotonic()
-                    if current_time > expires:
-                        raise OSError(errno=errno.ETIMEDOUT)
-                    if recalc_timeout:
-                        if "timeout" in kwargs:
-                            kwargs["timeout"] = expires - current_time
-                continue
-            if errcode:
-                raise SelectorError(errcode)
+            raise SelectorError(errcode)
+else:
+    def _syscall_wrapper(func, recalc_timeout, *args, **kwargs):
+        """ Wrapper function for syscalls that could fail due to EINTR.
+        All functions should be retried if there is time left in the timeout
+        in accordance with PEP 475. """
+        timeout = kwargs.get("timeout", None)
+        if timeout is None:
+            expires = None
+            recalc_timeout = False
+        else:
+            timeout = float(timeout)
+            if timeout < 0.0:  # Timeout less than 0 treated as no timeout.
+                expires = None
             else:
-                raise
-    return result
+                expires = monotonic() + timeout
+
+        args = list(args)
+        if recalc_timeout and "timeout" not in kwargs:
+            raise ValueError(
+                "Timeout must be in args or kwargs to be recalculated")
+
+        result = _SYSCALL_SENTINEL
+        while result is _SYSCALL_SENTINEL:
+            try:
+                result = func(*args, **kwargs)
+            # OSError is thrown by select.select
+            # IOError is thrown by select.epoll.poll
+            # select.error is thrown by select.poll.poll
+            # Aren't we thankful for Python 3.x rework for exceptions?
+            except (OSError, IOError, select.error) as e:
+                # select.error wasn't a subclass of OSError in the past.
+                errcode = None
+                if hasattr(e, "errno"):
+                    errcode = e.errno
+                elif hasattr(e, "args"):
+                    errcode = e.args[0]
+
+                # Also test for the Windows equivalent of EINTR.
+                is_interrupt = (errcode == errno.EINTR or (hasattr(errno, "WSAEINTR") and
+                                                           errcode == errno.WSAEINTR))
+
+                if is_interrupt:
+                    if expires is not None:
+                        current_time = monotonic()
+                        if current_time > expires:
+                            raise OSError(errno=errno.ETIMEDOUT)
+                        if recalc_timeout:
+                            if "timeout" in kwargs:
+                                kwargs["timeout"] = expires - current_time
+                    continue
+                if errcode:
+                    raise SelectorError(errcode)
+                else:
+                    raise
+        return result
 
 
 SelectorKey = namedtuple('SelectorKey', ['fileobj', 'fd', 'events', 'data'])
@@ -191,6 +209,18 @@ class BaseSelector(object):
             key = self._fd_to_key.pop(self._fileobj_lookup(fileobj))
         except KeyError:
             raise KeyError("{0!r} is not registered".format(fileobj))
+        
+        # Getting the fileno of a closed socket on Windows errors with EBADF.
+        except socket.error as e:  # Platform-specific: Windows.
+            if e.errno != errno.EBADF:
+                raise
+            else:
+                for key in self._fd_to_key.values():
+                    if key.fileobj is fileobj:
+                        self._fd_to_key.pop(key.fd)
+                        break
+                else:
+                    raise KeyError("{0!r} is not registered".format(fileobj))
         return key
 
     def modify(self, fileobj, events, data=None):

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -102,7 +102,7 @@ else:
                     errcode = e.errno
                 elif hasattr(e, "args"):
                     errcode = e.args[0]
-                    
+
                 # Also test for the Windows equivalent of EINTR.
                 is_interrupt = (errcode == errno.EINTR or (hasattr(errno, "WSAEINTR") and
                                                            errcode == errno.WSAEINTR))

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -10,8 +10,8 @@ import math
 import select
 import socket
 import sys
-from collections import namedtuple, Mapping
 import time
+from collections import namedtuple, Mapping
 
 try:
     monotonic = time.monotonic
@@ -65,8 +65,6 @@ if sys.version_info >= (3, 5):
             errcode = None
             if hasattr(e, "errno"):
                 errcode = e.errno
-            elif hasattr(e, "args"):
-                errcode = e.args[0]
             raise SelectorError(errcode)
 else:
     def _syscall_wrapper(func, recalc_timeout, *args, **kwargs):
@@ -102,7 +100,9 @@ else:
                 errcode = None
                 if hasattr(e, "errno"):
                     errcode = e.errno
-
+                elif hasattr(e, "args"):
+                    errcode = e.args[0]
+                    
                 # Also test for the Windows equivalent of EINTR.
                 is_interrupt = (errcode == errno.EINTR or (hasattr(errno, "WSAEINTR") and
                                                            errcode == errno.WSAEINTR))

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -51,6 +51,7 @@ def _fileobj_to_fd(fileobj):
         raise ValueError("Invalid file descriptor: {0}".format(fd))
     return fd
 
+
 # Determine which function to use to wrap system calls because Python 3.5+
 # already handles the case when system calls are interrupted.
 if sys.version_info >= (3, 5):
@@ -209,7 +210,7 @@ class BaseSelector(object):
             key = self._fd_to_key.pop(self._fileobj_lookup(fileobj))
         except KeyError:
             raise KeyError("{0!r} is not registered".format(fileobj))
-        
+
         # Getting the fileno of a closed socket on Windows errors with EBADF.
         except socket.error as e:  # Platform-specific: Windows.
             if e.errno != errno.EBADF:

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -102,8 +102,6 @@ else:
                 errcode = None
                 if hasattr(e, "errno"):
                     errcode = e.errno
-                elif hasattr(e, "args"):
-                    errcode = e.args[0]
 
                 # Also test for the Windows equivalent of EINTR.
                 is_interrupt = (errcode == errno.EINTR or (hasattr(errno, "WSAEINTR") and


### PR DESCRIPTION
I've updated my selectors2 project to 1.1.0 and the main feature added is a fast path the system call wrapper on Python 3.5+. This wrapper can be substantially smaller and faster because in Python 3.5+ PEP 475 is implemented which automatically retries system calls in the case of an interrupt. I figured I would propagate these changes here to make sure urllib3 is getting everything out of its selectors upgrade. :tada:

Overall the wrapper performs about **126% faster** with a happy path and **36% faster** with an error path.

This version also catches and correctly handles an error on Windows platforms when trying to call `BaseSelector.unregister` on a closed socket where the previous version did not.