### PR TITLE
Detect monkey-patched select module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ dev (master)
 * Resolved issue where the PyOpenSSL backend would not wrap SysCallError
   exceptions appropriately when sending data. (Pull #1125)
 
+* Selectors now detects a monkey-patched select module after import for modules
+  that patch the select module like eventlet, greenlet. (Pull #1128)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -723,8 +723,8 @@ class TestUniqueSelectScenarios(BaseSelectorTestCase):
     def test_select_module_defines_does_not_implement_poll(self):
         # This test is to make sure that if a platform defines
         # a selector as being available but does not actually
-        # implement it (kennethreitz/requests#3906) does not
-        # make DefaultSelector() fail.
+        # implement it (kennethreitz/requests#3906) then
+        # DefaultSelector() does not fail.
 
         # Reset the _DEFAULT_SELECTOR value as if using for the first time.
         selectors._DEFAULT_SELECTOR = None

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -547,13 +547,13 @@ def _default_selector(*_):
     detect if the select module is being monkey-patched incorrectly
     by eventlet, greenlet, and preserve proper behavior. """
     global DefaultSelector
-    if hasattr(select, 'kqueue'):
+    if hasattr(select, 'kqueue'):  # Platform-specific: Mac OS
         selector_type = KqueueSelector
-    elif hasattr(select, 'epoll'):
+    elif hasattr(select, 'epoll'):  # Platform-specific: Linux
         selector_type = EpollSelector
-    elif hasattr(select, 'poll'):
+    elif hasattr(select, 'poll'):  # Platform-specific: Linux
         selector_type = PollSelector
-    elif hasattr(select, 'select'):
+    elif hasattr(select, 'select'):  # Platform-specific: Windows
         selector_type = SelectSelector
     else:  # Platform-specific: AppEngine
         raise ValueError('Platform does not have a selector')

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -534,7 +534,8 @@ if hasattr(select, "kqueue"):
             self._kqueue.close()
             super(KqueueSelector, self).close()
 
-if not hasattr(select, 'select'):
+
+if not hasattr(select, 'select'):  # Platform-specific: AppEngine
     HAS_SELECT = False
 
 
@@ -554,7 +555,7 @@ def _default_selector(*_):
         selector_type = PollSelector
     elif hasattr(select, 'select'):
         selector_type = SelectSelector
-    else:
+    else:  # Platform-specific: AppEngine
         raise ValueError('Platform does not have a selector')
     DefaultSelector = selector_type
     return selector_type()

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -568,13 +568,13 @@ def DefaultSelector(*_):
     by eventlet, greenlet, and preserve proper behavior. """
     global _DEFAULT_SELECTOR
     if _DEFAULT_SELECTOR is None:
-        if _can_allocate('kqueue'):  # Platform-specific: Mac OS
+        if _can_allocate('kqueue'):
             _DEFAULT_SELECTOR = KqueueSelector
-        elif _can_allocate('epoll'):  # Platform-specific: Linux
+        elif _can_allocate('epoll'):
             _DEFAULT_SELECTOR = EpollSelector
-        elif _can_allocate('poll'):  # Platform-specific: Linux
+        elif _can_allocate('poll'):
             _DEFAULT_SELECTOR = PollSelector
-        elif hasattr(select, 'select'):  # Platform-specific: Windows
+        elif hasattr(select, 'select'):
             _DEFAULT_SELECTOR = SelectSelector
         else:  # Platform-specific: AppEngine
             raise ValueError('Platform does not have a selector')

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -544,7 +544,7 @@ if not hasattr(select, 'select'):  # Platform-specific: AppEngine
 # select() also can't accept a FD > FD_SETSIZE (usually around 1024)
 def _default_selector(*_):
     """ This function serves as a first call for DefaultSelector to
-    detect if the select module is being monkey-patched incorrectly 
+    detect if the select module is being monkey-patched incorrectly
     by eventlet, greenlet, and preserve proper behavior. """
     global DefaultSelector
     if hasattr(select, 'kqueue'):
@@ -562,4 +562,3 @@ def _default_selector(*_):
 
 
 DefaultSelector = _default_selector
-


### PR DESCRIPTION
This is another implementation for solving issue #1104. #1105 is too complex because it was trying to keep promises of the Python stdlib selectors modules that aren't relevant to urllib3.
This change is simpler and should make for a more comfortable change. :)

This change doesn't detect monkey-patches that occur after the first call to `DefaultSelector` but the major problem seems to be patches during import time so I think this is a good compromise.

Should hopefully make it into next requests release (?) as I've seen more than one project blacklisting upgrading requests until issue #1104 is resolved even though it's not really our fault.