### PR TITLE
allow http/https requests through https proxy

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -802,12 +802,21 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         except AttributeError:  # Platform-specific: Python 2.6
             set_tunnel = conn._set_tunnel
 
+        proxy_sock = None
+        if self.proxy.scheme == 'https':
+            self._validate_conn(conn)
+            proxy_sock = conn.sock
+            conn.sock = None
+
         if sys.version_info <= (2, 6, 4) and not self.proxy_headers:  # Python 2.6.4 and older
             set_tunnel(self.host, self.port)
         else:
             set_tunnel(self.host, self.port, self.proxy_headers)
 
-        conn.connect()
+        if proxy_sock is not None:
+            conn.sock = proxy_sock
+        else:
+            conn.connect()
 
     def _new_conn(self):
         """


### PR DESCRIPTION
Fix https://github.com/shazow/urllib3/issues/476

urllib3 http/https examples
```
python -c "print __import__('urllib3').ProxyManager('https://bwg.phus.lu').request('GET', 'http://httpbin.org/ip').data"
python -c "print __import__('urllib3').ProxyManager('https://bwg.phus.lu').request('GET', 'https://httpbin.org/ip').data"
```

requests http/https examples
```
python -c "print __import__('requests').get('http://httpbin.org/ip', proxies={'https': 'https://bwg.phus.lu', 'http': 'https://bwg.phus.lu'}).text"
python -c "print __import__('requests').get('https://httpbin.org/ip', proxies={'https': 'https://bwg.phus.lu', 'http': 'https://bwg.phus.lu'}).text"
```

Signed-off-by: Phus Lu <phuslu@hotmail.com>