### PR TITLE
Reduce selector overuse in v2 branch.

### DIFF
--- a/urllib3/util/connection.py
+++ b/urllib3/util/connection.py
@@ -1,33 +1,13 @@
 from __future__ import absolute_import
 import socket
-from .wait import wait_for_read
-from .selectors import HAS_SELECT, SelectorError
 
 
 def is_connection_dropped(conn):  # Platform-specific
     """
     Returns True if the connection is dropped and should be closed.
-
-    :param conn:
-        :class:`httplib.HTTPConnection` object.
-
-    Note: For platforms like AppEngine, this will always return ``False`` to
-    let the platform handle connection recycling transparently for us.
     """
-    # TODO: Replace this with something that uses the per-connection selector.
-    sock = getattr(conn, '_sock', False)
-    if sock is False:  # Platform-specific: AppEngine
-        return False
-    if sock is None:  # Connection already closed (such as by httplib).
-        return True
-
-    if not HAS_SELECT:
-        return False
-
-    try:
-        return bool(wait_for_read(sock, timeout=0.0))
-    except SelectorError:
-        return True
+    # TODO: Need to restore AppEngine behaviour here at some point.
+    return conn.is_dropped()
 
 
 # This function is copied from socket.py in the Python 2.7 standard


### PR DESCRIPTION
Right now the code will create new selectors to check for EOF, even though each connection now has one. We should probably stop doing that. :D