### PR TITLE
Remove release_conn parameter from v2 branch.

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -343,8 +343,8 @@ class TestConnectionPool(unittest.TestCase):
         self.assertEqual(initial_pool_size, new_pool_size)
 
     def test_release_conn_param_is_respected_after_http_error_retry(self):
-        """For successful ```urlopen(release_conn=False)```,
-        the connection isn't released, even after a retry.
+        """For successful ```urlopen()```, the connection isn't released, even
+        after a retry.
 
         This is a regression test for issue #651 [1], where the connection
         would be released if the initial request failed, even if a retry
@@ -385,7 +385,7 @@ class TestConnectionPool(unittest.TestCase):
             # released back into the pool.
             pool._make_request = _raise_once_make_request_function(exception, *args)
             response = pool.urlopen('GET', '/', retries=1,
-                                    release_conn=False, preload_content=False,
+                                    preload_content=False,
                                     chunked=True)
             self.assertEqual(pool.pool.qsize(), 0)
             self.assertEqual(pool.num_connections, 2)

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -611,13 +611,12 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         pool.urlopen('GET', '/')
         self.assertEqual(pool.pool.qsize(), MAXSIZE-2)
 
-    def test_release_conn_parameter(self):
+    def test_connections_arent_released(self):
         MAXSIZE = 5
         pool = HTTPConnectionPool(self.host, self.port, maxsize=MAXSIZE)
         self.assertEqual(pool.pool.qsize(), MAXSIZE)
 
-        # Make request without releasing connection
-        pool.request('GET', '/', release_conn=False, preload_content=False)
+        pool.request('GET', '/', preload_content=False)
         self.assertEqual(pool.pool.qsize(), MAXSIZE-1)
 
     def test_dns_error(self):
@@ -687,11 +686,10 @@ class TestConnectionPool(HTTPDummyServerTestCase):
             self.assertRaises(MaxRetryError,
                               http.request,
                               'GET', '/redirect',
-                              fields={'target': '/'}, release_conn=False, retries=0)
+                              fields={'target': '/'}, retries=0)
 
             r = http.request('GET', '/redirect',
                              fields={'target': '/'},
-                             release_conn=False,
                              retries=1)
             r.release_conn()
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -570,8 +570,8 @@ class TestSocketClosing(SocketDummyServerTestCase):
             self.fail("Timed out waiting for connection close")
 
     def test_release_conn_param_is_respected_after_timeout_retry(self):
-        """For successful ```urlopen(release_conn=False)```,
-        the connection isn't released, even after a retry.
+        """For successful ```urlopen()```, the connection isn't released, even
+        after a retry.
 
         This test allows a retry: one request fails, the next request succeeds.
 
@@ -616,7 +616,7 @@ class TestSocketClosing(SocketDummyServerTestCase):
             # First request should fail, but the timeout and `retries=1` should
             # save it.
             response = pool.urlopen('GET', '/', retries=1,
-                                    release_conn=False, preload_content=False,
+                                    preload_content=False,
                                     timeout=Timeout(connect=1, read=0.001))
 
             # The connection should still be on the response object, and none


### PR DESCRIPTION
The release_conn parameter is not really very sensible in the modern, new construction of urllib3, so this PR waves goodbye to it entirely.