### PR TITLE
Add assert_hostname to list of valid keys for PoolManager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ dev (master)
 * Fixed regression in 1.21 that threw exceptions when users passed the
   ``socket_options`` flag to the ``PoolManager``.  (Issue #1165)
 
+* Fixed regression in 1.21 that threw exceptions when users passed the
+  ``assert_hostname`` or ```assert_fingerprint`flag to the ``PoolManager``.
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -277,6 +277,16 @@ class TestPoolManager(unittest.TestCase):
         self.assertTrue(pool is other_pool)
         self.assertTrue(all(isinstance(key, PoolKey) for key in p.pools.keys()))
 
+    def test_assert_hostname_and_fingerprint_flag(self):
+        """Assert that pool manager can accept hostname and fingerprint flags."""
+        fingerprint = '92:81:FE:85:F7:0C:26:60:EC:D6:B3:BF:93:CF:F9:71:CC:07:7D:0A'
+        p = PoolManager(assert_hostname=True, assert_fingerprint=fingerprint)
+        self.addCleanup(p.clear)
+        pool = p.connection_from_url('https://example.com/')
+        self.assertEqual(1, len(p.pools))
+        self.assertTrue(pool.assert_hostname)
+        self.assertEqual(fingerprint, pool.assert_fingerprint)
+
     def test_http_connection_from_context_case_insensitive(self):
         """Assert scheme case is ignored when getting the https key class."""
         p = PoolManager()

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -45,6 +45,8 @@ _key_fields = (
     'key__proxy_headers',  # dict
     'key_socket_options',  # list of (level (int), optname (int), value (int or str)) tuples
     'key__socks_options',  # dict
+    'key_assert_hostname',  # bool or string
+    'key_assert_fingerprint',  # str
 )
 
 #: The namedtuple class used to construct keys for the connection pool.


### PR DESCRIPTION
In Kubernetes' client-python, we ran into this problem with
1.21:
https://travis-ci.org/kubernetes-incubator/client-python/jobs/225699267

We add the assert_hostname to our PoolManager here:
https://github.com/kubernetes-incubator/client-python/blob/192b67c4466c4e1c45f05eb4a1c6a6899e1c279d/kubernetes/client/rest.py#L107

I can't see any other workaround at the moment, please let us know is there's a better way to do this.