### PR TITLE
Retry SSL Errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 dev (master)
 ------------
 
+* Made the connection pool retry on ``SSLError``.  The original ``SSLError``
+  is available on ``MaxRetryError.reason``. (Issue #1112)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -36,7 +36,8 @@ from urllib3.exceptions import (
     InsecureRequestWarning,
     SystemTimeWarning,
     InsecurePlatformWarning,
-    MaxRetryError)
+    MaxRetryError,
+)
 from urllib3.packages import six
 from urllib3.util.timeout import Timeout
 import urllib3.util as util
@@ -329,22 +330,22 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         https_pool.assert_fingerprint = 'AA:AA:AA:AA:AA:AAAA:AA:AAAA:AA:' \
                                         'AA:AA:AA:AA:AA:AA:AA:AA:AA'
 
-        def _test_request():
+        def _test_request(pool):
             with self.assertRaises(MaxRetryError) as cm:
-                https_pool.request('GET', '/', retries=0)
+                pool.request('GET', '/', retries=0)
             self.assertIsInstance(cm.exception.reason, SSLError)
 
-        _test_request()
+        _test_request(https_pool)
         https_pool._get_conn()
 
         # Uneven length
         https_pool.assert_fingerprint = 'AA:A'
-        _test_request()
+        _test_request(https_pool)
         https_pool._get_conn()
 
         # Invalid length
         https_pool.assert_fingerprint = 'AA'
-        _test_request()
+        _test_request(https_pool)
 
     def test_verify_none_and_bad_fingerprint(self):
         https_pool = HTTPSConnectionPool('127.0.0.1', self.port,

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -82,12 +82,13 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         https_pool = http._new_pool('https', self.https_host,
                                     self.https_port)
         try:
-            https_pool.request('GET', '/')
+            https_pool.request('GET', '/', retries=0)
             self.fail("Didn't raise SSL error with wrong CA")
-        except SSLError as e:
-            self.assertTrue('certificate verify failed' in str(e),
+        except MaxRetryError as e:
+            self.assertIsInstance(e.reason, SSLError)
+            self.assertTrue('certificate verify failed' in str(e.reason),
                             "Expected 'certificate verify failed',"
-                            "instead got: %r" % e)
+                            "instead got: %r" % e.reason)
 
         http = proxy_from_url(self.proxy_url, cert_reqs='REQUIRED',
                               ca_certs=DEFAULT_CA)
@@ -103,10 +104,11 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         https_fail_pool = http._new_pool('https', '127.0.0.1', self.https_port)
 
         try:
-            https_fail_pool.request('GET', '/')
+            https_fail_pool.request('GET', '/', retries=0)
             self.fail("Didn't raise SSL invalid common name")
-        except SSLError as e:
-            self.assertTrue("doesn't match" in str(e))
+        except MaxRetryError as e:
+            self.assertIsInstance(e.reason, SSLError)
+            self.assertTrue("doesn't match" in str(e.reason))
 
     def test_redirect(self):
         http = proxy_from_url(self.proxy_url)


### PR DESCRIPTION
This is a fix for #1112. Instead of immediately raising SSLErrors, they are handled by the retry mechanism.

The change introduced ~22 test failures, all of them due to the fact that requests failed due to SSL errors now raise a `MaxRetryError`, and not an `SSLError`. I adapted these tests, also checking that  `MaxRetryError.reason` is an `SSLError`.

As mentioned in #1112, this is somewhat backwards incompatible: if clients explicitly handle `SSLError` exceptions, they now need to catch `MaxRetryError` instead and check if `reason` is an `SSLError`.

I didn't add an explicit test, since the new behaviour is tested implicitly in a lot of existing tests. Is that ok?