### PR TITLE
Fix deadlocks with pool_block=True and retries

### DIFF
--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -687,11 +687,13 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 retries = retries.increment(method, url, response=response, _pool=self)
             except MaxRetryError:
                 if retries.raise_on_redirect:
-                    # Release the connection for this response, since we're not
-                    # returning it to be released manually.
-                    response.release_conn()
+                    # Discarding the connection for this response, since we're
+                    # not returning it to be released manually.
+                    response.discard_conn()
                     raise
                 return response
+
+            response.discard_conn()
 
             retries.sleep_for_retry(response)
             log.debug("Redirecting %s -> %s", url, redirect_location)
@@ -710,11 +712,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                 retries = retries.increment(method, url, response=response, _pool=self)
             except MaxRetryError:
                 if retries.raise_on_status:
-                    # Release the connection for this response, since we're not
+                    # Discarding the connection for this response, since we're not
                     # returning it to be released manually.
-                    response.release_conn()
+                    response.discard_conn()
                     raise
                 return response
+
+            response.discard_conn()
+
             retries.sleep(response)
             log.debug("Retry: %s", url)
             return self.urlopen(

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -178,6 +178,13 @@ class HTTPResponse(io.IOBase):
         self._pool._put_conn(self._connection)
         self._connection = None
 
+    def discard_conn(self):
+        if not self._pool or not self._connection:
+            return
+
+        self._connection = self._connection and self._connection.close()
+        self._pool._put_conn(self._connection)
+
     @property
     def data(self):
         # For backwords-compat with earlier urllib3 0.4 and earlier.


### PR DESCRIPTION
Discard connection on retry/redirect before issuing another request to prevent deadlocks with pool_block=True