### PR TITLE
Remove support for sending unicode request bodies.

### DIFF
--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -65,10 +65,8 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
         self._test_body(b'thisshouldbeonechunk\r\nasdf')
 
     def test_unicode_body(self):
-        # Define u'thisshouldbeonechunk\r\näöüß' in a way, so that python3.1
-        # does not suffer a syntax error
         # Unicode bodies are not supported.
-        chunk = b'thisshouldbeonechunk\r\n\xc3\xa4\xc3\xb6\xc3\xbc\xc3\x9f'.decode('utf-8')
+        chunk = u'thisshouldbeonechunk\r\näöüß'
         self.assertRaises(InvalidBodyError, self._test_body, chunk)
 
     def test_empty_string_body(self):

--- a/test/with_dummyserver/test_chunked_transfer.py
+++ b/test/with_dummyserver/test_chunked_transfer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from urllib3 import HTTPConnectionPool
+from urllib3.exceptions import InvalidBodyError
 from urllib3.packages import six
 from dummyserver.testcase import SocketDummyServerTestCase
 
@@ -66,11 +67,12 @@ class TestChunkedTransfer(SocketDummyServerTestCase):
     def test_unicode_body(self):
         # Define u'thisshouldbeonechunk\r\näöüß' in a way, so that python3.1
         # does not suffer a syntax error
+        # Unicode bodies are not supported.
         chunk = b'thisshouldbeonechunk\r\n\xc3\xa4\xc3\xb6\xc3\xbc\xc3\x9f'.decode('utf-8')
-        self._test_body(chunk)
+        self.assertRaises(InvalidBodyError, self._test_body, chunk)
 
     def test_empty_string_body(self):
-        self._test_body('')
+        self._test_body(b'')
 
     def test_empty_iterable_body(self):
         self._test_body([])

--- a/urllib3/exceptions.py
+++ b/urllib3/exceptions.py
@@ -230,3 +230,11 @@ class FailedTunnelError(HTTPError):
     def __init__(self, message, response):
         super(FailedTunnelError, self).__init__(message)
         self.response = response
+
+
+class InvalidBodyError(HTTPError):
+    """
+    An attempt was made to send a request with a body object that urllib3 does
+    not support.
+    """
+    pass

--- a/urllib3/request.py
+++ b/urllib3/request.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from .filepost import encode_multipart_formdata
+from .packages import six
 from .packages.six.moves.urllib.parse import urlencode
 
 
@@ -138,6 +139,9 @@ class RequestMethods(object):
                 body, content_type = encode_multipart_formdata(fields, boundary=multipart_boundary)
             else:
                 body, content_type = urlencode(fields), 'application/x-www-form-urlencoded'
+
+            if isinstance(body, six.text_type):
+                body = body.encode('utf-8')
 
             extra_kw['body'] = body
             extra_kw['headers'] = {'Content-Type': content_type}


### PR DESCRIPTION
This has been bothering me for a while: the auto-encoding of unicode bodies is a really good source of subtle bugs, and I'd argue it violates the Zen of Python. This change removes that support from the v2 branch.