### PR TITLE
Add cleanup code to the dummyserver tests

### DIFF
--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -70,6 +70,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         https_pool = HTTPSConnectionPool(self.host, self.port,
                                          cert_reqs='CERT_REQUIRED',
                                          ca_certs=DEFAULT_CA)
+        self.addCleanup(https_pool.close)
 
         conn = https_pool._new_conn()
         self.assertEqual(conn.__class__, VerifiedHTTPSConnection)
@@ -414,6 +415,7 @@ class TestHTTPS(HTTPSDummyServerTestCase):
                                          cert_reqs='CERT_NONE')
         self.addCleanup(https_pool.close)
         conn = https_pool._new_conn()
+        self.addCleanup(conn.close)
         try:
             conn.set_tunnel(self.host, self.port)
         except AttributeError:  # python 2.6

--- a/test/with_dummyserver/test_proxy_poolmanager.py
+++ b/test/with_dummyserver/test_proxy_poolmanager.py
@@ -43,6 +43,7 @@ class TestHTTPProxyManager(HTTPDummyProxyTestCase):
         self.addCleanup(http.clear)
         hc2 = http.connection_from_host(self.http_host, self.http_port)
         conn = hc2._get_conn()
+        self.addCleanup(conn.close)
         hc2._make_request(conn, 'GET', '/')
         tcp_nodelay_setting = conn.sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
         self.assertEqual(tcp_nodelay_setting, 0,


### PR DESCRIPTION
Running the tests locally was throwing up a lot of warnings of the form:

    ResourceWarning: unclosed <ssl.SSLSocket fd=16,
        family=AddressFamily.AF_INET6, type=SocketKind.SOCK_STREAM, proto=6,
        laddr=('::1', 61145, 0, 0), raddr=('::1', 61134, 0, 0)>

This patch tries to reduce the number of `ResourceWarning`s that are emitted by the `with_dummyserver` tests. I get 37 less warnings on this branch compared to the current master (c82139e).

Longer term, it might be nice to switch to using `HTTPConnectionPool` as a context manager, which also reduces the specific ties to unittest, a la #1160 – although I’m less sure what I‘d do about the `HTTPConnection` objects. (Context manager omitted from this patch because the extra indentation makes the diff significantly messier.)