### PR TITLE
Pin out all unvendored Requests releases for docs.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 ndg-httpsclient
 sphinx
 alabaster
+requests>=2.0,<2.16


### PR DESCRIPTION
Turns out we got broken by Requests v2.16, which pins a version of urllib3 less than the development version.

Resolves #1182.