### PR TITLE
Rewrite Response I/O in terms of stream.

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -217,6 +217,22 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(next(stream), b'o')
         self.assertRaises(StopIteration, next, stream)
 
+    def test_double_streaming(self):
+        fp = [b'fo', b'o']
+        resp = HTTPResponse(fp, preload_content=False)
+
+        stream = list(resp.stream(decode_content=False))
+        self.assertEqual(stream, fp)
+
+        stream = list(resp.stream(decode_content=False))
+        self.assertEqual(stream, [])
+
+    def test_closed_streaming(self):
+        fp = BytesIO(b'foo')
+        resp = HTTPResponse(fp, preload_content=False)
+        resp.close()
+        self.assertRaises(StopIteration, next, resp.stream())
+
     def test_streaming_tell(self):
         fp = [b'fo', b'o']
         resp = HTTPResponse(fp, preload_content=False)

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -259,7 +259,6 @@ class TestResponse(unittest.TestCase):
         resp.close()
         self.assertRaises(StopIteration, next, stream)
 
-
     def test_streaming_tell(self):
         fp = [b'fo', b'o']
         resp = HTTPResponse(fp, preload_content=False)

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -202,9 +202,7 @@ class TestResponse(unittest.TestCase):
 
         # This is necessary to make sure the "no bytes left" part of `readinto`
         # gets tested.
-        print("First read")
         self.assertEqual(len(br.read(5)), 5)
-        print("Second read")
         self.assertEqual(len(br.read(5)), 5)
         self.assertEqual(len(br.read(5)), 0)
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -202,29 +202,31 @@ class TestResponse(unittest.TestCase):
 
         # This is necessary to make sure the "no bytes left" part of `readinto`
         # gets tested.
+        print("First read")
         self.assertEqual(len(br.read(5)), 5)
+        print("Second read")
         self.assertEqual(len(br.read(5)), 5)
         self.assertEqual(len(br.read(5)), 0)
 
     def test_streaming(self):
-        fp = BytesIO(b'foo')
+        fp = [b'fo', b'o']
         resp = HTTPResponse(fp, preload_content=False)
-        stream = resp.stream(2, decode_content=False)
+        stream = resp.stream(decode_content=False)
 
         self.assertEqual(next(stream), b'fo')
         self.assertEqual(next(stream), b'o')
         self.assertRaises(StopIteration, next, stream)
 
     def test_streaming_tell(self):
-        fp = BytesIO(b'foo')
+        fp = [b'fo', b'o']
         resp = HTTPResponse(fp, preload_content=False)
-        stream = resp.stream(2, decode_content=False)
+        stream = resp.stream(decode_content=False)
 
         position = 0
 
         position += len(next(stream))
         self.assertEqual(2, position)
-        self.assertEqual(3, resp.tell())
+        self.assertEqual(2, resp.tell())
 
         position += len(next(stream))
         self.assertEqual(3, position)
@@ -241,10 +243,9 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'gzip'},
                             preload_content=False)
-        stream = resp.stream(2)
+        stream = resp.stream()
 
-        self.assertEqual(next(stream), b'fo')
-        self.assertEqual(next(stream), b'o')
+        self.assertEqual(next(stream), b'foo')
         self.assertRaises(StopIteration, next, stream)
 
     def test_gzipped_streaming_tell(self):
@@ -337,10 +338,9 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'deflate'},
                             preload_content=False)
-        stream = resp.stream(2)
+        stream = resp.stream()
 
-        self.assertEqual(next(stream), b'fo')
-        self.assertEqual(next(stream), b'o')
+        self.assertEqual(next(stream), b'foo')
         self.assertRaises(StopIteration, next, stream)
 
     def test_deflate2_streaming(self):
@@ -352,16 +352,15 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(data)
         resp = HTTPResponse(fp, headers={'content-encoding': 'deflate'},
                             preload_content=False)
-        stream = resp.stream(2)
+        stream = resp.stream()
 
-        self.assertEqual(next(stream), b'fo')
-        self.assertEqual(next(stream), b'o')
+        self.assertEqual(next(stream), b'foo')
         self.assertRaises(StopIteration, next, stream)
 
     def test_empty_stream(self):
         fp = BytesIO(b'')
         resp = HTTPResponse(fp, preload_content=False)
-        stream = resp.stream(2, decode_content=False)
+        stream = resp.stream(decode_content=False)
 
         self.assertRaises(StopIteration, next, stream)
 
