### PR TITLE
Fix Python 2.6 builds

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -10,12 +10,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew outdated openssl || brew upgrade openssl
     brew install openssl@1.1
 
-    # We can't use OpenSSL@1.1 for the standard library, because it's
-    # unsupported, but we want it for PyOpenSSL. So use regular openssl here
-    # for now.
-    export LDFLAGS="-L$(brew --prefix openssl)/lib"
-    export CFLAGS="-I$(brew --prefix openssl)/include"
-
     # install pyenv
     git clone --depth 1 https://github.com/yyuu/pyenv.git ~/.pyenv
     PYENV_ROOT="$HOME/.pyenv"

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -9,8 +9,10 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 
-    # Use the good OpenSSL for PyOpenSSL.
-    export LDFLAGS="-L$(brew --prefix openssl@1.1)/lib"
+    # Use the good OpenSSL for PyOpenSSL. This also links it statically into
+    # cryptography, which more accurately reflects the way the wheel is used.
+    export CRYPTOGRAPHY_OSX_NO_LINK_FLAGS="1"
+    export LDFLAGS="$(brew --prefix openssl@1.1)/lib/libcrypto.a $(brew --prefix openssl@1.1)/lib/libssl.a"
     export CFLAGS="-I$(brew --prefix openssl@1.1)/include"
 fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands=
     nosetests []
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
-passenv = CFLAGS LDFLAGS TRAVIS
+passenv = CFLAGS LDFLAGS TRAVIS CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
 
 [testenv:py26]
 # Additional dependency on unittest2 for Python 2.6


### PR DESCRIPTION
So, cryptography currently doesn't have a wheel build for Python 2.6, which is causing our master branch tests to fail. This is because we're setting CFLAGS and LDFLAGS for the original build, which are unfortunately saved and re-used *badly* for subsequent pip builds.

I'm going to try to fix it.