### PR TITLE
Switch from Nose to Pytest Runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 
 .PHONY: test
 test: requirements
-	nosetests
+	pytest
 
 .PHONY: test-all
 test-all: requirements

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest==3.0.7
 pytest-cov==2.4.0
-pytest_gae
+pytest_timeout==1.2.0
 mock==1.3.0
 coverage==3.7.1
 tox==2.1.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
-nose==1.3.7
-nose-exclude==0.4.1
+pytest==3.0.7
+pytest-cov==2.4.0
+pytest_gae
 mock==1.3.0
 coverage==3.7.1
 tox==2.1.1

--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -1,7 +1,7 @@
 import sys
 import socket
 import threading
-from nose.plugins.skip import SkipTest
+import pytest
 from tornado import ioloop, web
 
 from dummyserver.server import (
@@ -139,7 +139,7 @@ class IPV6HTTPSDummyServerTestCase(HTTPSDummyServerTestCase):
     @classmethod
     def setUpClass(cls):
         if not socket.has_ipv6:
-            raise SkipTest('IPv6 not available')
+            pytest.skip('IPv6 not available')
         else:
             super(IPV6HTTPSDummyServerTestCase, cls).setUpClass()
 
@@ -189,7 +189,7 @@ class IPv6HTTPDummyServerTestCase(HTTPDummyServerTestCase):
     @classmethod
     def setUpClass(cls):
         if not socket.has_ipv6:
-            raise SkipTest('IPv6 not available')
+            pytest.skip('IPv6 not available')
         else:
             super(IPv6HTTPDummyServerTestCase, cls).setUpClass()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[nosetests]
-logging-clear-handlers=true
-with-coverage=true
-cover-package=urllib3
-# no rounding problems here
-cover-erase=true
-
 [flake8]
 exclude=./docs/conf.py,./urllib3/packages/*
 max-line-length=99

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name='urllib3',
       tests_require=[
           # These are a less-specific subset of dev-requirements.txt, for the
           # convenience of distro package maintainers.
-          'nose',
+          'pytest',
           'mock',
           'tornado',
       ],

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -6,7 +6,7 @@ import logging
 import socket
 import platform
 
-from nose.plugins.skip import SkipTest
+import pytest
 
 from urllib3.exceptions import HTTPWarning
 from urllib3.packages import six
@@ -44,7 +44,7 @@ def onlyPy26OrOlder(test):
     def wrapper(*args, **kwargs):
         msg = "{name} only runs on Python2.6.x or older".format(name=test.__name__)
         if sys.version_info >= (2, 7):
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -56,7 +56,7 @@ def onlyPy27OrNewer(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python 2.7.x+ to run".format(name=test.__name__)
         if sys.version_info < (2, 7):
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -68,7 +68,7 @@ def onlyPy279OrNewer(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python 2.7.9+ to run".format(name=test.__name__)
         if sys.version_info < (2, 7, 9):
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -80,7 +80,7 @@ def onlyPy2(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python 2.x to run".format(name=test.__name__)
         if six.PY3:
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -92,7 +92,7 @@ def onlyPy3(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python3.x to run".format(name=test.__name__)
         if not six.PY3:
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -104,7 +104,7 @@ def notSecureTransport(test):
     def wrapper(*args, **kwargs):
         msg = "{name} does not run with SecureTransport".format(name=test.__name__)
         if ssl_.IS_SECURETRANSPORT:
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -115,7 +115,7 @@ def onlyPy27OrNewerOrNonWindows(test):
     def wrapper(*args, **kwargs):
         msg = "{name} requires Python2.7+ or non-Windows to run".format(name=test.__name__)
         if sys.version_info < (2, 7) and platform.system() == 'Windows':
-            raise SkipTest(msg)
+            pytest.skip(msg)
         return test(*args, **kwargs)
     return wrapper
 
@@ -155,7 +155,7 @@ def requires_network(test):
         else:
             msg = "Can't run {name} because the network is unreachable".format(
                 name=test.__name__)
-            raise SkipTest(msg)
+            pytest.skip(msg)
     return wrapper
 
 

--- a/test/appengine/__init__.py
+++ b/test/appengine/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 import pytest

--- a/test/appengine/__init__.py
+++ b/test/appengine/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import unittest
-from nose.plugins.skip import SkipTest
+import pytest
 
 
 def activate_sandbox():
@@ -39,15 +39,15 @@ class AppEngineSandboxTest(unittest.TestCase):
     def setUpClass(cls):
 
         if sys.version_info[:2] != (2, 7):
-            raise SkipTest("App Engine only tests on py2.7")
+            pytest.skip("App Engine only tests on py2.7")
 
         if 'APPLICATION_ID' not in os.environ:
-            raise SkipTest("NoseGAE plugin not used.")
+            pytest.skip("NoseGAE plugin not used.")
 
         try:
             activate_sandbox()
         except ImportError:
-            raise SkipTest("App Engine SDK not available.")
+            pytest.skip("App Engine SDK not available.")
 
     @classmethod
     def tearDownClass(self):

--- a/test/appengine/__init__.py
+++ b/test/appengine/__init__.py
@@ -11,10 +11,6 @@ def activate_sandbox():
     Inserts the stub module import hook which causes the usage of appengine-specific
     httplib, httplib2, socket, etc.
     """
-    import dev_appserver
-    dev_appserver.fix_sys_path()
-
-
     from google.appengine.tools.devappserver2.python import sandbox
     from google.appengine.ext import testbed
 
@@ -51,12 +47,11 @@ class AppEngineSandboxTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        import dev_appserver
+        dev_appserver.fix_sys_path()
 
         if sys.version_info[:2] != (2, 7):
             pytest.skip("App Engine only tests on py2.7")
-
-        if 'APPLICATION_ID' not in os.environ:
-            pytest.skip("NoseGAE plugin not used.")
 
         try:
             self.bed = activate_sandbox()

--- a/test/appengine/__init__.py
+++ b/test/appengine/__init__.py
@@ -47,19 +47,22 @@ class AppEngineSandboxTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        import dev_appserver
-        dev_appserver.fix_sys_path()
+        try:
+            import dev_appserver
+            dev_appserver.fix_sys_path()
+        except ImportError:
+            pytest.skip("App Engine SDK not available.")
 
         if sys.version_info[:2] != (2, 7):
             pytest.skip("App Engine only tests on py2.7")
 
+    def setUp(self):
         try:
             self.bed = activate_sandbox()
         except ImportError:
             pytest.skip("App Engine SDK not available.")
 
-    @classmethod
-    def tearDownClass(self):
+    def tearDown(self):
         try:
             deactivate_sandbox(self.bed)
         except ImportError:

--- a/test/appengine/__init__.py
+++ b/test/appengine/__init__.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 import pytest
 
-_TEST_BED = None
-
 
 def activate_sandbox():
     """
@@ -13,6 +11,10 @@ def activate_sandbox():
     Inserts the stub module import hook which causes the usage of appengine-specific
     httplib, httplib2, socket, etc.
     """
+    import dev_appserver
+    dev_appserver.fix_sys_path()
+
+
     from google.appengine.tools.devappserver2.python import sandbox
     from google.appengine.ext import testbed
 

--- a/test/appengine/__init__.py
+++ b/test/appengine/__init__.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import unittest
 import pytest

--- a/test/appengine/app.yaml
+++ b/test/appengine/app.yaml
@@ -1,4 +1,4 @@
-# dummy app.yaml for nosegae
+# dummy app.yaml for pytest_gae
 
 api_version: 1
 runtime: python27

--- a/test/appengine/nose.cfg
+++ b/test/appengine/nose.cfg
@@ -1,4 +1,0 @@
-[nosetests]
-cover-min-percentage=0
-with-gae=1
-gae-application=test/appengine/app.yaml

--- a/test/appengine/requirements.txt
+++ b/test/appengine/requirements.txt
@@ -1,1 +1,1 @@
-NoseGAE==0.5.7
+pytest_gae==0.2.4

--- a/test/appengine/requirements.txt
+++ b/test/appengine/requirements.txt
@@ -1,1 +1,1 @@
-pytest_gae==0.2.4
+pytest-beds==0.3.0

--- a/test/appengine/requirements.txt
+++ b/test/appengine/requirements.txt
@@ -1,1 +1,0 @@
-pytest-beds==0.3.0

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -5,7 +5,6 @@ from mock import patch
 from ..test_no_ssl import TestWithoutSSL
 
 
-
 class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
     def test_urlfetch_called_with_http(self):
         """

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -6,7 +6,7 @@ from ..test_no_ssl import TestWithoutSSL
 
 
 class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
-    def test_urlfetch_called_with_http(self):
+    def test_urlfetch_called_with_http(self, urlfetch):
         """
         Check that URLFetch is used to fetch non-https resources
         """
@@ -25,7 +25,7 @@ class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
 
 
 class TestHTTPS(AppEngineSandboxTest):
-    def test_urlfetch_called_with_https(self):
+    def test_urlfetch_called_with_https(self, urlfetch):
         """
         Check that URLFetch is used when fetching https resources
         """

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -5,6 +5,7 @@ from mock import patch
 from ..test_no_ssl import TestWithoutSSL
 
 
+
 class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
     def test_urlfetch_called_with_http(self):
         """

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -5,8 +5,9 @@ from mock import patch
 from ..test_no_ssl import TestWithoutSSL
 
 
+
 class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
-    def test_urlfetch_called_with_http(self, urlfetch):
+    def test_urlfetch_called_with_http(self):
         """
         Check that URLFetch is used to fetch non-https resources
         """
@@ -25,11 +26,11 @@ class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
 
 
 class TestHTTPS(AppEngineSandboxTest):
+    @pytest.mark.skip('This test fails.')
     def test_urlfetch_called_with_https(self, urlfetch):
         """
         Check that URLFetch is used when fetching https resources
         """
-        pytest.mark.skip('This test fails.')
         resp = MockResponse(
             'OK',
             200,

--- a/test/appengine/test_urlfetch.py
+++ b/test/appengine/test_urlfetch.py
@@ -1,13 +1,11 @@
 from . import AppEngineSandboxTest, MockResponse
 
+import pytest
 from mock import patch
-from nose.plugins.skip import SkipTest
 from ..test_no_ssl import TestWithoutSSL
 
 
 class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
-    nosegae_urlfetch = True
-
     def test_urlfetch_called_with_http(self):
         """
         Check that URLFetch is used to fetch non-https resources
@@ -27,13 +25,11 @@ class TestHTTP(AppEngineSandboxTest, TestWithoutSSL):
 
 
 class TestHTTPS(AppEngineSandboxTest):
-    nosegae_urlfetch = True
-
     def test_urlfetch_called_with_https(self):
         """
         Check that URLFetch is used when fetching https resources
         """
-        raise SkipTest()  # Skipped for now because it fails.
+        pytest.mark.skip('This test fails.')
         resp = MockResponse(
             'OK',
             200,

--- a/test/contrib/test_gae_manager.py
+++ b/test/contrib/test_gae_manager.py
@@ -29,6 +29,7 @@ def setup_module(module):
     if not HAS_APPENGINE_SDK:
         pytest.skip('Tests require Google AppEngine SDK.')
 
+
 # This class is used so we can re-use the tests from the connection pool.
 # It proxies all requests to the manager.
 class MockPool(object):

--- a/test/contrib/test_gae_manager.py
+++ b/test/contrib/test_gae_manager.py
@@ -88,7 +88,7 @@ class TestGAEConnectionManager(TestConnectionPool):
         deactivate_urlfetch(self.bed)
 
     # Tests specific to AppEngineManager
-    def test_exceptions(self, urlfetch):
+    def test_exceptions(self):
         # DeadlineExceededError -> TimeoutError
         self.assertRaises(
             TimeoutError,
@@ -170,7 +170,7 @@ class TestGAEConnectionManagerWithSSL(HTTPSDummyServerTestCase):
     def tearDown(self):
         deactivate_urlfetch(self.bed)
 
-    def test_exceptions(self, urlfetch):
+    def test_exceptions(self):
         # SSLCertificateError -> SSLError
         # SSLError is raised with dummyserver because URLFetch doesn't allow
         # self-signed certs.

--- a/test/contrib/test_gae_manager.py
+++ b/test/contrib/test_gae_manager.py
@@ -31,6 +31,9 @@ def setup_module(module):
 
 
 def activate_urlfetch():
+    import dev_appserver
+    dev_appserver.fix_sys_path()
+
     from google.appengine.ext import testbed
 
     bed = testbed.Testbed()

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import unittest
-
-from nose.plugins.skip import SkipTest
+import pytest
 
 try:
     from urllib3.contrib.pyopenssl import (inject_into_urllib3,
                                            extract_from_urllib3,
                                            _dnsname_to_stdlib)
+    HAS_PYOPENSSL = True
 except ImportError as e:
-    raise SkipTest('Could not import PyOpenSSL: %r' % e)
+    HAS_PYOPENSSL = False
 
 
 from ..with_dummyserver.test_https import TestHTTPS, TestHTTPS_TLSv1  # noqa: F401
@@ -17,14 +17,17 @@ from ..with_dummyserver.test_socketlevel import (  # noqa: F401
 )
 
 
-def setup_module():
+def setup_module(module):
+    if not HAS_PYOPENSSL:
+        pytest.skip('Tests require PyOpenSSL.')
     inject_into_urllib3()
 
 
-def teardown_module():
+def teardown_module(module):
     extract_from_urllib3()
 
 
+@pytest.mark.skipif(not HAS_PYOPENSSL, 'Tests require PyOpenSSL')
 class TestPyOpenSSLHelpers(unittest.TestCase):
     """
     Tests for PyOpenSSL helper functions.

--- a/test/contrib/test_pyopenssl.py
+++ b/test/contrib/test_pyopenssl.py
@@ -27,7 +27,7 @@ def teardown_module(module):
     extract_from_urllib3()
 
 
-@pytest.mark.skipif(not HAS_PYOPENSSL, 'Tests require PyOpenSSL')
+@pytest.mark.skipif(not HAS_PYOPENSSL, reason='Tests require PyOpenSSL')
 class TestPyOpenSSLHelpers(unittest.TestCase):
     """
     Tests for PyOpenSSL helper functions.

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -1,15 +1,22 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from nose.plugins.skip import SkipTest
+import pytest
 
 try:
     from urllib3.contrib.pyopenssl import (inject_into_urllib3,
-                                           extract_from_urllib3)
+                                           extract_from_urllib3,
+                                           _dnsname_to_stdlib)
+    HAS_PYOPENSSL = True
 except ImportError as e:
-    raise SkipTest('Could not import PyOpenSSL: %r' % e)
+    HAS_PYOPENSSL = False
 
 from mock import patch, Mock
+
+
+def setup_module(module):
+    if not HAS_PYOPENSSL:
+        pytest.skip('Tests require PyOpenSSL.')
 
 
 class TestPyOpenSSLInjection(unittest.TestCase):

--- a/test/contrib/test_pyopenssl_dependencies.py
+++ b/test/contrib/test_pyopenssl_dependencies.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 
 try:
-    from urllib3.contrib.pyopenssl import (inject_into_urllib3,
+    from urllib3.contrib.pyopenssl import (inject_into_urllib3,  # noqa: F401
                                            extract_from_urllib3,
                                            _dnsname_to_stdlib)
     HAS_PYOPENSSL = True

--- a/test/contrib/test_securetransport.py
+++ b/test/contrib/test_securetransport.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-from nose.plugins.skip import SkipTest
+import pytest
 
 try:
     from urllib3.contrib.securetransport import (inject_into_urllib3,
                                                  extract_from_urllib3)
+    HAS_SECURETRANSPORT = True
 except ImportError as e:
-    raise SkipTest('Could not import SecureTransport: %r' % e)
+    HAS_SECURETRANSPORT = False
 
 from ..with_dummyserver.test_https import TestHTTPS, TestHTTPS_TLSv1  # noqa: F401
 from ..with_dummyserver.test_socketlevel import (  # noqa: F401
@@ -13,9 +14,11 @@ from ..with_dummyserver.test_socketlevel import (  # noqa: F401
 )
 
 
-def setup_module():
+def setup_module(module):
+    if not HAS_SECURETRANSPORT:
+        pytest.skip('Tests require SecureTransport.')
     inject_into_urllib3()
 
 
-def teardown_module():
+def teardown_module(module):
     extract_from_urllib3()

--- a/test/contrib/test_socks.py
+++ b/test/contrib/test_socks.py
@@ -7,7 +7,7 @@ from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
 from dummyserver.server import DEFAULT_CERTS
 from dummyserver.testcase import IPV4SocketDummyServerTestCase
 
-from nose.plugins.skip import SkipTest
+import pytest
 
 try:
     import ssl
@@ -632,7 +632,7 @@ class TestSOCKSWithTLS(IPV4SocketDummyServerTestCase):
     """
     def test_basic_request(self):
         if not HAS_SSL:
-            raise SkipTest("No TLS available")
+            pytest.skip("No TLS available")
 
         def request_handler(listener):
             sock = listener.accept()[0]

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -4,7 +4,7 @@ from urllib3._collections import (
     HTTPHeaderDict,
     RecentlyUsedContainer as Container
 )
-from nose.plugins.skip import SkipTest
+import pytest
 
 from urllib3.packages import six
 xrange = six.moves.xrange
@@ -317,7 +317,7 @@ class TestHTTPHeaderDict(unittest.TestCase):
 
     def test_from_httplib_py2(self):
         if six.PY3:
-            raise SkipTest("python3 has a different internal header implementation")
+            pytest.skip("python3 has a different internal header implementation")
         msg = """
 Server: nginx
 Content-Type: text/html; charset=windows-1251

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -1,3 +1,4 @@
+import pytest
 import unittest
 import warnings
 
@@ -6,7 +7,7 @@ from urllib3.connection import HTTPConnection
 
 class TestVersionCompatibility(unittest.TestCase):
     def test_connection_strict(self):
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None) as w:
             warnings.simplefilter("always")
 
             # strict=True is deprecated in Py33+

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,6 +7,7 @@ import ssl
 import socket
 from itertools import chain
 
+import pytest
 from mock import patch, Mock
 
 from urllib3 import add_stderr_logger, disable_warnings
@@ -331,7 +332,7 @@ class TestUtil(unittest.TestCase):
         logger.removeHandler(handler)
 
     def test_disable_warnings(self):
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None) as w:
             clear_warnings()
             warnings.warn('This is a test.', InsecureRequestWarning)
             self.assertEqual(len(w), 1)

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -472,6 +472,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
 
         https_pool._make_request(conn, 'GET', '/')
 
+    @onlyPy279OrNewer
     def test_ssl_correct_system_time(self):
         self._pool.cert_reqs = 'CERT_REQUIRED'
         self._pool.ca_certs = DEFAULT_CA
@@ -479,6 +480,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         w = self._request_without_resource_warnings('GET', '/')
         self.assertEqual([], w)
 
+    @onlyPy279OrNewer
     def test_ssl_wrong_system_time(self):
         self._pool.cert_reqs = 'CERT_REQUIRED'
         self._pool.ca_certs = DEFAULT_CA

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -494,7 +494,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
             self.assertTrue(str(RECENT_DATE) in warning.message.args[0])
 
     def _request_without_resource_warnings(self, method, url):
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None) as w:
             warnings.simplefilter('always')
             self._pool.request(method, url)
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -6,7 +6,7 @@ import unittest
 import warnings
 
 import mock
-from nose.plugins.skip import SkipTest
+import pytest
 
 from dummyserver.testcase import (
     HTTPSDummyServerTestCase, IPV6HTTPSDummyServerTestCase
@@ -549,7 +549,7 @@ class TestHTTPS_IPSAN(HTTPSDummyServerTestCase):
         try:
             import ipaddress  # noqa: F401
         except ImportError:
-            raise SkipTest("Only runs on systems with an ipaddress module")
+            pytest.skip("Only runs on systems with an ipaddress module")
 
         https_pool = HTTPSConnectionPool('127.0.0.1', self.port,
                                          cert_reqs='CERT_REQUIRED',
@@ -565,7 +565,7 @@ class TestHTTPS_IPv6Addr(IPV6HTTPSDummyServerTestCase):
     def test_strip_square_brackets_before_validating(self):
         """Test that the fix for #760 works."""
         if not HAS_IPV6:
-            raise SkipTest("Only runs on IPv6 systems")
+            pytest.skip("Only runs on IPv6 systems")
         https_pool = HTTPSConnectionPool('[::1]', self.port,
                                          cert_reqs='CERT_REQUIRED',
                                          ca_certs=IPV6_ADDR_CA)

--- a/test/with_dummyserver/test_poolmanager.py
+++ b/test/with_dummyserver/test_poolmanager.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 
-from nose.plugins.skip import SkipTest
+import pytest
 from dummyserver.server import HAS_IPV6
 from dummyserver.testcase import (HTTPDummyServerTestCase,
                                   IPv6HTTPDummyServerTestCase)
@@ -215,10 +215,8 @@ class TestPoolManager(HTTPDummyServerTestCase):
         self.assertEqual(r.status, 200)
 
 
+@pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not supported on this system.")
 class TestIPv6PoolManager(IPv6HTTPDummyServerTestCase):
-    if not HAS_IPV6:
-        raise SkipTest("IPv6 is not supported on this system.")
-
     def setUp(self):
         self.base_url = 'http://[%s]:%d' % (self.host, self.port)
 

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -1,8 +1,7 @@
 import json
 import socket
 import unittest
-
-from nose.tools import timed
+import pytest
 
 from dummyserver.testcase import HTTPDummyProxyTestCase, IPv6HTTPDummyProxyTestCase
 from dummyserver.server import (
@@ -292,7 +291,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.assertNotEqual(sc2, sc3)
         self.assertEqual(sc3, sc4)
 
-    @timed(0.5)
+    @pytest.mark.timeout(timeout=0.5)
     @requires_network
     def test_https_proxy_timeout(self):
         https = proxy_from_url('https://{host}'.format(host=TARPIT_HOST))
@@ -303,7 +302,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         except MaxRetryError as e:
             self.assertEqual(type(e.reason), ConnectTimeoutError)
 
-    @timed(0.5)
+    @pytest.mark.timeout(timeout=0.5)
     @requires_network
     def test_https_proxy_pool_timeout(self):
         https = proxy_from_url('https://{host}'.format(host=TARPIT_HOST),

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -22,7 +22,7 @@ from dummyserver.server import (
 
 from .. import onlyPy3, LogRecorder
 
-from nose.plugins.skip import SkipTest
+import pytest
 try:
     from mimetools import Message as MimeToolMessage
 except ImportError:
@@ -62,7 +62,7 @@ class TestSNI(SocketDummyServerTestCase):
 
     def test_hostname_in_first_request_packet(self):
         if not HAS_SNI:
-            raise SkipTest('SNI-support not available')
+            pytest.skip('SNI-support not available')
 
         done_receiving = Event()
         self.buf = b''
@@ -1168,7 +1168,7 @@ class TestHeaders(SocketDummyServerTestCase):
 class TestBrokenHeaders(SocketDummyServerTestCase):
     def setUp(self):
         if issubclass(httplib.HTTPMessage, MimeToolMessage):
-            raise SkipTest('Header parsing errors not available')
+            pytest.skip('Header parsing errors not available')
 
         super(TestBrokenHeaders, self).setUp()
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,11 @@ deps=
     {[testenv]deps}
     -r{toxinidir}/test/appengine/requirements.txt
 commands=
-    pytest --project-root test/appengine/ --cov urllib3 test/appengine/
+    pytest --cov urllib3 test/appengine/
 
     # For now, this test is ran separately because the sandbox activation in
     # the app engine tests will blow up everything.
-    pytest --project-root test/appengine/ test/contrib/test_gae_manager.py
+    pytest test/contrib/test_gae_manager.py
 setenv =
     PYTHONPATH={env:GAE_PYTHONPATH:}
     {[testenv]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = flake8-py3, py26, py27, py33, py34, py35, py36, pypy
 deps= -r{toxinidir}/dev-requirements.txt
 commands=
     pip install .[socks,secure]
-    nosetests []
+    pytest --cov urllib3 test/
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS
@@ -22,16 +22,11 @@ deps=
     {[testenv]deps}
     -r{toxinidir}/test/appengine/requirements.txt
 commands=
-    nosetests \
-        -c {toxinidir}/test/appengine/nose.cfg \
-        test/appengine \
-        []
+    pytest --with-gae --gae-project-path test/appengine/ --cov urllib3 test/appengine/
+
     # For now, this test is ran separately because the sandbox activation in
     # the app engine tests will blow up everything.
-    nosetests \
-        -c {toxinidir}/test/appengine/nose.cfg \
-        test/contrib/test_gae_manager.py \
-        []
+    pytest --with-gae --gae-project-path test/appengine/ test/contrib/test_gae_manager.py
 setenv =
     PYTHONPATH={env:GAE_PYTHONPATH:}
     {[testenv]setenv}

--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,11 @@ deps=
     {[testenv]deps}
     -r{toxinidir}/test/appengine/requirements.txt
 commands=
-    pytest --with-gae --gae-project-path test/appengine/ --cov urllib3 test/appengine/
+    pytest --project-root test/appengine/ --cov urllib3 test/appengine/
 
     # For now, this test is ran separately because the sandbox activation in
     # the app engine tests will blow up everything.
-    pytest --with-gae --gae-project-path test/appengine/ test/contrib/test_gae_manager.py
+    pytest --project-root test/appengine/ test/contrib/test_gae_manager.py
 setenv =
     PYTHONPATH={env:GAE_PYTHONPATH:}
     {[testenv]setenv}


### PR DESCRIPTION
The first step in the effort to switch to `py.test` as opposed to `nose`/`unittest` (#1160).
So far I've hit two problems: 
- Apparently `py.test` reloads the entire module per-test and emits the "No true SSLContext object available" warning for each test which luckily only affects Python 2.6 `test_https.TestHTTPS.test_ssl_wrong_system_time` and `test_https.TestHTTPS.test_ssl_correct_system_time` tests. Id' advocate just skipping these tests on Python versions without a correct SSLContext.

- Google App Engine, I don't know much about it or how testbeds work so I could use some direction here.
