### PR TITLE
Find supported TLS version in tests.

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -41,6 +41,7 @@ from urllib3.util import is_fp_closed, ssl_
 from urllib3.packages import six
 
 from . import clear_warnings
+from .tls_helpers import TLS_VERSION, TLS_VERSION_STRING
 
 # This number represents a time in seconds, it doesn't mean anything in
 # isolation. Setting to a high-ish value to avoid conflicts with the smaller
@@ -455,9 +456,9 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(resolve_cert_reqs('CERT_REQUIRED'), ssl.CERT_REQUIRED)
 
     def test_resolve_ssl_version(self):
-        self.assertEqual(resolve_ssl_version(ssl.PROTOCOL_TLSv1), ssl.PROTOCOL_TLSv1)
-        self.assertEqual(resolve_ssl_version("PROTOCOL_TLSv1"), ssl.PROTOCOL_TLSv1)
-        self.assertEqual(resolve_ssl_version("TLSv1"), ssl.PROTOCOL_TLSv1)
+        self.assertEqual(resolve_ssl_version(TLS_VERSION), TLS_VERSION)
+        self.assertEqual(resolve_ssl_version(TLS_VERSION_STRING), TLS_VERSION)
+        self.assertEqual(resolve_ssl_version(TLS_VERSION_STRING.split('_', 1)[1]), TLS_VERSION)
         self.assertEqual(resolve_ssl_version(ssl.PROTOCOL_SSLv23), ssl.PROTOCOL_SSLv23)
 
     def test_is_fp_closed_object_supports_closed(self):

--- a/test/tls_helpers.py
+++ b/test/tls_helpers.py
@@ -1,0 +1,26 @@
+"""
+These helpers are used with TLS tests, to factor out certain bits of common
+code that are needed for effective TLS testing.
+"""
+import ssl
+
+__all__ = ["TLS_VERSION", "TLS_VERSION_STRING"]
+
+# Several tests use specific TLS versions to confirm that they work. This can
+# be a bit risky, because not all implementations have the same set of TLS
+# versions. For this reason, we pick one early on that *is* present on this
+# implementation and use it.
+_options = [
+    "PROTOCOL_TLSv1_2", "PROTOCOL_TLSv1_1", "PROTOCOL_TLSv1", "PROTOCOL_SSLv3",
+    "PROTOCOL_SSLv2"
+]
+for option in _options:
+    try:
+        TLS_VERSION = getattr(ssl, option)
+    except AttributeError:
+        continue
+    else:
+        TLS_VERSION_STRING = option
+        break
+else:
+    raise ValueError("Unable to find a version of TLS to use")

--- a/test/tls_helpers.py
+++ b/test/tls_helpers.py
@@ -9,10 +9,12 @@ __all__ = ["TLS_VERSION", "TLS_VERSION_STRING"]
 # Several tests use specific TLS versions to confirm that they work. This can
 # be a bit risky, because not all implementations have the same set of TLS
 # versions. For this reason, we pick one early on that *is* present on this
-# implementation and use it.
+# implementation and use it. We also use the *lowest* version that is present
+# because some Python implementations define constants they cannot actually
+# use.
 _options = [
-    "PROTOCOL_TLSv1_2", "PROTOCOL_TLSv1_1", "PROTOCOL_TLSv1", "PROTOCOL_SSLv3",
-    "PROTOCOL_SSLv2"
+    "PROTOCOL_SSLv2", "PROTOCOL_SSLv3", "PROTOCOL_TLSv1", "PROTOCOL_TLSv1_1",
+    "PROTOCOL_TLSv1_2",
 ]
 for option in _options:
     try:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -39,6 +39,8 @@ from urllib3.packages import six
 from urllib3.util.timeout import Timeout
 import urllib3.util as util
 
+from ..tls_helpers import TLS_VERSION
+
 
 ResourceWarning = getattr(
         six.moves.builtins,
@@ -59,8 +61,8 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         r = self._pool.request('GET', '/')
         self.assertEqual(r.status, 200, r.data)
 
-    def test_set_ssl_version_to_tlsv1(self):
-        self._pool.ssl_version = ssl.PROTOCOL_TLSv1
+    def test_set_ssl_version_specific(self):
+        self._pool.ssl_version = TLS_VERSION
         r = self._pool.request('GET', '/')
         self.assertEqual(r.status, 200, r.data)
 
@@ -488,9 +490,9 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         return [x for x in w if not isinstance(x.message, ResourceWarning)]
 
 
-class TestHTTPS_TLSv1(HTTPSDummyServerTestCase):
+class TestHTTPS_SpecificVersion(HTTPSDummyServerTestCase):
     certs = DEFAULT_CERTS.copy()
-    certs['ssl_version'] = ssl.PROTOCOL_TLSv1
+    certs['ssl_version'] = TLS_VERSION
 
     def setUp(self):
         self._pool = HTTPSConnectionPool(self.host, self.port)


### PR DESCRIPTION
Resolves #1114.

This should be a solid forward-looking revision to these tests to ensure that they can run on a variety of systems without difficulty. We shouldn't have tests fail just because OpenSSL has been compiled slightly weirdly, especially as urllib3 itself has no reliance on these constants being present.