### PR TITLE
Swap out nose for pytest in the test runner

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,5 @@ tornado==4.2.1
 PySocks==1.5.6
 pkginfo>=1.0,!=1.3.0
 psutil==4.3.1
+pytest-cov==2.5.1
 pytest==3.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ tornado==4.2.1
 PySocks==1.5.6
 pkginfo>=1.0,!=1.3.0
 psutil==4.3.1
+pytest==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='urllib3',
       tests_require=[
           # These are a less-specific subset of dev-requirements.txt, for the
           # convenience of distro package maintainers.
+          'pytest',
           'nose',
           'mock',
           'tornado',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = flake8-py3, py26, py27, py33, py34, py35, py36, pypy
 deps= -r{toxinidir}/dev-requirements.txt
 commands=
     pip install .[socks,secure]
-    nosetests []
+    py.test test
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = flake8-py3, py26, py27, py33, py34, py35, py36, pypy
 deps= -r{toxinidir}/dev-requirements.txt
 commands=
     pip install .[socks,secure]
-    py.test test
+    py.test --cov urllib3 test
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS


### PR DESCRIPTION
The smallest possible step in the direction of #1160. All this does is start running the tests under pytest instead of nose – I was then thinking of doing small patches to gradually remove the nose-specific bits, so that dependency can eventually be removed.

(I have seen #1163, but (1) it appears to be a bit stalled, and (2) I usually prefer smaller patches, and getting the test runner out of the way paves the path for more small patches later.)