### PR TITLE
Wrap OpenSSL SysCallError on send as well as recv

### DIFF
--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -304,6 +304,8 @@ class WrappedSocket(object):
                 if not wr:
                     raise timeout()
                 continue
+            except OpenSSL.SSL.SysCallError as e:
+                raise SocketError(str(e))
 
     def sendall(self, data):
         total_sent = 0


### PR DESCRIPTION
I was having a similar issue as described in #367, occasionally getting "SysCallError: (104, 'Connection reset by peer')" on sending through the requests library. As I understand it, it should be intercepted and wrapped here.