### PR TITLE
Fix wait_for_io Tests

### DIFF
--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -562,7 +562,7 @@ def _can_allocate(struct):
 # Choose the best implementation, roughly:
 # kqueue == epoll > poll > select. Devpoll not supported. (See above)
 # select() also can't accept a FD > FD_SETSIZE (usually around 1024)
-def DefaultSelector(*_):
+def DefaultSelector():
     """ This function serves as a first call for DefaultSelector to
     detect if the select module is being monkey-patched incorrectly
     by eventlet, greenlet, and preserve proper behavior. """


### PR DESCRIPTION
As noticed by @sigmavirus24 there were extra parameters on `DefaultSelector` that were apparently only there to be silently passed in a `unittest.TestCase` while testing `wait_for_io` functions. These test cases have been reworked to use the same path as the `BaseSelectorTestCase` by patching `select` module and resetting the `DefaultSelector` cache. I hoisted `patch_select_module` outside the testcase to allow both sets of test cases to use it for patching.