### PR TITLE
Add alternative FIFO queue as a data structure for the connection pool

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -230,5 +230,8 @@ In chronological order:
 * Tuukka Mustonen <tuukka.mustonen@gmail.com>
   * Add counter for status_forcelist retries.
 
+* João Alves <joao.moa@gmail.com>
+  * Add fifo queue as an alternative for connection pool data structure.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -417,6 +417,10 @@ class TestConnectionPool(unittest.TestCase):
                                 preload_content=False)
         self.assertTrue(isinstance(response, CustomHTTPResponse))
 
+    def test_fifo_queue(self):
+        pool = HTTPConnectionPool(host='localhost', fifo_queue=True, maxsize=1, block=True)
+        self.addCleanup(pool.close)
+        self.assertEqual(pool.QueueCls.__name__, 'Queue')
 
 if __name__ == '__main__':
     unittest.main()

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -62,14 +62,17 @@ class ConnectionPool(object):
     """
 
     scheme = None
-    QueueCls = queue.LifoQueue
 
-    def __init__(self, host, port=None):
+    def __init__(self, host, port=None, fifo_queue=False):
         if not host:
             raise LocationValueError("No host specified.")
 
         self.host = _ipv6_host(host).lower()
         self.port = port
+        if fifo_queue:
+            self.QueueCls = queue.Queue
+        else:
+            self.QueueCls = queue.LifoQueue
 
     def __str__(self):
         return '%s(host=%r, port=%r)' % (type(self).__name__,
@@ -149,6 +152,10 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         A dictionary with proxy headers, should not be used directly,
         instead, see :class:`urllib3.connectionpool.ProxyManager`"
 
+    :param fifo_queue:
+        If True, this connection pool will use a FIFO queue to store its connections,
+        instead of the default stack (LIFO) implementation
+
     :param \\**conn_kw:
         Additional parameters are used to create fresh :class:`urllib3.connection.HTTPConnection`,
         :class:`urllib3.connection.HTTPSConnection` instances.
@@ -161,9 +168,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
     def __init__(self, host, port=None, strict=False,
                  timeout=Timeout.DEFAULT_TIMEOUT, maxsize=1, block=False,
                  headers=None, retries=None,
-                 _proxy=None, _proxy_headers=None,
+                 _proxy=None, _proxy_headers=None, fifo_queue=False,
                  **conn_kw):
-        ConnectionPool.__init__(self, host, port)
+        ConnectionPool.__init__(self, host, port, fifo_queue)
         RequestMethods.__init__(self, headers)
 
         self.strict = strict


### PR DESCRIPTION
This comes from issue #1158 
I am suggesting this change because for some systems it is
better to use all the connections from the pool equally, rather than the
same ones all the time, which is the default case with LIFO.

In our case, it improves reliability because our servers are behind an
ELB. Once there is a failure and we have to retry the request, we don't
want to reuse the same connection, but rather start a different connection
in the hope that the ELB will choose a different machine to respond.

Furthermore, an online search leads me to believe that FIFO is a commonly
used data structure in connection pools:
https://en.wikipedia.org/wiki/Object_pool_pattern#Examples
The C# example uses List.Remove(0) and List.Add(...)