### PR TITLE
Stop buffering entire deflate-encoded responses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ dev (master)
 * Resolved issue where the PyOpenSSL backend would not wrap SysCallError
   exceptions appropriately when sending data. (Pull #1125)
 
+* Reduced memory consumption when streaming zlib-compressed responses
+  (as opposed to raw deflate streams). (Pull #1129)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -224,5 +224,8 @@ In chronological order:
 * Tom White <s6yg1ez3@mail2tor.com>
   * Made SOCKS handler differentiate socks5h from socks5 and socks4a from socks4.
 
+* Tim Burke <tim.burke@gmail.com>
+  * Stop buffering entire deflate-encoded responses.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -38,7 +38,11 @@ class DeflateDecoder(object):
 
         self._data += data
         try:
-            return self._obj.decompress(data)
+            decompressed = self._obj.decompress(data)
+            if decompressed:
+                self._first_try = False
+                self._data = None
+            return decompressed
         except zlib.error:
             self._first_try = False
             self._obj = zlib.decompressobj(-zlib.MAX_WBITS)


### PR DESCRIPTION
Previously, if we received a deflate-encoded response that included the
zlib header, we would buffer the entire response in case decompressing
failed and we wanted to try interpretting the response as a raw deflate
stream.

Now, we commit to a single decoder as soon as we've decoded any data. As
a result, we can drop the buffer at the same time.