### PR TITLE
Test Python 3.6 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,11 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: "py35"
 
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+      TOXENV: "py36"
+
 install:
   # Install Python (from the official .msi of http://python.org) and pip when
   # not already installed.

--- a/dummyserver/server.py
+++ b/dummyserver/server.py
@@ -210,7 +210,9 @@ def bind_sockets(port, address=None, family=socket.AF_UNSPEC, backlog=128,
 
 
 def run_tornado_app(app, io_loop, certs, scheme, host):
-    app.last_req = datetime.fromtimestamp(0)
+    # We can't use fromtimestamp(0) because of CPython issue 29097, so we'll
+    # just construct the datetime object directly.
+    app.last_req = datetime(1970, 1, 1)
 
     if scheme == 'https':
         http_server = tornado.httpserver.HTTPServer(app, ssl_options=certs,


### PR DESCRIPTION
We should probably increase our test matrix to test as many versions on as many platforms as possible.