### PR TITLE
fix 1 lgtm.com alert

### DIFF
--- a/urllib3/packages/ssl_match_hostname/_implementation.py
+++ b/urllib3/packages/ssl_match_hostname/_implementation.py
@@ -108,13 +108,13 @@ def match_hostname(cert, hostname):
     try:
         # Divergence from upstream: ipaddress can't handle byte str
         host_ip = ipaddress.ip_address(_to_unicode(hostname))
-    except ValueError:
-        # Not an IP address (common case)
-        host_ip = None
     except UnicodeError:
         # Divergence from upstream: Have to deal with ipaddress not taking
         # byte strings.  addresses should be all ascii, so we consider it not
         # an ipaddress in this case
+        host_ip = None
+    except ValueError:
+        # Not an IP address (common case)
         host_ip = None
     except AttributeError:
         # Divergence from upstream: Make ipaddress library optional


### PR DESCRIPTION
Hi,
Just wanted to quickly fix this alert flagged up on lgtm.com.

`UnicodeError` is a subclass of `ValueError` so the ordering of the except blocks would have never allowed to reach it (arguably it had limited impact since the same action is to be taken in both blocks).

Hope this helps!

A total of 14 alerts have been flagged up by lgtm.com, you can enable pull request integration for fully automated PR reviews that will flag these in the future so that they don't get past code review.
https://lgtm.com/projects/g/shazow/urllib3