### PR TITLE
Address issues with testing on Windows

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,6 +4,7 @@ import errno
 import functools
 import logging
 import socket
+import platform
 
 from nose.plugins.skip import SkipTest
 
@@ -90,6 +91,17 @@ def onlyPy3(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python3.x to run".format(name=test.__name__)
         if not six.PY3:
+            raise SkipTest(msg)
+        return test(*args, **kwargs)
+    return wrapper
+
+
+def onlyPy27OrNewerOrNonWindows(test):
+    """Skips this test unless you are on Python2.7+ or non-Windows"""
+    @functools.wraps(test)
+    def wrapper(*args, **kwargs):
+        msg = "{name} requires Python2.7+ or non-Windows to run".format(name=test.__name__)
+        if sys.version_info < (2, 7) and platform.system() == 'Windows':
             raise SkipTest(msg)
         return test(*args, **kwargs)
     return wrapper

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -3,7 +3,10 @@ import socket
 try:
     _CONNECT_ERROR = (BlockingIOError, InterruptedError)
 except:
-    _CONNECT_ERROR = (Exception,)
+    try:
+        _CONNECT_ERROR = (WinError, OSError, socket.error)
+    except:
+        _CONNECT_ERROR = (OSError, socket.error)
     
 if hasattr(socket, 'socketpair'):
     # Since Python 3.5, socket.socketpair() is now also available on Windows

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -1,10 +1,16 @@
 import socket
 
+# Figuring out what errors could come out of a socket. There are three
+# different situations. Python 3 post-PEP3151 will define and use
+# BlockingIOError and InterruptedError from sockets. For Python pre-PEP3151
+# both OSError and socket.error can be raised except on Windows where
+# WindowsError can also be raised. We want to catch all of these possible
+# exceptions so we catch WindowsError if it's defined.
 try:
     _CONNECT_ERROR = (BlockingIOError, InterruptedError)
 except NameError:
     try:
-        _CONNECT_ERROR = (WinError, OSError, socket.error)  # noqa: F821
+        _CONNECT_ERROR = (WindowsError, OSError, socket.error)  # noqa: F821
     except NameError:
         _CONNECT_ERROR = (OSError, socket.error)
 

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -4,10 +4,10 @@ try:
     _CONNECT_ERROR = (BlockingIOError, InterruptedError)
 except:
     try:
-        _CONNECT_ERROR = (WinError, OSError, socket.error)
+        _CONNECT_ERROR = (WinError, OSError, socket.error)  # noqa: F821
     except:
         _CONNECT_ERROR = (OSError, socket.error)
-    
+
 if hasattr(socket, 'socketpair'):
     # Since Python 3.5, socket.socketpair() is now also available on Windows
     socketpair = socket.socketpair

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -2,10 +2,10 @@ import socket
 
 try:
     _CONNECT_ERROR = (BlockingIOError, InterruptedError)
-except:
+except NameError:
     try:
         _CONNECT_ERROR = (WinError, OSError, socket.error)  # noqa: F821
-    except:
+    except NameError:
         _CONNECT_ERROR = (OSError, socket.error)
 
 if hasattr(socket, 'socketpair'):

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -41,7 +41,7 @@ else:
                 csock.setblocking(False)
                 try:
                     csock.connect((addr, port))
-                except (BlockingIOError, InterruptedError):
+                except _CONNECT_ERROR:
                     pass
                 csock.setblocking(True)
                 ssock, _ = lsock.accept()

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -3,7 +3,7 @@ import socket
 try:
     _CONNECT_ERROR = (BlockingIOError, InterruptedError)
 except:
-    _CONNECT_ERROR = (OSError,)
+    _CONNECT_ERROR = (Exception,)
     
 if hasattr(socket, 'socketpair'):
     # Since Python 3.5, socket.socketpair() is now also available on Windows

--- a/test/socketpair_helper.py
+++ b/test/socketpair_helper.py
@@ -1,5 +1,10 @@
 import socket
 
+try:
+    _CONNECT_ERROR = (BlockingIOError, InterruptedError)
+except:
+    _CONNECT_ERROR = (OSError,)
+    
 if hasattr(socket, 'socketpair'):
     # Since Python 3.5, socket.socketpair() is now also available on Windows
     socketpair = socket.socketpair

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -569,7 +569,7 @@ class BaseSelectorTestCase(unittest.TestCase, AlarmMixin, TimerMixin):
 
 class BaseWaitForTestCase(unittest.TestCase, TimerMixin, AlarmMixin):
     def make_socketpair(self):
-        rd, wr = socket.socketpair()
+        rd, wr = socketpair()
 
         # Make non-blocking so we get errors if the
         # sockets are interacted with but not ready.

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -4,7 +4,6 @@ import os
 import psutil
 import select
 import signal
-import socket
 import sys
 import time
 import threading

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -43,10 +43,11 @@ SHORT_SELECT = 0.01
 # Tolerance values for timer/speed fluctuations.
 TOLERANCE = 0.75
 
-# Detect whether we're running on Travis.  This is used
-# to skip some verification points inside of tests to
+# Detect whether we're running on Travis or AppVeyor.  This
+# is used to skip some verification points inside of tests to
 # not randomly fail our CI due to wild timer/speed differences.
 TRAVIS_CI = "TRAVIS" in os.environ
+APPVEYOR = "APPVEYOR" in os.environ
 
 
 skipUnlessHasSelector = skipUnless(selectors.HAS_SELECT, "Platform doesn't have a selector")
@@ -128,7 +129,7 @@ class TimerContext(object):
         total_time = self.end_time - self.start_time
 
         # Skip timing on CI due to flakiness.
-        if TRAVIS_CI:
+        if TRAVIS_CI or APPVEYOR:
             return
 
         if self.lower is not None:

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -19,6 +19,7 @@ from dummyserver.server import (DEFAULT_CA, DEFAULT_CA_BAD, DEFAULT_CERTS,
 from test import (
     onlyPy26OrOlder,
     onlyPy279OrNewer,
+    onlyPy27OrNewerOrNonWindows,
     requires_network,
     TARPIT_HOST,
 )
@@ -496,7 +497,11 @@ class TestHTTPS_TLSv1(HTTPSDummyServerTestCase):
         self._pool = HTTPSConnectionPool(self.host, self.port)
         self.addCleanup(self._pool.close)
 
+    @onlyPy27OrNewerOrNonWindows
     def test_discards_connection_on_sslerror(self):
+        # This test is skipped on Windows for Python 2.6 because we suspect there
+        # is an issue with the OpenSSL for Python 2.6 on Windows.
+
         self._pool.cert_reqs = 'CERT_REQUIRED'
         self.assertRaises(SSLError, self._pool.request, 'GET', '/')
         self._pool.ca_certs = DEFAULT_CA

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands=
     nosetests []
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
-passenv = CFLAGS LDFLAGS TRAVIS CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
+passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
 
 [testenv:py26]
 # Additional dependency on unittest2 for Python 2.6


### PR DESCRIPTION
This PR comes after #1006 has been merged into master. We knew there would probably be some issues, and lo-and-behold there are. Only issues seem to be with testing using `socket.socketpair` and incompatibilities with our `socketpair` helper for Python 2.