@@ -396,9 +395,10 @@ class TestResponse(unittest.TestCase):
         fp = MockHTTPRequest()
         fp.fp = bio
         resp = HTTPResponse(fp, preload_content=False)
-        stream = resp.stream(2)
+        stream = resp.stream()
 
-        self.assertEqual(next(stream), b'fo')
+        self.assertEqual(next(stream), b'f')
+        self.assertEqual(next(stream), b'o')
         self.assertEqual(next(stream), b'o')
         self.assertRaises(StopIteration, next, stream)
 

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1284,6 +1284,11 @@ class TestBadContentLength(SocketDummyServerTestCase):
         # Test stream read when content length less than headers claim
         get_response = conn.request('GET', url='/', preload_content=False)
         data = get_response.stream(100)
+
+        # The first read will work fine.
+        next(data)
+
+        # The second one will see the EOF condition and barf.
         try:
             next(data)
             self.assertFail()

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -13,7 +13,6 @@ from .exceptions import (
     ProtocolError, DecodeError, ReadTimeoutError
 )
 from .packages.six import string_types as basestring, binary_type
-from .util.response import is_fp_closed
 from .util.ssl_ import BaseSSLError
 
 log = logging.getLogger(__name__)

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -356,10 +356,17 @@ class HTTPResponse(io.IOBase):
                 if decoded_chunk:
                     yield decoded_chunk
 
+            # This branch is speculative: most decoders do not need to flush,
+            # and so this produces no output. However, it's here because
+            # anecdotally some platforms on which we do not test (like Jython)
+            # do require the flush. For this reason, we exclude this from code
+            # coverage. Happily, the code here is so simple that testing the
+            # branch we don't enter is basically entirely unnecessary (it's
+            # just a yield statement).
             final_chunk = self._decode(
                 b'', decode_content, flush_decoder=True
             )
-            if final_chunk:
+            if final_chunk:  # Platform-specific: Jython
                 yield final_chunk
 
             self._fp = None

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -249,6 +249,11 @@ class HTTPResponse(io.IOBase):
                 # This includes IncompleteRead.
                 raise ProtocolError('Connection broken: %r' % e, e)
 
+            except GeneratorExit:
+                # We swallow GeneratorExit when it is emitted: this allows the
+                # use of the error checker inside stream()
+                pass
+
             # If no exception is thrown, we should avoid cleaning up
             # unnecessarily.
             clean_exit = True

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -408,7 +408,7 @@ class HTTPResponse(io.IOBase):
 
     @property
     def closed(self):
-        # TODO: Do we need this?
+        # This method is required for `io` module compatibility.
         if self._fp is None and not self._buffer:
             return True
         elif hasattr(self._fp, 'complete'):
@@ -417,7 +417,7 @@ class HTTPResponse(io.IOBase):
             return False
 
     def fileno(self):
-        # TODO: Do we need this?
+        # This method is required for `io` module compatibility.
         if self._fp is None:
             raise IOError("HTTPResponse has no file to get a fileno from")
         elif hasattr(self._fp, "fileno"):

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -400,6 +400,7 @@ class HTTPResponse(io.IOBase):
     def close(self):
         if not self.closed:
             self._fp.close()
+            self._buffer = b''
             self._fp = None
 
         if self._connection:
@@ -408,7 +409,7 @@ class HTTPResponse(io.IOBase):
     @property
     def closed(self):
         # TODO: Do we need this?
-        if self._fp is None:
+        if self._fp is None and not self._buffer:
             return True
         elif hasattr(self._fp, 'complete'):
             return self._fp.complete

--- a/urllib3/util/response.py
+++ b/urllib3/util/response.py
@@ -8,10 +8,6 @@ def is_fp_closed(obj):
     :param obj:
         The file-like object to check.
     """
-    # FPs that are None are always closed.
-    if obj is None:
-        return True
-
     try:
         # Check for our own base response class.
         return obj.complete


### PR DESCRIPTION
Now that I/O is done in terms of iterating a base connection, rather than in terms of calling read() on a file-like object, stream() becomes the more natural method to use to do I/O than read() does. This has meant both that there is a bunch of awkward code duplication in read() *and* that stream() became very inefficient, as it was doing buffered I/O.

This change adjusts stream so that it no longer does buffered I/O, and rewrites read() to be in terms of stream. This should help clean things up for writing an async response object in future. Along the way I've made some miscellaneous smaller changes.