### PR TITLE
Fix all flake/linter errors within tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ cover-package=urllib3
 cover-erase=true
 
 [flake8]
-exclude=./docs/conf.py,./test/*,./urllib3/packages/*
+exclude=./docs/conf.py,./urllib3/packages/*
 max-line-length=99
 
 [wheel]

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -7,7 +7,7 @@ import socket
 
 from nose.plugins.skip import SkipTest
 
-from urllib3.exceptions import MaxRetryError, HTTPWarning
+from urllib3.exceptions import HTTPWarning
 from urllib3.packages import six
 
 # We need a host that will not immediately close the connection with a TCP

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -29,9 +29,11 @@ def clear_warnings(cls=HTTPWarning):
         new_filters.append(f)
     warnings.filters[:] = new_filters
 
+
 def setUp():
     clear_warnings()
     warnings.simplefilter('ignore', HTTPWarning)
+
 
 def onlyPy26OrOlder(test):
     """Skips this test unless you are on Python2.6.x or earlier."""
@@ -44,6 +46,7 @@ def onlyPy26OrOlder(test):
         return test(*args, **kwargs)
     return wrapper
 
+
 def onlyPy27OrNewer(test):
     """Skips this test unless you are on Python 2.7.x or later."""
 
@@ -54,6 +57,7 @@ def onlyPy27OrNewer(test):
             raise SkipTest(msg)
         return test(*args, **kwargs)
     return wrapper
+
 
 def onlyPy279OrNewer(test):
     """Skips this test unless you are on Python 2.7.9 or later."""
@@ -66,6 +70,7 @@ def onlyPy279OrNewer(test):
         return test(*args, **kwargs)
     return wrapper
 
+
 def onlyPy2(test):
     """Skips this test unless you are on Python 2.x"""
 
@@ -76,6 +81,7 @@ def onlyPy2(test):
             raise SkipTest(msg)
         return test(*args, **kwargs)
     return wrapper
+
 
 def onlyPy3(test):
     """Skips this test unless you are on Python3.x"""
@@ -89,6 +95,8 @@ def onlyPy3(test):
     return wrapper
 
 _requires_network_has_route = None
+
+
 def requires_network(test):
     """Helps you skip tests that require the network"""
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -94,6 +94,7 @@ def onlyPy3(test):
         return test(*args, **kwargs)
     return wrapper
 
+
 _requires_network_has_route = None
 
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -94,7 +94,7 @@ def requires_network(test):
 
     def _is_unreachable_err(err):
         return getattr(err, 'errno', None) in (errno.ENETUNREACH,
-                                               errno.EHOSTUNREACH) # For OSX
+                                               errno.EHOSTUNREACH)  # For OSX
 
     def _has_route():
         try:

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -11,7 +11,7 @@ import time
 import urllib
 
 sys.path.append('../')
-import urllib3
+import urllib3  # noqa: E402
 
 
 # URLs to download. Doesn't matter as long as they're from the same host, so we

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -39,7 +39,7 @@ def urllib_get(url_list):
     assert url_list
     for url in url_list:
         now = time.time()
-        r = urllib.urlopen(url)
+        urllib.urlopen(url)
         elapsed = time.time() - now
         print("Got in %0.3f: %s" % (elapsed, url))
 
@@ -49,7 +49,7 @@ def pool_get(url_list):
     pool = urllib3.PoolManager()
     for url in url_list:
         now = time.time()
-        r = pool.request('GET', url, assert_same_host=False)
+        pool.request('GET', url, assert_same_host=False)
         elapsed = time.time() - now
         print("Got in %0.3fs: %s" % (elapsed, url))
 

--- a/test/contrib/test_gae_manager.py
+++ b/test/contrib/test_gae_manager.py
@@ -196,6 +196,7 @@ class TestGAERetry(TestRetry):
     test_retry_redirect_history = None
     test_multi_redirect_history = None
 
+
 class TestGAERetryAfter(TestRetryAfter):
     __test__ = True
 

--- a/test/contrib/test_gae_manager.py
+++ b/test/contrib/test_gae_manager.py
@@ -190,8 +190,8 @@ class TestGAERetry(TestRetry):
                                          self.pool._absolute_url('/successful_retry'),
                                          None, 418, None),))
 
-    #test_max_retry = None
-    #test_disabled_retry = None
+    # test_max_retry = None
+    # test_disabled_retry = None
     # We don't need these tests because URLFetch resolves its own redirects.
     test_retry_redirect_history = None
     test_multi_redirect_history = None

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -2,7 +2,6 @@
 import unittest
 
 from nose.plugins.skip import SkipTest
-from urllib3.packages import six
 
 try:
     from urllib3.contrib.pyopenssl import (inject_into_urllib3,
@@ -10,10 +9,6 @@ try:
                                            _dnsname_to_stdlib)
 except ImportError as e:
     raise SkipTest('Could not import PyOpenSSL: %r' % e)
-
-
-from ..with_dummyserver.test_https import TestHTTPS, TestHTTPS_TLSv1
-from ..with_dummyserver.test_socketlevel import TestSNI, TestSocketClosing
 
 
 def setup_module():

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -11,6 +11,7 @@ except ImportError as e:
 
 from mock import patch, Mock
 
+
 class TestPyOpenSSLInjection(unittest.TestCase):
     """
     Tests for error handling in pyopenssl's 'inject_into urllib3'

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -37,7 +37,7 @@ class TestPyOpenSSLInjection(unittest.TestCase):
         try:
             return_val = Mock()
             del return_val._x509
-            with patch("OpenSSL.crypto.X509", return_value=return_val) as mock:
+            with patch("OpenSSL.crypto.X509", return_value=return_val):
                 self.assertRaises(ImportError, inject_into_urllib3)
         finally:
             # `inject_into_urllib3` is not supposed to succeed.

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -375,7 +375,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url, username='user',
-                                           password='pass')
+                                     password='pass')
         response = pm.request('GET', 'http://16.17.18.19')
 
         self.assertEqual(response.status, 200)
@@ -394,7 +394,7 @@ class TestSocks5Proxy(IPV4SocketDummyServerTestCase):
         self._start_server(request_handler)
         proxy_url = "socks5h://%s:%s" % (self.host, self.port)
         pm = socks.SOCKSProxyManager(proxy_url, username='user',
-                                           password='badpass')
+                                     password='badpass')
 
         try:
             pm.request('GET', 'http://example.com', retries=False)
@@ -646,9 +646,9 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
             self.assertTrue(buf.startswith(b'GET / HTTP/1.1\r\n'))
 
             tls.sendall(b'HTTP/1.1 200 OK\r\n'
-                         b'Server: SocksTestServer\r\n'
-                         b'Content-Length: 0\r\n'
-                         b'\r\n')
+                        b'Server: SocksTestServer\r\n'
+                        b'Content-Length: 0\r\n'
+                        b'\r\n')
             tls.close()
 
         self._start_server(request_handler)

--- a/test/port_helpers.py
+++ b/test/port_helpers.py
@@ -9,6 +9,7 @@ import socket
 HOST = "127.0.0.1"
 HOSTv6 = "::1"
 
+
 def find_unused_port(family=socket.AF_INET, socktype=socket.SOCK_STREAM):
     """Returns an unused port that should be suitable for binding.  This is
     achieved by creating a temporary socket with the same family and type as
@@ -68,6 +69,7 @@ def find_unused_port(family=socket.AF_INET, socktype=socket.SOCK_STREAM):
     tempsock.close()
     del tempsock
     return port
+
 
 def bind_port(sock, host=HOST):
     """Bind the socket to a free port and return the port number.  Relies on

--- a/test/port_helpers.py
+++ b/test/port_helpers.py
@@ -88,11 +88,11 @@ def bind_port(sock, host=HOST):
     if sock.family == socket.AF_INET and sock.type == socket.SOCK_STREAM:
         if hasattr(socket, 'SO_REUSEADDR'):
             if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) == 1:
-                raise ValueError("tests should never set the SO_REUSEADDR "   \
+                raise ValueError("tests should never set the SO_REUSEADDR "
                                  "socket option on TCP/IP sockets!")
         if hasattr(socket, 'SO_REUSEPORT'):
             if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT) == 1:
-                raise ValueError("tests should never set the SO_REUSEPORT "   \
+                raise ValueError("tests should never set the SO_REUSEPORT "
                                  "socket option on TCP/IP sockets!")
         if hasattr(socket, 'SO_EXCLUSIVEADDRUSE'):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -148,17 +148,17 @@ class TestHTTPHeaderDict(unittest.TestCase):
         h = HTTPHeaderDict(ab=1, cd=2, ef=3, gh=4)
         self.assertEqual(len(h), 4)
         self.assertTrue('ab' in h)
-    
+
     def test_create_from_dict(self):
         h = HTTPHeaderDict(dict(ab=1, cd=2, ef=3, gh=4))
         self.assertEqual(len(h), 4)
         self.assertTrue('ab' in h)
-    
+
     def test_create_from_iterator(self):
         teststr = 'urllib3ontherocks'
         h = HTTPHeaderDict((c, c*5) for c in teststr)
         self.assertEqual(len(h), len(set(teststr)))
-        
+
     def test_create_from_list(self):
         h = HTTPHeaderDict([('ab', 'A'), ('cd', 'B'), ('cookie', 'C'), ('cookie', 'D'), ('cookie', 'E')])
         self.assertEqual(len(h), 3)
@@ -219,7 +219,7 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(self.d['b'], '100')
         self.d.add('cookie', 'with, comma')
         self.assertEqual(self.d.getlist('cookie'), ['foo', 'bar', 'asdf', 'with, comma'])
-        
+
     def test_extend_from_container(self):
         h = NonMappingHeaderContainer(Cookie='foo', e='foofoo')
         self.d.extend(h)

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -4,10 +4,10 @@ from urllib3._collections import (
     HTTPHeaderDict,
     RecentlyUsedContainer as Container
 )
+from nose.plugins.skip import SkipTest
+
 from urllib3.packages import six
 xrange = six.moves.xrange
-
-from nose.plugins.skip import SkipTest
 
 
 class TestLRUContainer(unittest.TestCase):

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -339,5 +339,6 @@ www-authenticate: bla
         self.assertEqual(d['www-authenticate'], 'asdf, bla')
         self.assertEqual(d.getlist('www-authenticate'), ['asdf', 'bla'])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -61,7 +61,7 @@ class TestLRUContainer(unittest.TestCase):
         # Keys should be ordered by access time
         self.assertEqual(list(d.keys()), [5, 6, 7, 8, 9])
 
-        new_order = [7,8,6,9,5]
+        new_order = [7, 8, 6, 9, 5]
         for k in new_order:
             d[k]
 

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -160,7 +160,8 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(len(h), len(set(teststr)))
 
     def test_create_from_list(self):
-        h = HTTPHeaderDict([('ab', 'A'), ('cd', 'B'), ('cookie', 'C'), ('cookie', 'D'), ('cookie', 'E')])
+        headers = [('ab', 'A'), ('cd', 'B'), ('cookie', 'C'), ('cookie', 'D'), ('cookie', 'E')]
+        h = HTTPHeaderDict(headers)
         self.assertEqual(len(h), 3)
         self.assertTrue('ab' in h)
         clist = h.getlist('cookie')
@@ -169,7 +170,8 @@ class TestHTTPHeaderDict(unittest.TestCase):
         self.assertEqual(clist[-1], 'E')
 
     def test_create_from_headerdict(self):
-        org = HTTPHeaderDict([('ab', 'A'), ('cd', 'B'), ('cookie', 'C'), ('cookie', 'D'), ('cookie', 'E')])
+        headers = [('ab', 'A'), ('cd', 'B'), ('cookie', 'C'), ('cookie', 'D'), ('cookie', 'E')]
+        org = HTTPHeaderDict(headers)
         h = HTTPHeaderDict(org)
         self.assertEqual(len(h), 3)
         self.assertTrue('ab' in h)
@@ -299,7 +301,9 @@ class TestHTTPHeaderDict(unittest.TestCase):
 
     def test_dict_conversion(self):
         # Also tested in connectionpool, needs to preserve case
-        hdict = {'Content-Length': '0', 'Content-type': 'text/plain', 'Server': 'TornadoServer/1.2.3'}
+        hdict = {'Content-Length': '0',
+                 'Content-type': 'text/plain',
+                 'Server': 'TornadoServer/1.2.3'}
         h = dict(HTTPHeaderDict(hdict).items())
         self.assertEqual(hdict, h)
         self.assertEqual(hdict, dict(HTTPHeaderDict(hdict)))

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -109,7 +109,7 @@ class TestLRUContainer(unittest.TestCase):
         for i in xrange(5):
             d[i] = i
         self.assertEqual(list(d.keys()), list(xrange(5)))
-        self.assertEqual(evicted_items, []) # Nothing disposed
+        self.assertEqual(evicted_items, [])  # Nothing disposed
 
         d[5] = 5
         self.assertEqual(list(d.keys()), list(xrange(1, 6)))

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -10,7 +10,7 @@ class TestVersionCompatibility(unittest.TestCase):
             warnings.simplefilter("always")
 
             # strict=True is deprecated in Py33+
-            conn = HTTPConnection('localhost', 12345, strict=True)
+            HTTPConnection('localhost', 12345, strict=True)
 
             if w:
                 self.fail('HTTPConnection raised warning on strict=True: %r' % w[0].message)
@@ -18,6 +18,6 @@ class TestVersionCompatibility(unittest.TestCase):
     def test_connection_source_address(self):
         try:
             # source_address does not exist in Py26-
-            conn = HTTPConnection('localhost', 12345, source_address='127.0.0.1')
+            HTTPConnection('localhost', 12345, source_address='127.0.0.1')
         except TypeError as e:
             self.fail('HTTPConnection raised TypeError on source_adddress: %r' % e)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -9,7 +9,6 @@ import mock
 
 from urllib3.connection import (
     CertificateError,
-    VerifiedHTTPSConnection,
     _match_hostname,
     RECENT_DATE
 )

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,17 +1,17 @@
 import datetime
-import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
-
 import mock
+import sys
 
 from urllib3.connection import (
     CertificateError,
     _match_hostname,
     RECENT_DATE
 )
+
+if sys.version_info >= (2, 7):
+    import unittest
+else:
+    import unittest2 as unittest
 
 
 class TestConnection(unittest.TestCase):

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -50,15 +50,12 @@ class TestConnectionPool(unittest.TestCase):
             ('https://google.com:443/', 'https://google.com/abracadabra'),
             ('https://google.com/', 'https://google.com:443/abracadabra'),
             ('http://[2607:f8b0:4005:805::200e%25eth0]/',
-             'http://[2607:f8b0:4005:805::200e%eth0]/'
-            ),
+             'http://[2607:f8b0:4005:805::200e%eth0]/'),
             ('https://[2607:f8b0:4005:805::200e%25eth0]:443/',
-             'https://[2607:f8b0:4005:805::200e%eth0]:443/'
-            ),
+             'https://[2607:f8b0:4005:805::200e%eth0]:443/'),
             ('http://[::1]/', 'http://[::1]'),
             ('http://[2001:558:fc00:200:f816:3eff:fef9:b954%lo]/',
-             'http://[2001:558:fc00:200:f816:3eff:fef9:b954%25lo]'
-            ),
+             'http://[2001:558:fc00:200:f816:3eff:fef9:b954%25lo]')
         ]
 
         for a, b in same_host:

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -193,7 +193,6 @@ class TestConnectionPool(unittest.TestCase):
             "Max retries exceeded with url: Test. "
             "(Caused by %r)" % err)
 
-
     def test_pool_size(self):
         POOL_SIZE = 1
         pool = HTTPConnectionPool(host='localhost', maxsize=POOL_SIZE, block=True)

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -322,7 +322,8 @@ class TestConnectionPool(unittest.TestCase):
         self.assertEqual(initial_pool_size, new_pool_size)
 
     def test_release_conn_param_is_respected_after_http_error_retry(self):
-        """For successful ```urlopen(release_conn=False)```, the connection isn't released, even after a retry.
+        """For successful ```urlopen(release_conn=False)```,
+        the connection isn't released, even after a retry.
 
         This is a regression test for issue #651 [1], where the connection
         would be released if the initial request failed, even if a retry

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -160,10 +160,10 @@ class TestConnectionPool(unittest.TestCase):
         pool = HTTPConnectionPool(host='localhost', maxsize=1, block=False)
 
         conn1 = pool._get_conn()
-        conn2 = pool._get_conn() # New because block=False
+        conn2 = pool._get_conn()  # New because block=False
 
         pool._put_conn(conn1)
-        pool._put_conn(conn2) # Should be discarded
+        pool._put_conn(conn2)  # Should be discarded
 
         self.assertEqual(conn1, pool._get_conn())
         self.assertNotEqual(conn2, pool._get_conn())

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -8,7 +8,6 @@ from urllib3.exceptions import (HTTPError, MaxRetryError, LocationParseError,
 from urllib3.connectionpool import HTTPConnectionPool
 
 
-
 class TestPickle(unittest.TestCase):
 
     def verify_pickling(self, item):

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -1,7 +1,7 @@
 import unittest
 
 from urllib3.fields import guess_content_type, RequestField
-from urllib3.packages.six import u, PY3
+from urllib3.packages.six import u
 from . import onlyPy2
 
 

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -48,82 +48,77 @@ class TestMultipartEncoding(unittest.TestCase):
 
         for fields in fieldsets:
             encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
+            expected = (b'--' + b(BOUNDARY) + b'\r\n'
+                        b'Content-Disposition: form-data; name="k"\r\n'
+                        b'\r\n'
+                        b'v\r\n'
+                        b'--' + b(BOUNDARY) + b'\r\n'
+                        b'Content-Disposition: form-data; name="k2"\r\n'
+                        b'\r\n'
+                        b'v2\r\n'
+                        b'--' + b(BOUNDARY) + b'--\r\n')
 
-            self.assertEqual(encoded,
-                b'--' + b(BOUNDARY) + b'\r\n'
-                b'Content-Disposition: form-data; name="k"\r\n'
-                b'\r\n'
-                b'v\r\n'
-                b'--' + b(BOUNDARY) + b'\r\n'
-                b'Content-Disposition: form-data; name="k2"\r\n'
-                b'\r\n'
-                b'v2\r\n'
-                b'--' + b(BOUNDARY) + b'--\r\n'
-                , fields)
+            self.assertEqual(encoded, expected, fields)
 
             self.assertEqual(content_type,
-                'multipart/form-data; boundary=' + str(BOUNDARY))
+                             'multipart/form-data; boundary=' + str(BOUNDARY))
 
     def test_filename(self):
         fields = [('k', ('somename', b'v'))]
 
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
+        expected = (b'--' + b(BOUNDARY) + b'\r\n'
+                    b'Content-Disposition: form-data; name="k"; filename="somename"\r\n'
+                    b'Content-Type: application/octet-stream\r\n'
+                    b'\r\n'
+                    b'v\r\n'
+                    b'--' + b(BOUNDARY) + b'--\r\n')
 
-        self.assertEqual(encoded,
-            b'--' + b(BOUNDARY) + b'\r\n'
-            b'Content-Disposition: form-data; name="k"; filename="somename"\r\n'
-            b'Content-Type: application/octet-stream\r\n'
-            b'\r\n'
-            b'v\r\n'
-            b'--' + b(BOUNDARY) + b'--\r\n'
-            )
+        self.assertEqual(encoded, expected)
 
         self.assertEqual(content_type,
-            'multipart/form-data; boundary=' + str(BOUNDARY))
+                         'multipart/form-data; boundary=' + str(BOUNDARY))
 
     def test_textplain(self):
         fields = [('k', ('somefile.txt', b'v'))]
 
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
+        expected = (b'--' + b(BOUNDARY) + b'\r\n'
+                    b'Content-Disposition: form-data; name="k"; filename="somefile.txt"\r\n'
+                    b'Content-Type: text/plain\r\n'
+                    b'\r\n'
+                    b'v\r\n'
+                    b'--' + b(BOUNDARY) + b'--\r\n')
 
-        self.assertEqual(encoded,
-            b'--' + b(BOUNDARY) + b'\r\n'
-            b'Content-Disposition: form-data; name="k"; filename="somefile.txt"\r\n'
-            b'Content-Type: text/plain\r\n'
-            b'\r\n'
-            b'v\r\n'
-            b'--' + b(BOUNDARY) + b'--\r\n'
-            )
+        self.assertEqual(encoded, expected)
 
         self.assertEqual(content_type,
-            'multipart/form-data; boundary=' + str(BOUNDARY))
+                         'multipart/form-data; boundary=' + str(BOUNDARY))
 
     def test_explicit(self):
         fields = [('k', ('somefile.txt', b'v', 'image/jpeg'))]
 
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
+        expected = (b'--' + b(BOUNDARY) + b'\r\n'
+                    b'Content-Disposition: form-data; name="k"; filename="somefile.txt"\r\n'
+                    b'Content-Type: image/jpeg\r\n'
+                    b'\r\n'
+                    b'v\r\n'
+                    b'--' + b(BOUNDARY) + b'--\r\n')
 
-        self.assertEqual(encoded,
-            b'--' + b(BOUNDARY) + b'\r\n'
-            b'Content-Disposition: form-data; name="k"; filename="somefile.txt"\r\n'
-            b'Content-Type: image/jpeg\r\n'
-            b'\r\n'
-            b'v\r\n'
-            b'--' + b(BOUNDARY) + b'--\r\n'
-            )
+        self.assertEqual(encoded, expected)
 
         self.assertEqual(content_type,
-            'multipart/form-data; boundary=' + str(BOUNDARY))
+                         'multipart/form-data; boundary=' + str(BOUNDARY))
 
     def test_request_fields(self):
-      fields = [RequestField('k', b'v', filename='somefile.txt', headers={'Content-Type': 'image/jpeg'})]
+        fields = [RequestField('k', b'v', filename='somefile.txt', headers={'Content-Type': 'image/jpeg'})]
 
-      encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
+        encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
+        expected = (b'--' + b(BOUNDARY) + b'\r\n'
+                    b'Content-Type: image/jpeg\r\n'
+                    b'\r\n'
+                    b'v\r\n'
+                    b'--' + b(BOUNDARY) + b'--\r\n')
 
-      self.assertEqual(encoded,
-          b'--' + b(BOUNDARY) + b'\r\n'
-          b'Content-Type: image/jpeg\r\n'
-          b'\r\n'
-          b'v\r\n'
-          b'--' + b(BOUNDARY) + b'--\r\n'
-          )
+        self.assertEqual(encoded, expected)

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -39,7 +39,6 @@ class TestMultipartEncoding(unittest.TestCase):
             encoded, _ = encode_multipart_formdata(fields, boundary=BOUNDARY)
             self.assertEqual(encoded.count(b(BOUNDARY)), 3)
 
-
     def test_field_encoding(self):
         fieldsets = [
             [('k', 'v'), ('k2', 'v2')],
@@ -65,7 +64,6 @@ class TestMultipartEncoding(unittest.TestCase):
             self.assertEqual(content_type,
                 'multipart/form-data; boundary=' + str(BOUNDARY))
 
-
     def test_filename(self):
         fields = [('k', ('somename', b'v'))]
 
@@ -83,7 +81,6 @@ class TestMultipartEncoding(unittest.TestCase):
         self.assertEqual(content_type,
             'multipart/form-data; boundary=' + str(BOUNDARY))
 
-
     def test_textplain(self):
         fields = [('k', ('somefile.txt', b'v'))]
 
@@ -100,7 +97,6 @@ class TestMultipartEncoding(unittest.TestCase):
 
         self.assertEqual(content_type,
             'multipart/form-data; boundary=' + str(BOUNDARY))
-
 
     def test_explicit(self):
         fields = [('k', ('somefile.txt', b'v', 'image/jpeg'))]

--- a/test/test_filepost.py
+++ b/test/test_filepost.py
@@ -112,7 +112,9 @@ class TestMultipartEncoding(unittest.TestCase):
                          'multipart/form-data; boundary=' + str(BOUNDARY))
 
     def test_request_fields(self):
-        fields = [RequestField('k', b'v', filename='somefile.txt', headers={'Content-Type': 'image/jpeg'})]
+        fields = [RequestField('k', b'v',
+                               filename='somefile.txt',
+                               headers={'Content-Type': 'image/jpeg'})]
 
         encoded, content_type = encode_multipart_formdata(fields, boundary=BOUNDARY)
         expected = (b'--' + b(BOUNDARY) + b'\r\n'

--- a/test/test_no_ssl.py
+++ b/test/test_no_ssl.py
@@ -81,9 +81,9 @@ class TestImportWithoutSSL(TestWithoutSSL):
         # importlib.
         # 'import' inside 'lambda' is invalid syntax.
         def import_ssl():
-            import ssl
+            import ssl  # noqa: F401
 
         self.assertRaises(ImportError, import_ssl)
 
     def test_import_urllib3(self):
-        import urllib3
+        import urllib3  # noqa: F401

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -75,7 +75,6 @@ class TestPoolManager(unittest.TestCase):
 
         self.assertEqual(len(p.pools), 0)
 
-
     def test_nohost(self):
         p = PoolManager(5)
         self.assertRaises(LocationValueError, p.connection_from_url, 'http://@')

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -7,6 +7,7 @@ import urllib3
 from urllib3.exceptions import EmptyPoolError
 from urllib3.packages.six.moves import queue
 
+
 class BadError(Exception):
     """
     This should not be raised.

--- a/test/test_queue_monkeypatch.py
+++ b/test/test_queue_monkeypatch.py
@@ -23,7 +23,7 @@ class TestMonkeypatchResistance(unittest.TestCase):
     def test_queue_monkeypatching(self):
         with mock.patch.object(queue, 'Empty', BadError):
             http = urllib3.HTTPConnectionPool(host="localhost", block=True)
-            first_conn = http._get_conn(timeout=1)
+            http._get_conn(timeout=1)
             self.assertRaises(EmptyPoolError, http._get_conn, timeout=1)
 
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -176,7 +176,7 @@ class TestResponse(unittest.TestCase):
         resp2.close()
         self.assertEqual(resp2.closed, True)
 
-        #also try when only data is present.
+        # also try when only data is present.
         resp3 = HTTPResponse('foodata')
         self.assertRaises(IOError, resp3.fileno)
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -275,7 +275,7 @@ class TestResponse(unittest.TestCase):
 
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'gzip'},
-                         preload_content=False)
+                            preload_content=False)
         stream = resp.stream(2)
 
         self.assertEqual(next(stream), b'f')
@@ -291,7 +291,7 @@ class TestResponse(unittest.TestCase):
 
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'gzip'},
-                         preload_content=False)
+                            preload_content=False)
         stream = resp.stream()
 
         # Read everything
@@ -360,7 +360,7 @@ class TestResponse(unittest.TestCase):
 
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'deflate'},
-                         preload_content=False)
+                            preload_content=False)
         stream = resp.stream(2)
 
         self.assertEqual(next(stream), b'f')
@@ -375,7 +375,7 @@ class TestResponse(unittest.TestCase):
 
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'deflate'},
-                         preload_content=False)
+                            preload_content=False)
         stream = resp.stream(2)
 
         self.assertEqual(next(stream), b'f')
@@ -698,7 +698,7 @@ class MockChunkedEncodingWithoutCRLFOnEnd(MockChunkedEncodingResponse):
 
     def _encode_chunk(self, chunk):
         return '%X\r\n%s%s' % (len(chunk), chunk.decode(),
-            "\r\n" if len(chunk) > 0 else "")
+                               "\r\n" if len(chunk) > 0 else "")
 
 
 class MockChunkedEncodingWithExtensions(MockChunkedEncodingResponse):

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -119,7 +119,6 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(r.read(), b'')
         self.assertEqual(r.read(), b'')
 
-
     def test_chunked_decoding_deflate2(self):
         import zlib
         compress = zlib.compressobj(6, zlib.DEFLATED, -zlib.MAX_WBITS)
@@ -136,7 +135,6 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(r.read(), b'')
         self.assertEqual(r.read(), b'')
 
-
     def test_chunked_decoding_gzip(self):
         import zlib
         compress = zlib.compressobj(6, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
@@ -152,7 +150,6 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(r.read(2), b'oo')
         self.assertEqual(r.read(), b'')
         self.assertEqual(r.read(), b'')
-
 
     def test_body_blob(self):
         resp = HTTPResponse(b'foo')
@@ -232,7 +229,6 @@ class TestResponse(unittest.TestCase):
         # in `test_io_bufferedreader` like it does for all the other python
         # versions.  Probably this is because the `io` module in py2.6 is an
         # old version that has a different underlying implementation.
-
 
         fp = BytesIO(b'foo')
         resp = HTTPResponse(fp, preload_content=False)

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -103,15 +103,15 @@ class RetryTest(unittest.TestCase):
         max_backoff = Retry.BACKOFF_MAX
 
         retry = Retry(total=100, backoff_factor=0.2)
-        self.assertEqual(retry.get_backoff_time(), 0) # First request
+        self.assertEqual(retry.get_backoff_time(), 0)  # First request
 
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 0) # First retry
+        self.assertEqual(retry.get_backoff_time(), 0)  # First retry
 
         retry = retry.increment(method='GET')
         self.assertEqual(retry.backoff_factor, 0.2)
         self.assertEqual(retry.total, 98)
-        self.assertEqual(retry.get_backoff_time(), 0.4) # Start backoff
+        self.assertEqual(retry.get_backoff_time(), 0.4)  # Start backoff
 
         retry = retry.increment(method='GET')
         self.assertEqual(retry.get_backoff_time(), 0.8)

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -151,7 +151,7 @@ class RetryTest(unittest.TestCase):
         retry.sleep()
 
     def test_status_forcelist(self):
-        retry = Retry(status_forcelist=xrange(500,600))
+        retry = Retry(status_forcelist=xrange(500, 600))
         self.assertFalse(retry.is_retry('GET', status_code=200))
         self.assertFalse(retry.is_retry('GET', status_code=400))
         self.assertTrue(retry.is_retry('GET', status_code=500))

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -187,7 +187,8 @@ class RetryTest(unittest.TestCase):
     def test_error_message(self):
         retry = Retry(total=0)
         try:
-            retry = retry.increment(method='GET', error=ReadTimeoutError(None, "/", "read timed out"))
+            retry = retry.increment(method='GET',
+                                    error=ReadTimeoutError(None, "/", "read timed out"))
             raise AssertionError("Should have raised a MaxRetryError")
         except MaxRetryError as e:
             assert 'Caused by redirect' not in str(e)
@@ -229,16 +230,21 @@ class RetryTest(unittest.TestCase):
         self.assertEqual(retry.history, tuple())
         connection_error = ConnectTimeoutError('conntimeout')
         retry = retry.increment('GET', '/test1', None, connection_error)
-        self.assertEqual(retry.history, (RequestHistory('GET', '/test1', connection_error, None, None),))
+        history = (RequestHistory('GET', '/test1', connection_error, None, None),)
+        self.assertEqual(retry.history, history)
+
         read_error = ReadTimeoutError(None, "/test2", "read timed out")
         retry = retry.increment('POST', '/test2', None, read_error)
-        self.assertEqual(retry.history, (RequestHistory('GET', '/test1', connection_error, None, None),
-                                         RequestHistory('POST', '/test2', read_error, None, None)))
+        history = (RequestHistory('GET', '/test1', connection_error, None, None),
+                   RequestHistory('POST', '/test2', read_error, None, None))
+        self.assertEqual(retry.history, history)
+
         response = HTTPResponse(status=500)
         retry = retry.increment('GET', '/test3', response, None)
-        self.assertEqual(retry.history, (RequestHistory('GET', '/test1', connection_error, None, None),
-                                         RequestHistory('POST', '/test2', read_error, None, None),
-                                         RequestHistory('GET', '/test3', None, 500, None)))
+        history = (RequestHistory('GET', '/test1', connection_error, None, None),
+                   RequestHistory('POST', '/test2', read_error, None, None),
+                   RequestHistory('GET', '/test3', None, 500, None))
+        self.assertEqual(retry.history, history)
 
     def test_retry_method_not_in_whitelist(self):
         error = ReadTimeoutError(None, "/", "read timed out")

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -9,10 +9,10 @@ import time
 import threading
 
 try:  # Python 2.6 unittest module doesn't have skip decorators.
-    from unittest import skip, skipIf, skipUnless
+    from unittest import skipIf, skipUnless
     import unittest
 except ImportError:
-    from unittest2 import skip, skipIf, skipUnless
+    from unittest2 import skipIf, skipUnless
     import unittest2 as unittest
 
 try:  # Python 2.x doesn't define time.perf_counter.
@@ -123,7 +123,7 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
     SELECTOR = selectors.DefaultSelector
 
     def make_socketpair(self):
-        rd, wr = socket.socketpair()
+        rd, wr = socketpair()
 
         # Make non-blocking so we get errors if the
         # sockets are interacted with but not ready.

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -536,7 +536,7 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
         after_fds = len(proc.open_files())
         self.assertEqual(before_fds, after_fds)
 
-    def test_selector_error(self):
+    def test_selector_error_exception(self):
         err = selectors.SelectorError(1)
         self.assertEqual(err.__repr__(), "<SelectorError errno=1>")
         self.assertEqual(err.__str__(), "<SelectorError errno=1>")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -47,6 +47,7 @@ from . import clear_warnings
 # numbers used for timeouts
 TIMEOUT_EPOCH = 1000
 
+
 class TestUtil(unittest.TestCase):
     def test_get_host(self):
         url_host_map = {

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -371,7 +371,6 @@ class TestUtil(unittest.TestCase):
         except ValueError as e:
             self.assertTrue('int, float or None' in str(e))
 
-
     @patch('urllib3.util.timeout.current_time')
     def test_timeout(self, current_time):
         timeout = Timeout(total=3)
@@ -411,13 +410,11 @@ class TestUtil(unittest.TestCase):
         timeout = Timeout(5)
         self.assertEqual(timeout.total, 5)
 
-
     def test_timeout_str(self):
         timeout = Timeout(connect=1, read=2, total=3)
         self.assertEqual(str(timeout), "Timeout(connect=1, read=2, total=3)")
         timeout = Timeout(connect=1, read=None, total=3)
         self.assertEqual(str(timeout), "Timeout(connect=1, read=None, total=3)")
-
 
     @patch('urllib3.util.timeout.current_time')
     def test_timeout_elapsed(self, current_time):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -143,39 +143,39 @@ class TestUtil(unittest.TestCase):
             actual_normalized_url = parse_url(url).url
             self.assertEqual(actual_normalized_url, expected_normalized_url)
 
-    parse_url_host_map = {
-        'http://google.com/mail': Url('http', host='google.com', path='/mail'),
-        'http://google.com/mail/': Url('http', host='google.com', path='/mail/'),
-        'http://google.com/mail': Url('http', host='google.com', path='mail'),
-        'google.com/mail': Url(host='google.com', path='/mail'),
-        'http://google.com/': Url('http', host='google.com', path='/'),
-        'http://google.com': Url('http', host='google.com'),
-        'http://google.com?foo': Url('http', host='google.com', path='', query='foo'),
+    parse_url_host_map = [
+        ('http://google.com/mail', Url('http', host='google.com', path='/mail')),
+        ('http://google.com/mail/', Url('http', host='google.com', path='/mail/')),
+        ('http://google.com/mail', Url('http', host='google.com', path='mail')),
+        ('google.com/mail', Url(host='google.com', path='/mail')),
+        ('http://google.com/', Url('http', host='google.com', path='/')),
+        ('http://google.com', Url('http', host='google.com')),
+        ('http://google.com?foo', Url('http', host='google.com', path='', query='foo')),
 
         # Path/query/fragment
-        '': Url(),
-        '/': Url(path='/'),
-        '#?/!google.com/?foo#bar': Url(path='', fragment='?/!google.com/?foo#bar'),
-        '/foo': Url(path='/foo'),
-        '/foo?bar=baz': Url(path='/foo', query='bar=baz'),
-        '/foo?bar=baz#banana?apple/orange': Url(path='/foo',
-                                                query='bar=baz',
-                                                fragment='banana?apple/orange'),
+        ('', Url()),
+        ('/', Url(path='/')),
+        ('#?/!google.com/?foo#bar', Url(path='', fragment='?/!google.com/?foo#bar')),
+        ('/foo', Url(path='/foo')),
+        ('/foo?bar=baz', Url(path='/foo', query='bar=baz')),
+        ('/foo?bar=baz#banana?apple/orange', Url(path='/foo',
+                                                 query='bar=baz',
+                                                 fragment='banana?apple/orange')),
 
         # Port
-        'http://google.com/': Url('http', host='google.com', path='/'),
-        'http://google.com:80/': Url('http', host='google.com', port=80, path='/'),
-        'http://google.com:80': Url('http', host='google.com', port=80),
+        ('http://google.com/', Url('http', host='google.com', path='/')),
+        ('http://google.com:80/', Url('http', host='google.com', port=80, path='/')),
+        ('http://google.com:80', Url('http', host='google.com', port=80)),
 
         # Auth
-        'http://foo:bar@localhost/': Url('http', auth='foo:bar', host='localhost', path='/'),
-        'http://foo@localhost/': Url('http', auth='foo', host='localhost', path='/'),
-        'http://foo:bar@baz@localhost/': Url('http',
-                                             auth='foo:bar@baz',
-                                             host='localhost',
-                                             path='/'),
-        'http://@': Url('http', host=None, auth='')
-    }
+        ('http://foo:bar@localhost/', Url('http', auth='foo:bar', host='localhost', path='/')),
+        ('http://foo@localhost/', Url('http', auth='foo', host='localhost', path='/')),
+        ('http://foo:bar@baz@localhost/', Url('http',
+                                              auth='foo:bar@baz',
+                                              host='localhost',
+                                              path='/')),
+        ('http://@', Url('http', host=None, auth=''))
+    ]
 
     non_round_tripping_parse_url_host_map = {
         # Path/query/fragment
@@ -189,13 +189,13 @@ class TestUtil(unittest.TestCase):
         }
 
     def test_parse_url(self):
-        for url, expected_Url in chain(self.parse_url_host_map.items(),
+        for url, expected_Url in chain(self.parse_url_host_map,
                                        self.non_round_tripping_parse_url_host_map.items()):
             returned_Url = parse_url(url)
             self.assertEqual(returned_Url, expected_Url)
 
     def test_unparse_url(self):
-        for url, expected_Url in self.parse_url_host_map.items():
+        for url, expected_Url in self.parse_url_host_map:
             self.assertEqual(url, expected_Url.url)
 
     def test_parse_url_invalid_IPv6(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -83,8 +83,10 @@ class TestUtil(unittest.TestCase):
             'http://[2a00:1450:4001:c01::67]:80/test': ('http', '[2a00:1450:4001:c01::67]', 80),
 
             # More IPv6 from http://www.ietf.org/rfc/rfc2732.txt
-            'http://[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:8000/index.html': ('http', '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]', 8000),
-            'http://[1080:0:0:0:8:800:200c:417a]/index.html': ('http', '[1080:0:0:0:8:800:200c:417a]', None),
+            'http://[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:8000/index.html': (
+                'http', '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]', 8000),
+            'http://[1080:0:0:0:8:800:200c:417a]/index.html': (
+                'http', '[1080:0:0:0:8:800:200c:417a]', None),
             'http://[3ffe:2a00:100:7031::1]': ('http', '[3ffe:2a00:100:7031::1]', None),
             'http://[1080::8:800:200c:417a]/foo': ('http', '[1080::8:800:200c:417a]', None),
             'http://[::192.9.5.5]/ipng': ('http', '[::192.9.5.5]', None),
@@ -119,8 +121,10 @@ class TestUtil(unittest.TestCase):
             '173.194.35.7': ('http', '173.194.35.7', None),
             'HTTP://173.194.35.7': ('http', '173.194.35.7', None),
             'HTTP://[2a00:1450:4001:c01::67]:80/test': ('http', '[2a00:1450:4001:c01::67]', 80),
-            'HTTP://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8000/index.html': ('http', '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]', 8000),
-            'HTTPS://[1080:0:0:0:8:800:200c:417A]/index.html': ('https', '[1080:0:0:0:8:800:200c:417a]', None),
+            'HTTP://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8000/index.html': (
+                'http', '[fedc:ba98:7654:3210:fedc:ba98:7654:3210]', 8000),
+            'HTTPS://[1080:0:0:0:8:800:200c:417A]/index.html': (
+                'https', '[1080:0:0:0:8:800:200c:417a]', None),
         }
         for url, expected_host in url_host_map.items():
             returned_host = get_host(url)
@@ -130,7 +134,8 @@ class TestUtil(unittest.TestCase):
         """Assert parse_url normalizes the scheme/host, and only the scheme/host"""
         test_urls = [
             ('HTTP://GOOGLE.COM/MAIL/', 'http://google.com/MAIL/'),
-            ('HTTP://JeremyCline:Hunter2@Example.com:8080/', 'http://JeremyCline:Hunter2@example.com:8080/'),
+            ('HTTP://JeremyCline:Hunter2@Example.com:8080/',
+             'http://JeremyCline:Hunter2@example.com:8080/'),
             ('HTTPS://Example.Com/?Key=Value', 'https://example.com/?Key=Value'),
             ('Https://Example.Com/#Fragment', 'https://example.com/#Fragment'),
         ]
@@ -153,7 +158,9 @@ class TestUtil(unittest.TestCase):
         '#?/!google.com/?foo#bar': Url(path='', fragment='?/!google.com/?foo#bar'),
         '/foo': Url(path='/foo'),
         '/foo?bar=baz': Url(path='/foo', query='bar=baz'),
-        '/foo?bar=baz#banana?apple/orange': Url(path='/foo', query='bar=baz', fragment='banana?apple/orange'),
+        '/foo?bar=baz#banana?apple/orange': Url(path='/foo',
+                                                query='bar=baz',
+                                                fragment='banana?apple/orange'),
 
         # Port
         'http://google.com/': Url('http', host='google.com', path='/'),
@@ -163,7 +170,10 @@ class TestUtil(unittest.TestCase):
         # Auth
         'http://foo:bar@localhost/': Url('http', auth='foo:bar', host='localhost', path='/'),
         'http://foo@localhost/': Url('http', auth='foo', host='localhost', path='/'),
-        'http://foo:bar@baz@localhost/': Url('http', auth='foo:bar@baz', host='localhost', path='/'),
+        'http://foo:bar@baz@localhost/': Url('http',
+                                             auth='foo:bar@baz',
+                                             host='localhost',
+                                             path='/'),
         'http://@': Url('http', host=None, auth='')
     }
 
@@ -179,7 +189,8 @@ class TestUtil(unittest.TestCase):
         }
 
     def test_parse_url(self):
-        for url, expected_Url in chain(self.parse_url_host_map.items(), self.non_round_tripping_parse_url_host_map.items()):
+        for url, expected_Url in chain(self.parse_url_host_map.items(),
+                                       self.non_round_tripping_parse_url_host_map.items()):
             returned_Url = parse_url(url)
             self.assertEqual(returned_Url, expected_Url)
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -306,7 +306,7 @@ class TestUtil(unittest.TestCase):
             self.assertEqual(output, expected)
 
     def test_add_stderr_logger(self):
-        handler = add_stderr_logger(level=logging.INFO) # Don't actually print debug
+        handler = add_stderr_logger(level=logging.INFO)  # Don't actually print debug
         logger = logging.getLogger('urllib3')
         self.assertTrue(handler in logger.handlers)
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -29,7 +29,6 @@ from urllib3.exceptions import (
     LocationParseError,
     TimeoutStateError,
     InsecureRequestWarning,
-    SSLError,
     SNIMissingWarning,
     InvalidHeader,
     UnrewindableBodyError,

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -28,7 +28,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self.start_chunked_handler()
         chunks = ['foo', 'bar', '', 'bazzzzzzzzzzzzzzzzzzzzzz']
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
-        r = pool.urlopen('GET', '/', chunks, headers=dict(DNT='1'), chunked=True)
+        pool.urlopen('GET', '/', chunks, headers=dict(DNT='1'), chunked=True)
 
         self.assertTrue(b'Transfer-Encoding' in self.buffer)
         body = self.buffer.split(b'\r\n\r\n', 1)[1]
@@ -42,7 +42,7 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
     def _test_body(self, data):
         self.start_chunked_handler()
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
-        r = pool.urlopen('GET', '/', data, chunked=True)
+        pool.urlopen('GET', '/', data, chunked=True)
         header, body = self.buffer.split(b'\r\n\r\n', 1)
 
         self.assertTrue(b'Transfer-Encoding: chunked' in header.split(b'\r\n'))

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -871,6 +871,7 @@ class TestRetryAfter(HTTPDummyServerTestCase):
         self.assertEqual(r.status, 200)
         self.assertTrue(delta < 1)
 
+
 class TestFileBodiesOnRetryOrRedirect(HTTPDummyServerTestCase):
     def setUp(self):
         self.pool = HTTPConnectionPool(self.host, self.port, timeout=0.1)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -928,5 +928,6 @@ class TestFileBodiesOnRetryOrRedirect(HTTPDummyServerTestCase):
         except UnrewindableBodyError as e:
             self.assertTrue('Unable to record file position for' in str(e))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -571,7 +571,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(pool.num_connections, 1)
 
     def test_for_double_release(self):
-        MAXSIZE=5
+        MAXSIZE = 5
 
         # Check default state
         pool = HTTPConnectionPool(self.host, self.port, maxsize=MAXSIZE)
@@ -601,7 +601,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         self.assertEqual(pool.pool.qsize(), MAXSIZE-2)
 
     def test_release_conn_parameter(self):
-        MAXSIZE=5
+        MAXSIZE = 5
         pool = HTTPConnectionPool(self.host, self.port, maxsize=MAXSIZE)
         self.assertEqual(pool.pool.qsize(), MAXSIZE)
 

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1,4 +1,3 @@
-import errno
 import io
 import logging
 import socket
@@ -7,13 +6,9 @@ import unittest
 import time
 import warnings
 
-from datetime import datetime
-from datetime import timedelta
-
 import mock
 
 from .. import (
-    requires_network, onlyPy3, onlyPy26OrOlder,
     TARPIT_HOST, VALID_SOURCE_ADDRESSES, INVALID_SOURCE_ADDRESSES,
 )
 from ..port_helpers import find_unused_port
@@ -27,7 +22,6 @@ from urllib3.exceptions import (
     DecodeError,
     MaxRetryError,
     ReadTimeoutError,
-    ProtocolError,
     NewConnectionError,
     UnrewindableBodyError,
 )

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -923,7 +923,7 @@ class TestFileBodiesOnRetryOrRedirect(HTTPDummyServerTestCase):
         # which is unsupported by BytesIO.
         headers = {'Content-Length': '8'}
         try:
-            resp = self.pool.urlopen('PUT', url, headers=headers, body=body)
+            self.pool.urlopen('PUT', url, headers=headers, body=body)
             self.fail('PUT successful despite failed rewind.')
         except UnrewindableBodyError as e:
             self.assertTrue('Unable to record file position for' in str(e))

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -65,11 +65,11 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, timeout=SHORT_TIMEOUT, retries=False)
         wait_for_socket(ready_event)
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/')
-        block_event.set() # Release block
+        block_event.set()  # Release block
 
         # Shouldn't raise this time
         wait_for_socket(ready_event)
-        block_event.set() # Pre-release block
+        block_event.set()  # Pre-release block
         pool.request('GET', '/')
 
     def test_conn_closed(self):
@@ -103,12 +103,12 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         conn = pool._get_conn()
         self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', '/')
         pool._put_conn(conn)
-        block_event.set() # Release request
+        block_event.set()  # Release request
 
         wait_for_socket(ready_event)
         block_event.clear()
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/')
-        block_event.set() # Release request
+        block_event.set()  # Release request
 
         # Request-specific timeouts should raise errors
         pool = HTTPConnectionPool(self.host, self.port, timeout=LONG_TIMEOUT, retries=False)
@@ -118,7 +118,7 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         now = time.time()
         self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', '/', timeout=timeout)
         delta = time.time() - now
-        block_event.set() # Release request
+        block_event.set()  # Release request
 
         self.assertTrue(delta < LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
         pool._put_conn(conn)
@@ -129,19 +129,19 @@ class TestConnectionPoolTimeouts(SocketDummyServerTestCase):
         delta = time.time() - now
 
         self.assertTrue(delta < LONG_TIMEOUT, "timeout was pool-level LONG_TIMEOUT rather than request-level SHORT_TIMEOUT")
-        block_event.set() # Release request
+        block_event.set()  # Release request
 
         # Timeout int/float passed directly to request and _make_request should
         # raise a request timeout
         wait_for_socket(ready_event)
         self.assertRaises(ReadTimeoutError, pool.request, 'GET', '/', timeout=SHORT_TIMEOUT)
-        block_event.set() # Release request
+        block_event.set()  # Release request
 
         wait_for_socket(ready_event)
         conn = pool._new_conn()
         # FIXME: This assert flakes sometimes. Not sure why.
         self.assertRaises(ReadTimeoutError, pool._make_request, conn, 'GET', '/', timeout=SHORT_TIMEOUT)
-        block_event.set() # Release request
+        block_event.set()  # Release request
 
     def test_connect_timeout(self):
         url = '/'
@@ -363,7 +363,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         conn = pool._get_conn()
         try:
             conn.set_tunnel(self.host, self.port)
-        except AttributeError: # python 2.6
+        except AttributeError:  # python 2.6
             conn._set_tunnel(self.host, self.port)
 
         conn._tunnel = mock.Mock(return_value=None)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -206,12 +206,12 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
     def test_get(self):
         r = self.pool.request('GET', '/specific_method',
-                               fields={'method': 'GET'})
+                              fields={'method': 'GET'})
         self.assertEqual(r.status, 200, r.data)
 
     def test_post_url(self):
         r = self.pool.request('POST', '/specific_method',
-                               fields={'method': 'POST'})
+                              fields={'method': 'POST'})
         self.assertEqual(r.status, 200, r.data)
 
     def test_urlopen_put(self):
@@ -221,11 +221,11 @@ class TestConnectionPool(HTTPDummyServerTestCase):
     def test_wrong_specific_method(self):
         # To make sure the dummy server is actually returning failed responses
         r = self.pool.request('GET', '/specific_method',
-                               fields={'method': 'POST'})
+                              fields={'method': 'POST'})
         self.assertEqual(r.status, 400, r.data)
 
         r = self.pool.request('POST', '/specific_method',
-                               fields={'method': 'GET'})
+                              fields={'method': 'GET'})
         self.assertEqual(r.status, 400, r.data)
 
     def test_upload(self):
@@ -456,8 +456,8 @@ class TestConnectionPool(HTTPDummyServerTestCase):
     def test_post_with_multipart(self):
         data = {'banana': 'hammock', 'lol': 'cat'}
         r = self.pool.request('POST', '/echo',
-                                    fields=data,
-                                    encode_multipart=True)
+                              fields=data,
+                              encode_multipart=True)
         body = r.data.split(b'\r\n')
 
         encoded_data = encode_multipart_formdata(data)[0]
@@ -480,13 +480,13 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
     def test_check_gzip(self):
         r = self.pool.request('GET', '/encodingrequest',
-                                   headers={'accept-encoding': 'gzip'})
+                              headers={'accept-encoding': 'gzip'})
         self.assertEqual(r.headers.get('content-encoding'), 'gzip')
         self.assertEqual(r.data, b'hello, world!')
 
     def test_check_deflate(self):
         r = self.pool.request('GET', '/encodingrequest',
-                                   headers={'accept-encoding': 'deflate'})
+                              headers={'accept-encoding': 'deflate'})
         self.assertEqual(r.headers.get('content-encoding'), 'deflate')
         self.assertEqual(r.data, b'hello, world!')
 
@@ -553,7 +553,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
         try:
             r2 = pool.request('POST', '/echo', fields=req2_data, multipart_boundary=boundary,
-                                    preload_content=False, pool_timeout=0.001)
+                              preload_content=False, pool_timeout=0.001)
 
             # This branch should generally bail here, but maybe someday it will
             # work? Perhaps by some sort of magic. Consider it a TODO.

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -626,7 +626,7 @@ class TestConnectionPool(HTTPDummyServerTestCase):
                               NoIPv6Warning)
                 continue
             pool = HTTPConnectionPool(self.host, self.port,
-                    source_address=addr, retries=False)
+                                      source_address=addr, retries=False)
             r = pool.request('GET', '/source_address')
             self.assertEqual(r.data, b(addr[0]))
 
@@ -678,7 +678,9 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             # url. We won't get a response for this  and so the
             # conn won't be implicitly returned to the pool.
             self.assertRaises(MaxRetryError,
-                http.request, 'GET', '/redirect', fields={'target': '/'}, release_conn=False, retries=0)
+                              http.request,
+                              'GET', '/redirect',
+                              fields={'target': '/'}, release_conn=False, retries=0)
 
             r = http.request('GET', '/redirect', fields={'target': '/'}, release_conn=False, retries=1)
             r.release_conn()
@@ -699,8 +701,8 @@ class TestRetry(HTTPDummyServerTestCase):
     def test_max_retry(self):
         try:
             r = self.pool.request('GET', '/redirect',
-                              fields={'target': '/'},
-                              retries=0)
+                                  fields={'target': '/'},
+                                  retries=0)
             self.fail("Failed to raise MaxRetryError exception, returned %r" % r.status)
         except MaxRetryError:
             pass
@@ -817,37 +819,37 @@ class TestRetryAfter(HTTPDummyServerTestCase):
     def test_retry_after(self):
         # Request twice in a second to get a 429 response.
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': '429 Too Many Requests'},
-                retries=False)
+                              fields={'status': '429 Too Many Requests'},
+                              retries=False)
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': '429 Too Many Requests'},
-                retries=False)
+                              fields={'status': '429 Too Many Requests'},
+                              retries=False)
         self.assertEqual(r.status, 429)
 
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': '429 Too Many Requests'},
-                retries=True)
+                              fields={'status': '429 Too Many Requests'},
+                              retries=True)
         self.assertEqual(r.status, 200)
 
         # Request twice in a second to get a 503 response.
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': '503 Service Unavailable'},
-                retries=False)
+                              fields={'status': '503 Service Unavailable'},
+                              retries=False)
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': '503 Service Unavailable'},
-                retries=False)
+                              fields={'status': '503 Service Unavailable'},
+                              retries=False)
         self.assertEqual(r.status, 503)
 
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': '503 Service Unavailable'},
-                retries=True)
+                              fields={'status': '503 Service Unavailable'},
+                              retries=True)
         self.assertEqual(r.status, 200)
 
         # Ignore Retry-After header on status which is not defined in
         # Retry.RETRY_AFTER_STATUS_CODES.
         r = self.pool.request('GET', '/retry_after',
-                fields={'status': "418 I'm a teapot"},
-                retries=True)
+                              fields={'status': "418 I'm a teapot"},
+                              retries=True)
         self.assertEqual(r.status, 418)
 
     def test_redirect_after(self):

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -21,7 +21,6 @@ from test import (
     onlyPy279OrNewer,
     requires_network,
     TARPIT_HOST,
-    clear_warnings,
 )
 from urllib3 import HTTPSConnectionPool
 from urllib3.connection import (
@@ -31,7 +30,6 @@ from urllib3.connection import (
 )
 from urllib3.exceptions import (
     SSLError,
-    ReadTimeoutError,
     ConnectTimeoutError,
     InsecureRequestWarning,
     SystemTimeWarning,

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -428,8 +428,9 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
         conn = VerifiedHTTPSConnection(self.host, self.port)
         https_pool = HTTPSConnectionPool(self.host, self.port,
-                cert_reqs='CERT_REQUIRED', ca_certs=DEFAULT_CA,
-                assert_fingerprint=fingerprint)
+                                         cert_reqs='CERT_REQUIRED',
+                                         ca_certs=DEFAULT_CA,
+                                         assert_fingerprint=fingerprint)
 
         https_pool._make_request(conn, 'GET', '/')
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -381,7 +381,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         conn = https_pool._new_conn()
         try:
             conn.set_tunnel(self.host, self.port)
-        except AttributeError: # python 2.6
+        except AttributeError:  # python 2.6
             conn._set_tunnel(self.host, self.port)
         conn._tunnel = mock.Mock()
         https_pool._make_request(conn, 'GET', '/')

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -52,7 +52,6 @@ log.setLevel(logging.NOTSET)
 log.addHandler(logging.StreamHandler(sys.stdout))
 
 
-
 class TestHTTPS(HTTPSDummyServerTestCase):
     def setUp(self):
         self._pool = HTTPSConnectionPool(self.host, self.port)

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -208,5 +208,6 @@ class TestIPv6PoolManager(IPv6HTTPDummyServerTestCase):
         http = PoolManager()
         http.request('GET', self.base_url)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -42,7 +42,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
         self.assertEqual(r.status, 303)
 
         r = http.request('GET', '%s/redirect' % self.base_url,
-                         fields={'target': '%s/redirect?target=%s/' % (self.base_url, self.base_url)})
+                         fields={'target': '%s/redirect?target=%s/' % (self.base_url,
+                                                                       self.base_url)})
 
         self.assertEqual(r.status, 200)
         self.assertEqual(r.data, b'Dummy server!')
@@ -86,7 +87,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         try:
             r = http.request('GET', '%s/redirect' % self.base_url,
-                             fields={'target': '%s/redirect?target=%s/' % (self.base_url, self.base_url)},
+                             fields={'target': '%s/redirect?target=%s/' % (self.base_url,
+                                                                           self.base_url)},
                              retries=1)
             self.fail("Failed to raise MaxRetryError exception, returned %r" % r.status)
         except MaxRetryError:
@@ -94,7 +96,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
 
         try:
             r = http.request('GET', '%s/redirect' % self.base_url,
-                             fields={'target': '%s/redirect?target=%s/' % (self.base_url, self.base_url)},
+                             fields={'target': '%s/redirect?target=%s/' % (self.base_url,
+                                                                           self.base_url)},
                              retries=Retry(total=None, redirect=1))
             self.fail("Failed to raise MaxRetryError exception, returned %r" % r.status)
         except MaxRetryError:
@@ -104,7 +107,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
         http = PoolManager()
 
         r = http.request('GET', '%s/redirect' % self.base_url,
-                         fields={'target': '%s/redirect?target=%s/' % (self.base_url, self.base_url)},
+                         fields={'target': '%s/redirect?target=%s/' % (self.base_url,
+                                                                       self.base_url)},
                          retries=Retry(total=None, redirect=1, raise_on_redirect=False))
 
         self.assertEqual(r.status, 303)
@@ -125,7 +129,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
             # raise explicitly
             r = http.request('GET', '%s/status' % self.base_url,
                              fields={'status': '500 Internal Server Error'},
-                             retries=Retry(total=1, status_forcelist=range(500, 600), raise_on_status=True))
+                             retries=Retry(total=1,
+                                           status_forcelist=range(500, 600),
+                                           raise_on_status=True))
             self.fail("Failed to raise MaxRetryError exception, returned %r" % r.status)
         except MaxRetryError:
             pass
@@ -133,7 +139,9 @@ class TestPoolManager(HTTPDummyServerTestCase):
         # don't raise
         r = http.request('GET', '%s/status' % self.base_url,
                          fields={'status': '500 Internal Server Error'},
-                         retries=Retry(total=1, status_forcelist=range(500, 600), raise_on_status=False))
+                         retries=Retry(total=1,
+                                       status_forcelist=range(500, 600),
+                                       raise_on_status=False))
 
         self.assertEqual(r.status, 500)
 

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -7,7 +7,7 @@ from dummyserver.testcase import (HTTPDummyServerTestCase,
                                   IPv6HTTPDummyServerTestCase)
 from urllib3.poolmanager import PoolManager
 from urllib3.connectionpool import port_by_scheme
-from urllib3.exceptions import MaxRetryError, SSLError
+from urllib3.exceptions import MaxRetryError
 from urllib3.util.retry import Retry
 
 

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -51,13 +51,13 @@ class TestPoolManager(HTTPDummyServerTestCase):
         http = PoolManager()
 
         r = http.request('GET', '%s/redirect' % self.base_url,
-                         fields = {'target': '/redirect'},
-                         redirect = False)
+                         fields={'target': '/redirect'},
+                         redirect=False)
 
         self.assertEqual(r.status, 303)
 
         r = http.request('GET', '%s/redirect' % self.base_url,
-                         fields = {'target': '/redirect'})
+                         fields={'target': '/redirect'})
 
         self.assertEqual(r.status, 200)
         self.assertEqual(r.data, b'Dummy server!')

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -287,7 +287,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             https.request('GET', self.http_url, timeout=0.001)
             self.fail("Failed to raise retry error.")
         except MaxRetryError as e:
-           self.assertEqual(type(e.reason), ConnectTimeoutError)
+            self.assertEqual(type(e.reason), ConnectTimeoutError)
 
     @timed(0.5)
     @requires_network

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -162,35 +162,35 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.http_host_alt, self.http_port))
+                         '%s:%s' % (self.http_host_alt, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.https_host, self.https_port))
+                         '%s:%s' % (self.https_host, self.https_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.https_host_alt, self.https_port))
+                         '%s:%s' % (self.https_host_alt, self.https_port))
 
         r = http.request_encode_body('POST', '%s/headers' % self.http_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -198,7 +198,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -206,7 +206,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.https_host, self.https_port))
+                         '%s:%s' % (self.https_host, self.https_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -214,7 +214,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s' % (self.http_host, self.http_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -222,7 +222,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                         '%s:%s'%(self.https_host, self.https_port))
+                         '%s:%s' % (self.https_host, self.https_port))
 
     def test_headerdict(self):
         default_headers = HTTPHeaderDict(a='b')

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -244,19 +244,19 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         http = proxy_from_url(self.proxy_url)
 
         for x in range(2):
-            r = http.urlopen('GET', self.http_url)
+            http.urlopen('GET', self.http_url)
         self.assertEqual(len(http.pools), 1)
 
         for x in range(2):
-            r = http.urlopen('GET', self.http_url_alt)
+            http.urlopen('GET', self.http_url_alt)
         self.assertEqual(len(http.pools), 1)
 
         for x in range(2):
-            r = http.urlopen('GET', self.https_url)
+            http.urlopen('GET', self.https_url)
         self.assertEqual(len(http.pools), 2)
 
         for x in range(2):
-            r = http.urlopen('GET', self.https_url_alt)
+            http.urlopen('GET', self.https_url_alt)
         self.assertEqual(len(http.pools), 3)
 
     def test_proxy_pooling_ext(self):

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -331,5 +331,6 @@ class TestIPv6HTTPProxyManager(IPv6HTTPDummyProxyTestCase):
         r = http.request('GET', '%s/' % self.https_url)
         self.assertEqual(r.status, 200)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -154,7 +154,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(r._pool.host, self.https_host)
 
     def test_headers(self):
-        http = proxy_from_url(self.proxy_url,headers={'Foo': 'bar'},
+        http = proxy_from_url(self.proxy_url, headers={'Foo': 'bar'},
                 proxy_headers={'Hickory': 'dickory'})
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url)
@@ -162,35 +162,35 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host_alt,self.http_port))
+                '%s:%s'%(self.http_host_alt, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host,self.https_port))
+                '%s:%s'%(self.https_host, self.https_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host_alt,self.https_port))
+                '%s:%s'%(self.https_host_alt, self.https_port))
 
         r = http.request_encode_body('POST', '%s/headers' % self.http_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -198,7 +198,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -206,7 +206,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host,self.https_port))
+                '%s:%s'%(self.https_host, self.https_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -214,7 +214,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host,self.http_port))
+                '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -222,7 +222,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host,self.https_port))
+                '%s:%s'%(self.https_host, self.https_port))
 
     def test_headerdict(self):
         default_headers = HTTPHeaderDict(a='b')
@@ -265,19 +265,19 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         hc2 = http.connection_from_host(self.http_host, self.http_port)
         hc3 = http.connection_from_url(self.http_url_alt)
         hc4 = http.connection_from_host(self.http_host_alt, self.http_port)
-        self.assertEqual(hc1,hc2)
-        self.assertEqual(hc2,hc3)
-        self.assertEqual(hc3,hc4)
+        self.assertEqual(hc1, hc2)
+        self.assertEqual(hc2, hc3)
+        self.assertEqual(hc3, hc4)
 
         sc1 = http.connection_from_url(self.https_url)
         sc2 = http.connection_from_host(self.https_host,
-                self.https_port,scheme='https')
+                self.https_port, scheme='https')
         sc3 = http.connection_from_url(self.https_url_alt)
         sc4 = http.connection_from_host(self.https_host_alt,
-                self.https_port,scheme='https')
-        self.assertEqual(sc1,sc2)
-        self.assertNotEqual(sc2,sc3)
-        self.assertEqual(sc3,sc4)
+                self.https_port, scheme='https')
+        self.assertEqual(sc1, sc2)
+        self.assertNotEqual(sc2, sc3)
+        self.assertEqual(sc3, sc4)
 
     @timed(0.5)
     @requires_network

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -155,42 +155,42 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
     def test_headers(self):
         http = proxy_from_url(self.proxy_url, headers={'Foo': 'bar'},
-                proxy_headers={'Hickory': 'dickory'})
+                              proxy_headers={'Hickory': 'dickory'})
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host_alt, self.http_port))
+                         '%s:%s'%(self.http_host_alt, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host, self.https_port))
+                         '%s:%s'%(self.https_host, self.https_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url_alt)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host_alt, self.https_port))
+                         '%s:%s'%(self.https_host_alt, self.https_port))
 
         r = http.request_encode_body('POST', '%s/headers' % self.http_url)
         returned_headers = json.loads(r.data.decode())
         self.assertEqual(returned_headers.get('Foo'), 'bar')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -198,7 +198,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_url('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -206,7 +206,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host, self.https_port))
+                         '%s:%s'%(self.https_host, self.https_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.http_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -214,7 +214,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), 'dickory')
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.http_host, self.http_port))
+                         '%s:%s'%(self.http_host, self.http_port))
 
         r = http.request_encode_body('GET', '%s/headers' % self.https_url, headers={'Baz': 'quux'})
         returned_headers = json.loads(r.data.decode())
@@ -222,7 +222,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertEqual(returned_headers.get('Baz'), 'quux')
         self.assertEqual(returned_headers.get('Hickory'), None)
         self.assertEqual(returned_headers.get('Host'),
-                '%s:%s'%(self.https_host, self.https_port))
+                         '%s:%s'%(self.https_host, self.https_port))
 
     def test_headerdict(self):
         default_headers = HTTPHeaderDict(a='b')
@@ -271,10 +271,10 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
 
         sc1 = http.connection_from_url(self.https_url)
         sc2 = http.connection_from_host(self.https_host,
-                self.https_port, scheme='https')
+                                        self.https_port, scheme='https')
         sc3 = http.connection_from_url(self.https_url_alt)
         sc4 = http.connection_from_host(self.https_host_alt,
-                self.https_port, scheme='https')
+                                        self.https_port, scheme='https')
         self.assertEqual(sc1, sc2)
         self.assertNotEqual(sc2, sc3)
         self.assertEqual(sc3, sc4)

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -279,7 +279,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertNotEqual(sc2,sc3)
         self.assertEqual(sc3,sc4)
 
-
     @timed(0.5)
     @requires_network
     def test_https_proxy_timeout(self):
@@ -289,7 +288,6 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
             self.fail("Failed to raise retry error.")
         except MaxRetryError as e:
            self.assertEqual(type(e.reason), ConnectTimeoutError)
-
 
     @timed(0.5)
     @requires_network

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -133,6 +133,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
     def test_connection_read_timeout(self):
         timed_out = Event()
+
         def socket_handler(listener):
             sock = listener.accept()[0]
             while not sock.recv(65536).endswith(b'\r\n\r\n'):
@@ -153,6 +154,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
     def test_read_timeout_dont_retry_method_not_in_whitelist(self):
         timed_out = Event()
+
         def socket_handler(listener):
             sock = listener.accept()[0]
             sock.recv(65536)
@@ -170,6 +172,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
     def test_https_connection_read_timeout(self):
         """ Handshake timeouts should fail with a Timeout"""
         timed_out = Event()
+
         def socket_handler(listener):
             sock = listener.accept()[0]
             while not sock.recv(65536):
@@ -725,6 +728,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                            '\r\n'
                            'Hi').encode('utf-8'))
             ssl_sock.close()
+            
         def echo_socket_handler(listener):
             proxy_ssl_one(listener)
             proxy_ssl_one(listener)

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1153,7 +1153,7 @@ class TestBadContentLength(SocketDummyServerTestCase):
         self._start_server(socket_handler)
         conn = HTTPConnectionPool(self.host, self.port, maxsize=1)
 
-        #Test stream on 0 length body
+        # Test stream on 0 length body
         head_response = conn.request('HEAD', url='/', preload_content=False,
                                      enforce_content_length=True)
         data = [chunk for chunk in head_response.stream(1)]

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -868,6 +868,7 @@ class TestErrorWrapping(SocketDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
         self.assertRaises(ProtocolError, pool.request, 'GET', '/')
 
+
 class TestHeaders(SocketDummyServerTestCase):
 
     @onlyPy3
@@ -1089,6 +1090,7 @@ class TestStream(SocketDummyServerTestCase):
         self.assertEqual([b'hello, world'], list(r.stream(None)))
 
         done_event.set()
+
 
 class TestBadContentLength(SocketDummyServerTestCase):
     def test_enforce_content_length_get(self):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -143,7 +143,11 @@ class TestSocketClosing(SocketDummyServerTestCase):
             sock.close()
 
         self._start_server(socket_handler)
-        http = HTTPConnectionPool(self.host, self.port, timeout=0.001, retries=False, maxsize=3, block=True)
+        http = HTTPConnectionPool(self.host, self.port,
+                                  timeout=0.001,
+                                  retries=False,
+                                  maxsize=3,
+                                  block=True)
 
         try:
             self.assertRaises(ReadTimeoutError, http.request, 'GET', '/', release_conn=False)
@@ -524,7 +528,8 @@ class TestSocketClosing(SocketDummyServerTestCase):
             self.fail("Timed out waiting for connection close")
 
     def test_release_conn_param_is_respected_after_timeout_retry(self):
-        """For successful ```urlopen(release_conn=False)```, the connection isn't released, even after a retry.
+        """For successful ```urlopen(release_conn=False)```,
+        the connection isn't released, even after a retry.
 
         This test allows a retry: one request fails, the next request succeeds.
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -104,10 +104,10 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
                 body = 'Response %d' % i
                 sock.send(('HTTP/1.1 200 OK\r\n'
-                          'Content-Type: text/plain\r\n'
-                          'Content-Length: %d\r\n'
-                          '\r\n'
-                          '%s' % (len(body), body)).encode('utf-8'))
+                           'Content-Type: text/plain\r\n'
+                           'Content-Length: %d\r\n'
+                           '\r\n'
+                           '%s' % (len(body), body)).encode('utf-8'))
 
                 sock.close()  # simulate a server timing out, closing socket
                 done_closing.set()  # let the test know it can proceed
@@ -202,10 +202,10 @@ class TestSocketClosing(SocketDummyServerTestCase):
             # Now respond immediately.
             body = 'Response 2'
             sock.send(('HTTP/1.1 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: %d\r\n'
-                      '\r\n'
-                      '%s' % (len(body), body)).encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       '%s' % (len(body), body)).encode('utf-8'))
 
             sock.close()
 
@@ -324,10 +324,10 @@ class TestSocketClosing(SocketDummyServerTestCase):
             # send unknown http protocol
             body = "bad http 0.5 response"
             sock.send(('HTTP/0.5 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: %d\r\n'
-                      '\r\n'
-                      '%s' % (len(body), body)).encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       '%s' % (len(body), body)).encode('utf-8'))
             sock.close()
 
             # Second request.
@@ -338,10 +338,10 @@ class TestSocketClosing(SocketDummyServerTestCase):
 
             # Now respond immediately.
             sock.send(('HTTP/1.1 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: %d\r\n'
-                      '\r\n'
-                      'foo' % (len('foo'))).encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       'foo' % (len('foo'))).encode('utf-8'))
 
             sock.close()  # Close the socket.
 
@@ -393,13 +393,11 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 buf = sock.recv(65536)
 
             # Send partial response and close socket.
-            sock.send((
-                'HTTP/1.1 200 OK\r\n'
-                'Content-Type: text/plain\r\n'
-                'Content-Length: %d\r\n'
-                '\r\n'
-                '%s' % (len(body), partial_body)).encode('utf-8')
-            )
+            sock.send(('HTTP/1.1 200 OK\r\n'
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       '%s' % (len(body), partial_body)).encode('utf-8'))
             sock.close()
 
         self._start_server(socket_handler)
@@ -495,9 +493,9 @@ class TestSocketClosing(SocketDummyServerTestCase):
                 buf = sock.recv(65536)
 
             sock.send(('HTTP/1.1 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: 0\r\n'
-                      '\r\n').encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: 0\r\n'
+                       '\r\n').encode('utf-8'))
 
             # Wait for the socket to close.
             done_closing.wait(timeout=1)
@@ -595,10 +593,10 @@ class TestProxyManager(SocketDummyServerTestCase):
                 buf += sock.recv(65536)
 
             sock.send(('HTTP/1.1 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: %d\r\n'
-                      '\r\n'
-                      '%s' % (len(buf), buf.decode('utf-8'))).encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       '%s' % (len(buf), buf.decode('utf-8'))).encode('utf-8'))
             sock.close()
 
         self._start_server(echo_socket_handler)
@@ -630,10 +628,10 @@ class TestProxyManager(SocketDummyServerTestCase):
                 buf += sock.recv(65536)
 
             sock.send(('HTTP/1.1 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: %d\r\n'
-                      '\r\n'
-                      '%s' % (len(buf), buf.decode('utf-8'))).encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       '%s' % (len(buf), buf.decode('utf-8'))).encode('utf-8'))
             sock.close()
 
         self._start_server(echo_socket_handler)
@@ -669,10 +667,10 @@ class TestProxyManager(SocketDummyServerTestCase):
                 buf += sock.recv(65536)
 
             sock.send(('HTTP/1.1 200 OK\r\n'
-                      'Content-Type: text/plain\r\n'
-                      'Content-Length: %d\r\n'
-                      '\r\n'
-                      '%s' % (len(buf), buf.decode('utf-8'))).encode('utf-8'))
+                       'Content-Type: text/plain\r\n'
+                       'Content-Length: %d\r\n'
+                       '\r\n'
+                       '%s' % (len(buf), buf.decode('utf-8'))).encode('utf-8'))
             sock.close()
             close_event.set()
 
@@ -688,8 +686,8 @@ class TestProxyManager(SocketDummyServerTestCase):
 
         close_event.wait(timeout=1)
         self.assertRaises(ProxyError, conn.urlopen, 'GET',
-                'http://www.google.com',
-                assert_same_host=False, retries=False)
+                          'http://www.google.com',
+                          assert_same_host=False, retries=False)
 
     def test_connect_reconn(self):
         def proxy_ssl_one(listener):

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -916,7 +916,7 @@ class TestHeaders(SocketDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
         pool.request('GET', '/', headers=HTTPHeaderDict(headers))
         self.assertEqual(expected_headers, parsed_headers)
-    
+
     def test_request_headers_are_sent_in_the_original_order(self):
         # NOTE: Probability this test gives a false negative is 1/(K!)
         K = 16
@@ -924,7 +924,7 @@ class TestHeaders(SocketDummyServerTestCase):
         #       so that if the internal implementation tries to sort them,
         #       a change will be detected.
         expected_request_headers = [(u'X-Header-%d' % i, str(i)) for i in reversed(range(K))]
-        
+
         actual_request_headers = []
 
         def socket_handler(listener):
@@ -954,7 +954,7 @@ class TestHeaders(SocketDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
         pool.request('GET', '/', headers=OrderedDict(expected_request_headers))
         self.assertEqual(expected_request_headers, actual_request_headers)
-    
+
     def test_response_headers_are_returned_in_the_original_order(self):
         # NOTE: Probability this test gives a false negative is 1/(K!)
         K = 16
@@ -962,7 +962,7 @@ class TestHeaders(SocketDummyServerTestCase):
         #       so that if the internal implementation tries to sort them,
         #       a change will be detected.
         expected_response_headers = [('X-Header-%d' % i, str(i)) for i in reversed(range(K))]
-        
+
         def socket_handler(listener):
             sock = listener.accept()[0]
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -70,7 +70,7 @@ class TestSNI(SocketDummyServerTestCase):
         def socket_handler(listener):
             sock = listener.accept()[0]
 
-            self.buf = sock.recv(65536) # We only accept one packet
+            self.buf = sock.recv(65536)  # We only accept one packet
             done_receiving.set()  # let the test know it can proceed
             sock.close()
 
@@ -78,7 +78,7 @@ class TestSNI(SocketDummyServerTestCase):
         pool = HTTPSConnectionPool(self.host, self.port)
         try:
             pool.request('GET', '/', retries=0)
-        except SSLError: # We are violating the protocol
+        except SSLError:  # We are violating the protocol
             pass
         done_receiving.wait()
         self.assertTrue(self.host.encode('ascii') in self.buf,
@@ -884,7 +884,7 @@ class TestHeaders(SocketDummyServerTestCase):
         pool = HTTPConnectionPool(self.host, self.port, retries=False)
         HEADERS = {'Content-Length': '0', 'Content-type': 'text/plain'}
         r = pool.request('GET', '/')
-        self.assertEqual(HEADERS, dict(r.headers.items())) # to preserve case sensitivity
+        self.assertEqual(HEADERS, dict(r.headers.items()))  # to preserve case sensitivity
 
     def test_headers_are_sent_with_the_original_case(self):
         headers = {'foo': 'bar', 'bAz': 'quux'}

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -6,7 +6,6 @@ from urllib3.poolmanager import proxy_from_url
 from urllib3.exceptions import (
         MaxRetryError,
         ProxyError,
-        ConnectTimeoutError,
         ReadTimeoutError,
         SSLError,
         ProtocolError,

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -728,7 +728,7 @@ class TestProxyManager(SocketDummyServerTestCase):
                            '\r\n'
                            'Hi').encode('utf-8'))
             ssl_sock.close()
-            
+
         def echo_socket_handler(listener):
             proxy_ssl_one(listener)
             proxy_ssl_one(listener)

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps=
     flake8
 commands=
     flake8 --version
-    flake8 setup.py docs dummyserver urllib3
+    flake8 setup.py docs dummyserver urllib3 test
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
Work so far on fixing all flake / lint errors in the `test/` directory. Also adds that directory to the list of locations that are checked by `flake8` by the CI.

This PR does not yet check for line too long because of how many instances there are of that error, I will work on that tonight.