### PR TITLE
Add JythonSelectSelector to urllib3/util/selectors.py [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ env:
 # https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
   include:
+    - python: 2.7
+      env:
+        - TOXENV=jython JYTHON=org.python:jython-installer:2.7.0
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -8,6 +8,9 @@ if [ -n "$JYTHON" ]; then
     jip install $JYTHON
     OLD_VIRTUAL_ENV=$VIRTUAL_ENV
     java -jar $OLD_VIRTUAL_ENV/javalib/jython-installer-2.7.0.jar -s -d $HOME/jython
+
+    # Required for --distribute option.
+    pip install virtualenv==1.9.1
     virtualenv --distribute -p $HOME/jython/bin/jython $HOME/jenv
 fi
 

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -13,9 +13,8 @@ if [ -n "$JYTHON" ]; then
     pip install virtualenv==1.9.1
     virtualenv --distribute -p $HOME/jython/bin/jython $HOME/jenv
     source $HOME/jenv/bin/activate
-fi
 
-if [[ "$(uname -s)" == 'Darwin' ]]; then
+elif [[ "$(uname -s)" == 'Darwin' ]]; then
     sw_vers
     brew update || brew update
 

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -6,9 +6,8 @@ set -x
 if [ -n "$JYTHON" ]; then
     pip install jip
     jip install $JYTHON
-    _JYTHON_BASENAME=${NON_GROUP_ID/:/-}
     OLD_VIRTUAL_ENV=$VIRTUAL_ENV
-    java -jar $OLD_VIRTUAL_ENV/javalib/${_JYTHON_BASENAME}.jar -s -d $HOME/jython
+    java -jar $OLD_VIRTUAL_ENV/javalib/jython-installer-2.7.0.jar -s -d $HOME/jython
     virtualenv --distribute -p $HOME/jython/bin/jython $HOME/jenv
 fi
 

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -3,6 +3,15 @@
 set -e
 set -x
 
+if [ -n "$JYTHON" ]; then
+    pip install jip
+    jip install $JYTHON
+    _JYTHON_BASENAME=${NON_GROUP_ID/:/-}
+    OLD_VIRTUAL_ENV=$VIRTUAL_ENV
+    java -jar $OLD_VIRTUAL_ENV/javalib/${_JYTHON_BASENAME}.jar -s -d $HOME/jython
+    virtualenv --distribute -p $HOME/jython/bin/jython $HOME/jenv
+fi
+
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     sw_vers
     brew update || brew update

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -12,6 +12,7 @@ if [ -n "$JYTHON" ]; then
     # Required for --distribute option.
     pip install virtualenv==1.9.1
     virtualenv --distribute -p $HOME/jython/bin/jython $HOME/jenv
+    source $HOME/jenv/bin/activate
 fi
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then

--- a/_travis/run.sh
+++ b/_travis/run.sh
@@ -16,4 +16,9 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     export CFLAGS="-I$(brew --prefix openssl@1.1)/include"
 fi
 
+if [ -n "$JYTHON" ]; then
+    source $HOME/jenv/bin/activate
+    export CLASSPATH=$VIRTUAL_ENV/javalib/*
+fi
+
 tox

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -54,7 +54,7 @@ APPVEYOR = "APPVEYOR" in os.environ
 skipUnlessHasSelector = skipUnless(selectors.HAS_SELECT, "Platform doesn't have a selector")
 skipUnlessHasENOSYS = skipUnless(hasattr(errno, 'ENOSYS'), "Platform doesn't have errno.ENOSYS")
 skipUnlessHasAlarm = skipUnless(hasattr(signal, 'alarm'), "Platform doesn't have signal.alarm()")
-skipUnlessJython = skipUnless(platform.system() == 'Jython', "Platform is not Jython")
+skipUnlessJython = skipUnless(platform.system() == 'Java', "Platform is not Jython")
 
 
 def patch_select_module(testcase, *keep, **replace):

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 import errno
 import os
 import psutil
+import platform
 import select
 import signal
 import sys
@@ -53,6 +54,7 @@ APPVEYOR = "APPVEYOR" in os.environ
 skipUnlessHasSelector = skipUnless(selectors.HAS_SELECT, "Platform doesn't have a selector")
 skipUnlessHasENOSYS = skipUnless(hasattr(errno, 'ENOSYS'), "Platform doesn't have errno.ENOSYS")
 skipUnlessHasAlarm = skipUnless(hasattr(signal, 'alarm'), "Platform doesn't have signal.alarm()")
+skipUnlessJython = skipUnless(platform.system() == 'Jython', "Platform is not Jython")
 
 
 def patch_select_module(testcase, *keep, **replace):
@@ -769,6 +771,13 @@ class EpollSelectorTestCase(BaseSelectorTestCase, ScalableSelectorMixin):
 class KqueueSelectorTestCase(BaseSelectorTestCase, ScalableSelectorMixin):
     def setUp(self):
         patch_select_module(self, 'kqueue')
+
+
+@skipUnlessJython
+@skipUnless(hasattr(selectors, "JythonSelectSelector"), "Platform doesn't have a SelectSelector")
+class JythonSelectSelectorTestBase(BaseSelectorTestCase):
+    def setUp(self):
+        patch_select_module(self, 'select')
 
 
 @skipUnless(hasattr(selectors, "SelectSelector"), "Platform doesn't have a SelectSelector")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8-py3, py26, py27, py33, py34, py35, py36, pypy
+envlist = flake8-py3, py26, py27, py33, py34, py35, py36, pypy, jython
 
 [testenv]
 deps= -r{toxinidir}/dev-requirements.txt

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -333,7 +333,7 @@ if hasattr(select, "select"):
                     ready.append((key, events & key.events))
             return ready
 
-    if platform.system() == 'Java':
+    if _IS_JYTHON:
         class _JythonSelectorMapping(object):
             """ This is an implementation of _SelectorMapping that is built
             for use specifically with Jython, which does not provide a hashable

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -24,6 +24,7 @@ EVENT_WRITE = (1 << 1)
 HAS_SELECT = True  # Variable that shows whether the platform has a selector.
 _SYSCALL_SENTINEL = object()  # Sentinel in case a system call returns None.
 _DEFAULT_SELECTOR = None
+_IS_JYTHON = platform.system() == 'Java'
 
 
 class SelectorError(Exception):
@@ -332,6 +333,100 @@ if hasattr(select, "select"):
                     ready.append((key, events & key.events))
             return ready
 
+    if platform.system() == 'Java':
+        class _JythonSelectorMapping(object):
+            """ This is an implementation of _SelectorMapping that is built
+            for use specifically with Jython, which does not provide a hashable
+            value from socket.socket.fileno(). """
+            def __init__(self, selector):
+                self._selector = selector
+                
+            def __len__(self):
+                return len(self._selector._sockets)
+
+            def __getitem__(self, fileobj):
+                for sock, key in self._selector._sockets:
+                    if sock is fileobj:
+                        return key
+                else:
+                    raise KeyError("{0!r} is not registered.".format(fileobj))
+
+
+        class JythonSelectSelector(SelectSelector):
+            """ This is an implementation of SelectSelector that is for Jython
+            which works around that Jython's socket.socket.fileno() does not
+            return an integer fd value. All SelectorKey.fd will be equal to -1
+            and should not be used. This instead uses object id to compare fileobj
+            and will only use select.select as it's the only selector that allows
+            directly passing in socket objects rather than registering fds.
+            
+            See: https://github.com/kennethreitz/requests/issues/3992
+                 http://bugs.jython.org/issue1678
+                 https://wiki.python.org/jython/NewSocketModule#socket.fileno.28.29_does_not_return_an_integer
+            """
+            def __init__(self):
+                super(JythonSelectSelector, self).__init__()
+
+                self._sockets = [] # Uses a list of tuples instead of dictionary.
+                self._map = _JythonSelectorMapping(self)
+                self._readers = []
+                self._writers = []
+
+            def register(self, fileobj, events, data=None):
+                for sock, _ in self._sockets:
+                    if sock is fileobj:
+                        raise KeyError("{0!r} is already registered"
+                           .format(fileobj, sock))
+                
+                key = SelectorKey(fileobj, -1, events, data)
+                self._sockets.append((fileobj, key))
+
+                if events & EVENT_READ:
+                    self._readers.append(fileobj)
+                if events & EVENT_WRITE:
+                    self._writers.append(fileobj)
+            
+            def unregister(self, fileobj):
+                for i, (sock, key) in enumerate(self._sockets):
+                    if sock is fileobj:
+                        break
+                else:
+                    raise KeyError("{0!r} is not registered.".format(fileobj))
+
+                if key.events & EVENT_READ:
+                    self._readers.remove(fileobj)
+                if key.events & EVENT_WRITE:
+                    self._writers.remove(fileobj)
+
+                del self._sockets[i]
+                return key
+
+            def select(self, timeout=None):
+                if not len(self._readers) and not len(self._writers):
+                    return []
+
+                timeout = None if timeout is None else max(timeout, 0.0)
+                ready = []
+                r, w, _ = _syscall_wrapper(self._select, True, self._readers,
+                                       self._writers, timeout)
+                
+                seen = []
+                for sock in r + w:
+                    if sock in seen:
+                        continue
+                    seen.append(sock)
+                    events = 0
+                    if sock in r:
+                        events |= EVENT_READ
+                    if sock in w:
+                        events |= EVENT_WRITE
+
+                    for fileobj, key in self._sockets:
+                        if fileobj is sock:
+                            ready.append((key, events & key.events))
+
+                return ready
+
 
 if hasattr(select, "poll"):
     class PollSelector(BaseSelector):
@@ -567,7 +662,9 @@ def DefaultSelector():
     detect if the select module is being monkey-patched incorrectly
     by eventlet, greenlet, and preserve proper behavior. """
     global _DEFAULT_SELECTOR
-    if _DEFAULT_SELECTOR is None:
+    if _DEFAULT_SELECTOR is None: 
+        if _IS_JYTHON:  # Platform-specific: Jython
+            _DEFAULT_SELECTOR = JythonSelectSelector
         if _can_allocate('kqueue'):
             _DEFAULT_SELECTOR = KqueueSelector
         elif _can_allocate('epoll'):

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -11,6 +11,7 @@ import select
 import socket
 import sys
 import time
+import platform
 from collections import namedtuple, Mapping
 
 try:
@@ -333,99 +334,99 @@ if hasattr(select, "select"):
                     ready.append((key, events & key.events))
             return ready
 
-    if _IS_JYTHON:
-        class _JythonSelectorMapping(object):
-            """ This is an implementation of _SelectorMapping that is built
-            for use specifically with Jython, which does not provide a hashable
-            value from socket.socket.fileno(). """
-            def __init__(self, selector):
-                self._selector = selector
-                
-            def __len__(self):
-                return len(self._selector._sockets)
+    class _JythonSelectorMapping(object):
+        """ This is an implementation of _SelectorMapping that is built
+        for use specifically with Jython, which does not provide a hashable
+        value from socket.socket.fileno(). """
+        def __init__(self, selector):
+            assert isinstance(selector, JythonSelectSelector)
+            self._selector = selector
 
-            def __getitem__(self, fileobj):
-                for sock, key in self._selector._sockets:
-                    if sock is fileobj:
-                        return key
-                else:
-                    raise KeyError("{0!r} is not registered.".format(fileobj))
+        def __len__(self):
+            return len(self._selector._sockets)
 
+        def __getitem__(self, fileobj):
+            for sock, key in self._selector._sockets:
+                if sock is fileobj:
+                    return key
+            else:
+                raise KeyError("{0!r} is not registered.".format(fileobj))
 
-        class JythonSelectSelector(SelectSelector):
-            """ This is an implementation of SelectSelector that is for Jython
-            which works around that Jython's socket.socket.fileno() does not
-            return an integer fd value. All SelectorKey.fd will be equal to -1
-            and should not be used. This instead uses object id to compare fileobj
-            and will only use select.select as it's the only selector that allows
-            directly passing in socket objects rather than registering fds.
-            
-            See: https://github.com/kennethreitz/requests/issues/3992
-                 http://bugs.jython.org/issue1678
-                 https://wiki.python.org/jython/NewSocketModule#socket.fileno.28.29_does_not_return_an_integer
-            """
-            def __init__(self):
-                super(JythonSelectSelector, self).__init__()
+    class JythonSelectSelector(SelectSelector):
+        """ This is an implementation of SelectSelector that is for Jython
+        which works around that Jython's socket.socket.fileno() does not
+        return an integer fd value. All SelectorKey.fd will be equal to -1
+        and should not be used. This instead uses object id to compare fileobj
+        and will only use select.select as it's the only selector that allows
+        directly passing in socket objects rather than registering fds.
 
-                self._sockets = [] # Uses a list of tuples instead of dictionary.
-                self._map = _JythonSelectorMapping(self)
-                self._readers = []
-                self._writers = []
+        See: https://github.com/kennethreitz/requests/issues/3992
+             http://bugs.jython.org/issue1678
+             https://wiki.python.org/jython/NewSocketModule#socket.fileno.28.29_does_not_return_an_integer
+        """
+        def __init__(self):
+            super(JythonSelectSelector, self).__init__()
 
-            def register(self, fileobj, events, data=None):
-                for sock, _ in self._sockets:
-                    if sock is fileobj:
-                        raise KeyError("{0!r} is already registered"
-                           .format(fileobj, sock))
-                
-                key = SelectorKey(fileobj, -1, events, data)
-                self._sockets.append((fileobj, key))
+            self._sockets = []  # Uses a list of tuples instead of dictionary.
+            self._map = _JythonSelectorMapping(self)
+            self._readers = []
+            self._writers = []
 
-                if events & EVENT_READ:
-                    self._readers.append(fileobj)
-                if events & EVENT_WRITE:
-                    self._writers.append(fileobj)
-            
-            def unregister(self, fileobj):
-                for i, (sock, key) in enumerate(self._sockets):
-                    if sock is fileobj:
-                        break
-                else:
-                    raise KeyError("{0!r} is not registered.".format(fileobj))
+        def register(self, fileobj, events, data=None):
+            for sock, _ in self._sockets:
+                if sock is fileobj:
+                    raise KeyError("{0!r} is already registered"
+                                   .format(fileobj, sock))
 
-                if key.events & EVENT_READ:
-                    self._readers.remove(fileobj)
-                if key.events & EVENT_WRITE:
-                    self._writers.remove(fileobj)
+            key = SelectorKey(fileobj, -1, events, data)
+            self._sockets.append((fileobj, key))
 
-                del self._sockets[i]
-                return key
+            if events & EVENT_READ:
+                self._readers.append(fileobj)
+            if events & EVENT_WRITE:
+                self._writers.append(fileobj)
+            return key
 
-            def select(self, timeout=None):
-                if not len(self._readers) and not len(self._writers):
-                    return []
+        def unregister(self, fileobj):
+            for i, (sock, key) in enumerate(self._sockets):
+                if sock is fileobj:
+                    break
+            else:
+                raise KeyError("{0!r} is not registered.".format(fileobj))
 
-                timeout = None if timeout is None else max(timeout, 0.0)
-                ready = []
-                r, w, _ = _syscall_wrapper(self._select, True, self._readers,
+            if key.events & EVENT_READ:
+                self._readers.remove(fileobj)
+            if key.events & EVENT_WRITE:
+                self._writers.remove(fileobj)
+
+            del self._sockets[i]
+            return key
+
+        def select(self, timeout=None):
+            if not len(self._readers) and not len(self._writers):
+                return []
+
+            timeout = None if timeout is None else max(timeout, 0.0)
+            ready = []
+            r, w, _ = _syscall_wrapper(self._select, True, self._readers,
                                        self._writers, timeout)
-                
-                seen = []
-                for sock in r + w:
-                    if sock in seen:
-                        continue
-                    seen.append(sock)
-                    events = 0
-                    if sock in r:
-                        events |= EVENT_READ
-                    if sock in w:
-                        events |= EVENT_WRITE
 
-                    for fileobj, key in self._sockets:
-                        if fileobj is sock:
-                            ready.append((key, events & key.events))
+            seen = []
+            for sock in r + w:
+                if sock in seen:
+                    continue
+                seen.append(sock)
+                events = 0
+                if sock in r:
+                    events |= EVENT_READ
+                if sock in w:
+                    events |= EVENT_WRITE
 
-                return ready
+                for fileobj, key in self._sockets:
+                    if fileobj is sock:
+                        ready.append((key, events & key.events))
+
+            return ready
 
 
 if hasattr(select, "poll"):
@@ -662,10 +663,10 @@ def DefaultSelector():
     detect if the select module is being monkey-patched incorrectly
     by eventlet, greenlet, and preserve proper behavior. """
     global _DEFAULT_SELECTOR
-    if _DEFAULT_SELECTOR is None: 
+    if _DEFAULT_SELECTOR is None:
         if _IS_JYTHON:  # Platform-specific: Jython
             _DEFAULT_SELECTOR = JythonSelectSelector
-        if _can_allocate('kqueue'):
+        elif _can_allocate('kqueue'):
             _DEFAULT_SELECTOR = KqueueSelector
         elif _can_allocate('epoll'):
             _DEFAULT_SELECTOR = EpollSelector


### PR DESCRIPTION
As reported by @LordGaav Jython apparently over-rides the default behavior of `socket.socket.fileno()` and instead returns a `socket`. The current implementation of `BaseSelector` relies heavily on the hash-ability of the return value of `fileobj.fileno()`.  This is just a quick implementation, there may be issues with it. I would also like to actually test it on Jython and if that's not possible in our CI setup perhaps make some `mock` tests that simulate a `socket` that returns itself from `fileno()`.

References:
- kennethreitz/requests#3992
- http://bugs.jython.org/issue1678
- https://wiki.python.org/jython/NewSocketModule#socket.fileno.28.29_does_not_return_an_integer