### PR TITLE
Rewrite test_response.py and test_retry.py to be pytest-style

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -181,7 +181,8 @@ class TestResponse(unittest.TestCase):
 
         # Try closing with an `httplib.HTTPResponse`, because it has an
         # `isclosed` method.
-        hlr = httplib.HTTPResponse(socket.socket())
+        sock = socket.socket()
+        hlr = httplib.HTTPResponse(sock)
         resp2 = HTTPResponse(hlr, preload_content=False)
         self.assertEqual(resp2.closed, False)
         resp2.close()
@@ -196,9 +197,11 @@ class TestResponse(unittest.TestCase):
         # `isclosed`, or `fileno`.  Unlikely, but possible.
         self.assertEqual(resp3.closed, True)
         self.assertRaises(IOError, resp3.fileno)
+        sock.close()
 
     def test_io_closed_consistently(self):
-        hlr = httplib.HTTPResponse(socket.socket())
+        sock = socket.socket()
+        hlr = httplib.HTTPResponse(sock)
         hlr.fp = BytesIO(b'foo')
         hlr.chunked = 0
         hlr.length = 3
@@ -211,6 +214,7 @@ class TestResponse(unittest.TestCase):
         self.assertEqual(resp.closed, True)
         self.assertEqual(resp._fp.isclosed(), True)
         self.assertEqual(is_fp_closed(resp._fp), True)
+        sock.close()
 
     def test_io_bufferedreader(self):
         fp = BytesIO(b'foo')

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -1,5 +1,4 @@
 import socket
-import sys
 
 from io import BytesIO, BufferedReader
 
@@ -13,10 +12,7 @@ from urllib3.util.response import is_fp_closed
 
 from base64 import b64decode
 
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
+import pytest
 
 # A known random (i.e, not-too-compressible) payload generated with:
 #    "".join(random.choice(string.printable) for i in xrange(512))
@@ -34,63 +30,62 @@ S5moAj5HexY/g/F8TctpxwsvyZp38dXeLDjSQvEQIkF7XR3YXbeZgKk3V34KGCPOAeeuQDIgyVhV
 nP4HF2uWHA==""")
 
 
-class TestLegacyResponse(unittest.TestCase):
+class TestLegacyResponse(object):
     def test_getheaders(self):
         headers = {'host': 'example.com'}
         r = HTTPResponse(headers=headers)
-        self.assertEqual(r.getheaders(), headers)
+        assert r.getheaders() == headers
 
     def test_getheader(self):
         headers = {'host': 'example.com'}
         r = HTTPResponse(headers=headers)
-        self.assertEqual(r.getheader('host'), 'example.com')
+        assert r.getheader('host') == 'example.com'
 
 
-class TestResponse(unittest.TestCase):
+class TestResponse(object):
     def test_cache_content(self):
         r = HTTPResponse('foo')
-        self.assertEqual(r.data, 'foo')
-        self.assertEqual(r._body, 'foo')
+        assert r.data == 'foo'
+        assert r._body == 'foo'
 
     def test_default(self):
         r = HTTPResponse()
-        self.assertEqual(r.data, None)
+        assert r.data is None
 
     def test_none(self):
         r = HTTPResponse(None)
-        self.assertEqual(r.data, None)
+        assert r.data is None
 
     def test_preload(self):
         fp = BytesIO(b'foo')
 
         r = HTTPResponse(fp, preload_content=True)
 
-        self.assertEqual(fp.tell(), len(b'foo'))
-        self.assertEqual(r.data, b'foo')
+        assert fp.tell() == len(b'foo')
+        assert r.data == b'foo'
 
     def test_no_preload(self):
         fp = BytesIO(b'foo')
 
         r = HTTPResponse(fp, preload_content=False)
 
-        self.assertEqual(fp.tell(), 0)
-        self.assertEqual(r.data, b'foo')
-        self.assertEqual(fp.tell(), len(b'foo'))
+        assert fp.tell() == 0
+        assert r.data == b'foo'
+        assert fp.tell() == len(b'foo')
 
     def test_decode_bad_data(self):
         fp = BytesIO(b'\x00' * 10)
-        self.assertRaises(DecodeError, HTTPResponse, fp, headers={
-            'content-encoding': 'deflate'
-        })
+        with pytest.raises(DecodeError):
+            HTTPResponse(fp, headers={'content-encoding': 'deflate'})
 
     def test_reference_read(self):
         fp = BytesIO(b'foo')
         r = HTTPResponse(fp, preload_content=False)
 
-        self.assertEqual(r.read(1), b'f')
-        self.assertEqual(r.read(2), b'oo')
-        self.assertEqual(r.read(), b'')
-        self.assertEqual(r.read(), b'')
+        assert r.read(1) == b'f'
+        assert r.read(2) == b'oo'
+        assert r.read() == b''
+        assert r.read() == b''
 
     def test_decode_deflate(self):
         import zlib
@@ -99,7 +94,7 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(data)
         r = HTTPResponse(fp, headers={'content-encoding': 'deflate'})
 
-        self.assertEqual(r.data, b'foo')
+        assert r.data == b'foo'
 
     def test_decode_deflate_case_insensitve(self):
         import zlib
@@ -108,7 +103,7 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(data)
         r = HTTPResponse(fp, headers={'content-encoding': 'DeFlAtE'})
 
-        self.assertEqual(r.data, b'foo')
+        assert r.data == b'foo'
 
     def test_chunked_decoding_deflate(self):
         import zlib
@@ -118,15 +113,15 @@ class TestResponse(unittest.TestCase):
         r = HTTPResponse(fp, headers={'content-encoding': 'deflate'},
                          preload_content=False)
 
-        self.assertEqual(r.read(3), b'')
+        assert r.read(3) == b''
         # Buffer in case we need to switch to the raw stream
-        self.assertIsNotNone(r._decoder._data)
-        self.assertEqual(r.read(1), b'f')
+        assert r._decoder._data is not None
+        assert r.read(1) == b'f'
         # Now that we've decoded data, we just stream through the decoder
-        self.assertIsNone(r._decoder._data)
-        self.assertEqual(r.read(2), b'oo')
-        self.assertEqual(r.read(), b'')
-        self.assertEqual(r.read(), b'')
+        assert r._decoder._data is None
+        assert r.read(2) == b'oo'
+        assert r.read() == b''
+        assert r.read() == b''
 
     def test_chunked_decoding_deflate2(self):
         import zlib
@@ -138,13 +133,13 @@ class TestResponse(unittest.TestCase):
         r = HTTPResponse(fp, headers={'content-encoding': 'deflate'},
                          preload_content=False)
 
-        self.assertEqual(r.read(1), b'')
-        self.assertEqual(r.read(1), b'f')
+        assert r.read(1) == b''
+        assert r.read(1) == b'f'
         # Once we've decoded data, we just stream to the decoder; no buffering
-        self.assertIsNone(r._decoder._data)
-        self.assertEqual(r.read(2), b'oo')
-        self.assertEqual(r.read(), b'')
-        self.assertEqual(r.read(), b'')
+        assert r._decoder._data is None
+        assert r.read(2) == b'oo'
+        assert r.read() == b''
+        assert r.read() == b''
 
     def test_chunked_decoding_gzip(self):
         import zlib
@@ -156,47 +151,50 @@ class TestResponse(unittest.TestCase):
         r = HTTPResponse(fp, headers={'content-encoding': 'gzip'},
                          preload_content=False)
 
-        self.assertEqual(r.read(11), b'')
-        self.assertEqual(r.read(1), b'f')
-        self.assertEqual(r.read(2), b'oo')
-        self.assertEqual(r.read(), b'')
-        self.assertEqual(r.read(), b'')
+        assert r.read(11) == b''
+        assert r.read(1) == b'f'
+        assert r.read(2) == b'oo'
+        assert r.read() == b''
+        assert r.read() == b''
 
     def test_body_blob(self):
         resp = HTTPResponse(b'foo')
-        self.assertEqual(resp.data, b'foo')
-        self.assertTrue(resp.closed)
+        assert resp.data == b'foo'
+        assert resp.closed
 
     def test_io(self):
         fp = BytesIO(b'foo')
         resp = HTTPResponse(fp, preload_content=False)
 
-        self.assertEqual(resp.closed, False)
-        self.assertEqual(resp.readable(), True)
-        self.assertEqual(resp.writable(), False)
-        self.assertRaises(IOError, resp.fileno)
+        assert not resp.closed
+        assert resp.readable()
+        assert not resp.writable()
+        with pytest.raises(IOError):
+            resp.fileno()
 
         resp.close()
-        self.assertEqual(resp.closed, True)
+        assert resp.closed
 
         # Try closing with an `httplib.HTTPResponse`, because it has an
         # `isclosed` method.
         sock = socket.socket()
         hlr = httplib.HTTPResponse(sock)
         resp2 = HTTPResponse(hlr, preload_content=False)
-        self.assertEqual(resp2.closed, False)
+        assert not resp2.closed
         resp2.close()
-        self.assertEqual(resp2.closed, True)
+        assert resp2.closed
 
         # also try when only data is present.
         resp3 = HTTPResponse('foodata')
-        self.assertRaises(IOError, resp3.fileno)
+        with pytest.raises(IOError):
+            resp3.fileno()
 
         resp3._fp = 2
         # A corner case where _fp is present but doesn't have `closed`,
         # `isclosed`, or `fileno`.  Unlikely, but possible.
-        self.assertEqual(resp3.closed, True)
-        self.assertRaises(IOError, resp3.fileno)
+        assert resp3.closed
+        with pytest.raises(IOError):
+            resp3.fileno()
         sock.close()
 
     def test_io_closed_consistently(self):
@@ -207,13 +205,13 @@ class TestResponse(unittest.TestCase):
         hlr.length = 3
         resp = HTTPResponse(hlr, preload_content=False)
 
-        self.assertEqual(resp.closed, False)
-        self.assertEqual(resp._fp.isclosed(), False)
-        self.assertEqual(is_fp_closed(resp._fp), False)
+        assert not resp.closed
+        assert not resp._fp.isclosed()
+        assert not is_fp_closed(resp._fp)
         resp.read()
-        self.assertEqual(resp.closed, True)
-        self.assertEqual(resp._fp.isclosed(), True)
-        self.assertEqual(is_fp_closed(resp._fp), True)
+        assert resp.closed
+        assert resp._fp.isclosed()
+        assert is_fp_closed(resp._fp)
         sock.close()
 
     def test_io_bufferedreader(self):
@@ -221,10 +219,10 @@ class TestResponse(unittest.TestCase):
         resp = HTTPResponse(fp, preload_content=False)
         br = BufferedReader(resp)
 
-        self.assertEqual(br.read(), b'foo')
+        assert br.read() == b'foo'
 
         br.close()
-        self.assertEqual(resp.closed, True)
+        assert resp.closed
 
         b = b'fooandahalf'
         fp = BytesIO(b)
@@ -232,7 +230,7 @@ class TestResponse(unittest.TestCase):
         br = BufferedReader(resp, 5)
 
         br.read(1)  # sets up the buffer, reading 5
-        self.assertEqual(len(fp.read()), len(b) - 5)
+        assert len(fp.read()) == (len(b) - 5)
 
         # This is necessary to make sure the "no bytes left" part of `readinto`
         # gets tested.
@@ -261,9 +259,10 @@ class TestResponse(unittest.TestCase):
         resp = HTTPResponse(fp, preload_content=False)
         stream = resp.stream(2, decode_content=False)
 
-        self.assertEqual(next(stream), b'fo')
-        self.assertEqual(next(stream), b'o')
-        self.assertRaises(StopIteration, next, stream)
+        assert next(stream) == b'fo'
+        assert next(stream) == b'o'
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_streaming_tell(self):
         fp = BytesIO(b'foo')
@@ -273,14 +272,15 @@ class TestResponse(unittest.TestCase):
         position = 0
 
         position += len(next(stream))
-        self.assertEqual(2, position)
-        self.assertEqual(position, resp.tell())
+        assert 2 == position
+        assert position == resp.tell()
 
         position += len(next(stream))
-        self.assertEqual(3, position)
-        self.assertEqual(position, resp.tell())
+        assert 3 == position
+        assert position == resp.tell()
 
-        self.assertRaises(StopIteration, next, stream)
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_gzipped_streaming(self):
         import zlib
@@ -293,9 +293,10 @@ class TestResponse(unittest.TestCase):
                             preload_content=False)
         stream = resp.stream(2)
 
-        self.assertEqual(next(stream), b'f')
-        self.assertEqual(next(stream), b'oo')
-        self.assertRaises(StopIteration, next, stream)
+        assert next(stream) == b'f'
+        assert next(stream) == b'oo'
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_gzipped_streaming_tell(self):
         import zlib
@@ -311,11 +312,12 @@ class TestResponse(unittest.TestCase):
 
         # Read everything
         payload = next(stream)
-        self.assertEqual(payload, uncompressed_data)
+        assert payload == uncompressed_data
 
-        self.assertEqual(len(data), resp.tell())
+        assert len(data) == resp.tell()
 
-        self.assertRaises(StopIteration, next, stream)
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_deflate_streaming_tell_intermediate_point(self):
         # Ensure that ``tell()`` returns the correct number of bytes when
@@ -354,20 +356,21 @@ class TestResponse(unittest.TestCase):
         parts_positions = [(part, resp.tell()) for part in stream]
         end_of_stream = resp.tell()
 
-        self.assertRaises(StopIteration, next, stream)
+        with pytest.raises(StopIteration):
+            next(stream)
 
         parts, positions = zip(*parts_positions)
 
         # Check that the payload is equal to the uncompressed data
         payload = b"".join(parts)
-        self.assertEqual(uncompressed_data, payload)
+        assert uncompressed_data == payload
 
         # Check that the positions in the stream are correct
         expected = [(i+1)*payload_part_size for i in range(NUMBER_OF_READS)]
-        self.assertEqual(expected, list(positions))
+        assert expected == list(positions)
 
         # Check that the end of the stream is in the correct place
-        self.assertEqual(len(ZLIB_PAYLOAD), end_of_stream)
+        assert len(ZLIB_PAYLOAD) == end_of_stream
 
     def test_deflate_streaming(self):
         import zlib
@@ -378,9 +381,10 @@ class TestResponse(unittest.TestCase):
                             preload_content=False)
         stream = resp.stream(2)
 
-        self.assertEqual(next(stream), b'f')
-        self.assertEqual(next(stream), b'oo')
-        self.assertRaises(StopIteration, next, stream)
+        assert next(stream) == b'f'
+        assert next(stream) == b'oo'
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_deflate2_streaming(self):
         import zlib
@@ -393,39 +397,41 @@ class TestResponse(unittest.TestCase):
                             preload_content=False)
         stream = resp.stream(2)
 
-        self.assertEqual(next(stream), b'f')
-        self.assertEqual(next(stream), b'oo')
-        self.assertRaises(StopIteration, next, stream)
+        assert next(stream) == b'f'
+        assert next(stream) == b'oo'
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_empty_stream(self):
         fp = BytesIO(b'')
         resp = HTTPResponse(fp, preload_content=False)
         stream = resp.stream(2, decode_content=False)
 
-        self.assertRaises(StopIteration, next, stream)
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_length_no_header(self):
         fp = BytesIO(b'12345')
         resp = HTTPResponse(fp, preload_content=False)
-        self.assertEqual(resp.length_remaining, None)
+        assert resp.length_remaining is None
 
     def test_length_w_valid_header(self):
         headers = {"content-length": "5"}
         fp = BytesIO(b'12345')
 
         resp = HTTPResponse(fp, headers=headers, preload_content=False)
-        self.assertEqual(resp.length_remaining, 5)
+        assert resp.length_remaining == 5
 
     def test_length_w_bad_header(self):
         garbage = {'content-length': 'foo'}
         fp = BytesIO(b'12345')
 
         resp = HTTPResponse(fp, headers=garbage, preload_content=False)
-        self.assertEqual(resp.length_remaining, None)
+        assert resp.length_remaining is None
 
         garbage['content-length'] = "-10"
         resp = HTTPResponse(fp, headers=garbage, preload_content=False)
-        self.assertEqual(resp.length_remaining, None)
+        assert resp.length_remaining is None
 
     def test_length_when_chunked(self):
         # This is expressly forbidden in RFC 7230 sec 3.3.2
@@ -436,7 +442,7 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(b'12345')
 
         resp = HTTPResponse(fp, headers=headers, preload_content=False)
-        self.assertEqual(resp.length_remaining, None)
+        assert resp.length_remaining is None
 
     def test_length_with_multiple_content_lengths(self):
         headers = {'content-length': '5, 5, 5'}
@@ -444,10 +450,10 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(b'abcde')
 
         resp = HTTPResponse(fp, headers=headers, preload_content=False)
-        self.assertEqual(resp.length_remaining, 5)
+        assert resp.length_remaining == 5
 
-        self.assertRaises(InvalidHeader, HTTPResponse, fp,
-                          headers=garbage, preload_content=False)
+        with pytest.raises(InvalidHeader):
+            HTTPResponse(fp, headers=garbage, preload_content=False)
 
     def test_length_after_read(self):
         headers = {"content-length": "5"}
@@ -456,20 +462,20 @@ class TestResponse(unittest.TestCase):
         fp = BytesIO(b'12345')
         resp = HTTPResponse(fp, preload_content=False)
         resp.read()
-        self.assertEqual(resp.length_remaining, None)
+        assert resp.length_remaining is None
 
         # Test our update from content-length
         fp = BytesIO(b'12345')
         resp = HTTPResponse(fp, headers=headers, preload_content=False)
         resp.read()
-        self.assertEqual(resp.length_remaining, 0)
+        assert resp.length_remaining == 0
 
         # Test partial read
         fp = BytesIO(b'12345')
         resp = HTTPResponse(fp, headers=headers, preload_content=False)
         data = resp.stream(2)
         next(data)
-        self.assertEqual(resp.length_remaining, 3)
+        assert resp.length_remaining == 3
 
     def test_mock_httpresponse_stream(self):
         # Mock out a HTTP Request that does enough to make it through urllib3's
@@ -494,9 +500,10 @@ class TestResponse(unittest.TestCase):
         resp = HTTPResponse(fp, preload_content=False)
         stream = resp.stream(2)
 
-        self.assertEqual(next(stream), b'fo')
-        self.assertEqual(next(stream), b'o')
-        self.assertRaises(StopIteration, next, stream)
+        assert next(stream) == b'fo'
+        assert next(stream) == b'o'
+        with pytest.raises(StopIteration):
+            next(stream)
 
     def test_mock_transfer_encoding_chunked(self):
         stream = [b"fo", b"o", b"bar"]
@@ -505,10 +512,7 @@ class TestResponse(unittest.TestCase):
         r.fp = fp
         resp = HTTPResponse(r, preload_content=False, headers={'transfer-encoding': 'chunked'})
 
-        i = 0
-        for c in resp.stream():
-            self.assertEqual(c, stream[i])
-            i += 1
+        assert stream == list(resp.stream())
 
     def test_mock_gzipped_transfer_encoding_chunked_decoded(self):
         """Show that we can decode the gizpped and chunked body."""
@@ -531,7 +535,7 @@ class TestResponse(unittest.TestCase):
         for c in resp.stream(decode_content=True):
             data += c
 
-        self.assertEqual(b'foobar', data)
+        assert b'foobar' == data
 
     def test_mock_transfer_encoding_chunked_custom_read(self):
         stream = [b"foooo", b"bbbbaaaaar"]
@@ -543,12 +547,7 @@ class TestResponse(unittest.TestCase):
         resp = HTTPResponse(r, preload_content=False, headers={'transfer-encoding': 'chunked'})
         expected_response = [b'fo', b'oo', b'o', b'bb', b'bb', b'aa', b'aa', b'ar']
         response = list(resp.read_chunked(2))
-        if getattr(self, "assertListEqual", False):
-            self.assertListEqual(expected_response, response)
-        else:
-            for index, item in enumerate(response):
-                v = expected_response[index]
-                self.assertEqual(item, v)
+        assert expected_response == response
 
     def test_mock_transfer_encoding_chunked_unlmtd_read(self):
         stream = [b"foooo", b"bbbbaaaaar"]
@@ -558,18 +557,14 @@ class TestResponse(unittest.TestCase):
         r.chunked = True
         r.chunk_left = None
         resp = HTTPResponse(r, preload_content=False, headers={'transfer-encoding': 'chunked'})
-        if getattr(self, "assertListEqual", False):
-            self.assertListEqual(stream, list(resp.read_chunked()))
-        else:
-            for index, item in enumerate(resp.read_chunked()):
-                v = stream[index]
-                self.assertEqual(item, v)
+        assert stream == list(resp.read_chunked())
 
     def test_read_not_chunked_response_as_chunks(self):
         fp = BytesIO(b'foo')
         resp = HTTPResponse(fp, preload_content=False)
         r = resp.read_chunked()
-        self.assertRaises(ResponseNotChunked, next, r)
+        with pytest.raises(ResponseNotChunked):
+            next(r)
 
     def test_invalid_chunks(self):
         stream = [b"foooo", b"bbbbaaaaar"]
@@ -579,7 +574,8 @@ class TestResponse(unittest.TestCase):
         r.chunked = True
         r.chunk_left = None
         resp = HTTPResponse(r, preload_content=False, headers={'transfer-encoding': 'chunked'})
-        self.assertRaises(ProtocolError, next, resp.read_chunked())
+        with pytest.raises(ProtocolError):
+            next(resp.read_chunked())
 
     def test_chunked_response_without_crlf_on_end(self):
         stream = [b"foo", b"bar", b"baz"]
@@ -589,12 +585,7 @@ class TestResponse(unittest.TestCase):
         r.chunked = True
         r.chunk_left = None
         resp = HTTPResponse(r, preload_content=False, headers={'transfer-encoding': 'chunked'})
-        if getattr(self, "assertListEqual", False):
-            self.assertListEqual(stream, list(resp.stream()))
-        else:
-            for index, item in enumerate(resp.stream()):
-                v = stream[index]
-                self.assertEqual(item, v)
+        assert stream == list(resp.stream())
 
     def test_chunked_response_with_extensions(self):
         stream = [b"foo", b"bar"]
@@ -604,26 +595,21 @@ class TestResponse(unittest.TestCase):
         r.chunked = True
         r.chunk_left = None
         resp = HTTPResponse(r, preload_content=False, headers={'transfer-encoding': 'chunked'})
-        if getattr(self, "assertListEqual", False):
-            self.assertListEqual(stream, list(resp.stream()))
-        else:
-            for index, item in enumerate(resp.stream()):
-                v = stream[index]
-                self.assertEqual(item, v)
+        assert stream == list(resp.stream())
 
     def test_get_case_insensitive_headers(self):
         headers = {'host': 'example.com'}
         r = HTTPResponse(headers=headers)
-        self.assertEqual(r.headers.get('host'), 'example.com')
-        self.assertEqual(r.headers.get('Host'), 'example.com')
+        assert r.headers.get('host') == 'example.com'
+        assert r.headers.get('Host') == 'example.com'
 
     def test_retries(self):
         fp = BytesIO(b'')
         resp = HTTPResponse(fp)
-        self.assertEqual(resp.retries, None)
+        assert resp.retries is None
         retry = Retry()
         resp = HTTPResponse(fp, retries=retry)
-        self.assertEqual(resp.retries, retry)
+        assert resp.retries == retry
 
 
 class MockChunkedEncodingResponse(object):
@@ -726,7 +712,3 @@ class MockSock(object):
     @classmethod
     def makefile(cls, *args, **kwargs):
         return
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/test_retry.py
+++ b/test/test_retry.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from urllib3.response import HTTPResponse
 from urllib3.packages.six.moves import xrange
@@ -11,17 +11,15 @@ from urllib3.exceptions import (
 )
 
 
-class RetryTest(unittest.TestCase):
+class TestRetry(object):
 
     def test_string(self):
         """ Retry string representation looks the way we expect """
         retry = Retry()
-        self.assertEqual(str(retry),
-                         'Retry(total=10, connect=None, read=None, redirect=None, status=None)')
+        assert str(retry) == 'Retry(total=10, connect=None, read=None, redirect=None, status=None)'
         for _ in range(3):
             retry = retry.increment(method='GET')
-        self.assertEqual(str(retry),
-                         'Retry(total=7, connect=None, read=None, redirect=None, status=None)')
+        assert str(retry) == 'Retry(total=7, connect=None, read=None, redirect=None, status=None)'
 
     def test_retry_both_specified(self):
         """Total can win if it's lower than the connect value"""
@@ -29,11 +27,9 @@ class RetryTest(unittest.TestCase):
         retry = Retry(connect=3, total=2)
         retry = retry.increment(error=error)
         retry = retry.increment(error=error)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry.increment(error=error)
-            self.fail("Failed to raise error.")
-        except MaxRetryError as e:
-            self.assertEqual(e.reason, error)
+        assert e.value.reason == error
 
     def test_retry_higher_total_loses(self):
         """ A lower connect timeout than the total is honored """
@@ -41,7 +37,8 @@ class RetryTest(unittest.TestCase):
         retry = Retry(connect=2, total=3)
         retry = retry.increment(error=error)
         retry = retry.increment(error=error)
-        self.assertRaises(MaxRetryError, retry.increment, error=error)
+        with pytest.raises(MaxRetryError):
+            retry.increment(error=error)
 
     def test_retry_higher_total_loses_vs_read(self):
         """ A lower read timeout than the total is honored """
@@ -49,7 +46,8 @@ class RetryTest(unittest.TestCase):
         retry = Retry(read=2, total=3)
         retry = retry.increment(method='GET', error=error)
         retry = retry.increment(method='GET', error=error)
-        self.assertRaises(MaxRetryError, retry.increment, method='GET', error=error)
+        with pytest.raises(MaxRetryError):
+            retry.increment(method='GET', error=error)
 
     def test_retry_total_none(self):
         """ if Total is none, connect error should take precedence """
@@ -57,105 +55,99 @@ class RetryTest(unittest.TestCase):
         retry = Retry(connect=2, total=None)
         retry = retry.increment(error=error)
         retry = retry.increment(error=error)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry.increment(error=error)
-            self.fail("Failed to raise error.")
-        except MaxRetryError as e:
-            self.assertEqual(e.reason, error)
+        assert e.value.reason == error
 
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry(connect=2, total=None)
         retry = retry.increment(method='GET', error=error)
         retry = retry.increment(method='GET', error=error)
         retry = retry.increment(method='GET', error=error)
-        self.assertFalse(retry.is_exhausted())
+        assert not retry.is_exhausted()
 
     def test_retry_default(self):
         """ If no value is specified, should retry connects 3 times """
         retry = Retry()
-        self.assertEqual(retry.total, 10)
-        self.assertEqual(retry.connect, None)
-        self.assertEqual(retry.read, None)
-        self.assertEqual(retry.redirect, None)
+        assert retry.total == 10
+        assert retry.connect is None
+        assert retry.read is None
+        assert retry.redirect is None
 
         error = ConnectTimeoutError()
         retry = Retry(connect=1)
         retry = retry.increment(error=error)
-        self.assertRaises(MaxRetryError, retry.increment, error=error)
+        with pytest.raises(MaxRetryError):
+            retry.increment(error=error)
 
         retry = Retry(connect=1)
         retry = retry.increment(error=error)
-        self.assertFalse(retry.is_exhausted())
+        assert not retry.is_exhausted()
 
-        self.assertTrue(Retry(0).raise_on_redirect)
-        self.assertFalse(Retry(False).raise_on_redirect)
+        assert Retry(0).raise_on_redirect
+        assert not Retry(False).raise_on_redirect
 
     def test_retry_read_zero(self):
         """ No second chances on read timeouts, by default """
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry(read=0)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry.increment(method='GET', error=error)
-            self.fail("Failed to raise error.")
-        except MaxRetryError as e:
-            self.assertEqual(e.reason, error)
+        assert e.value.reason == error
 
     def test_status_counter(self):
         resp = HTTPResponse(status=400)
         retry = Retry(status=2)
         retry = retry.increment(response=resp)
         retry = retry.increment(response=resp)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry.increment(response=resp)
-            self.fail("Failed to raise error.")
-        except MaxRetryError as e:
-            self.assertEqual(str(e.reason),
-                             ResponseError.SPECIFIC_ERROR.format(status_code=400))
+        assert str(e.value.reason) == ResponseError.SPECIFIC_ERROR.format(status_code=400)
 
     def test_backoff(self):
         """ Backoff is computed correctly """
         max_backoff = Retry.BACKOFF_MAX
 
         retry = Retry(total=100, backoff_factor=0.2)
-        self.assertEqual(retry.get_backoff_time(), 0)  # First request
+        assert retry.get_backoff_time() == 0  # First request
 
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 0)  # First retry
+        assert retry.get_backoff_time() == 0  # First retry
 
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.backoff_factor, 0.2)
-        self.assertEqual(retry.total, 98)
-        self.assertEqual(retry.get_backoff_time(), 0.4)  # Start backoff
+        assert retry.backoff_factor == 0.2
+        assert retry.total == 98
+        assert retry.get_backoff_time() == 0.4  # Start backoff
 
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 0.8)
+        assert retry.get_backoff_time() == 0.8
 
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 1.6)
+        assert retry.get_backoff_time() == 1.6
 
         for i in xrange(10):
             retry = retry.increment(method='GET')
 
-        self.assertEqual(retry.get_backoff_time(), max_backoff)
+        assert retry.get_backoff_time() == max_backoff
 
     def test_zero_backoff(self):
         retry = Retry()
-        self.assertEqual(retry.get_backoff_time(), 0)
+        assert retry.get_backoff_time() == 0
         retry = retry.increment(method='GET')
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 0)
+        assert retry.get_backoff_time() == 0
 
     def test_backoff_reset_after_redirect(self):
         retry = Retry(total=100, redirect=5, backoff_factor=0.2)
         retry = retry.increment(method='GET')
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 0.4)
+        assert retry.get_backoff_time() == 0.4
         redirect_response = HTTPResponse(status=302, headers={'location': 'test'})
         retry = retry.increment(method='GET', response=redirect_response)
-        self.assertEqual(retry.get_backoff_time(), 0)
+        assert retry.get_backoff_time() == 0
         retry = retry.increment(method='GET')
         retry = retry.increment(method='GET')
-        self.assertEqual(retry.get_backoff_time(), 0.4)
+        assert retry.get_backoff_time() == 0.4
 
     def test_sleep(self):
         # sleep a very small amount of time so our code coverage is happy
@@ -166,101 +158,95 @@ class RetryTest(unittest.TestCase):
 
     def test_status_forcelist(self):
         retry = Retry(status_forcelist=xrange(500, 600))
-        self.assertFalse(retry.is_retry('GET', status_code=200))
-        self.assertFalse(retry.is_retry('GET', status_code=400))
-        self.assertTrue(retry.is_retry('GET', status_code=500))
+        assert not retry.is_retry('GET', status_code=200)
+        assert not retry.is_retry('GET', status_code=400)
+        assert retry.is_retry('GET', status_code=500)
 
         retry = Retry(total=1, status_forcelist=[418])
-        self.assertFalse(retry.is_retry('GET', status_code=400))
-        self.assertTrue(retry.is_retry('GET', status_code=418))
+        assert not retry.is_retry('GET', status_code=400)
+        assert retry.is_retry('GET', status_code=418)
 
         # String status codes are not matched.
         retry = Retry(total=1, status_forcelist=['418'])
-        self.assertFalse(retry.is_retry('GET', status_code=418))
+        assert not retry.is_retry('GET', status_code=418)
 
     def test_method_whitelist_with_status_forcelist(self):
         # Falsey method_whitelist means to retry on any method.
         retry = Retry(status_forcelist=[500], method_whitelist=None)
-        self.assertTrue(retry.is_retry('GET', status_code=500))
-        self.assertTrue(retry.is_retry('POST', status_code=500))
+        assert retry.is_retry('GET', status_code=500)
+        assert retry.is_retry('POST', status_code=500)
 
         # Criteria of method_whitelist and status_forcelist are ANDed.
         retry = Retry(status_forcelist=[500], method_whitelist=['POST'])
-        self.assertFalse(retry.is_retry('GET', status_code=500))
-        self.assertTrue(retry.is_retry('POST', status_code=500))
+        assert not retry.is_retry('GET', status_code=500)
+        assert retry.is_retry('POST', status_code=500)
 
     def test_exhausted(self):
-        self.assertFalse(Retry(0).is_exhausted())
-        self.assertTrue(Retry(-1).is_exhausted())
-        self.assertEqual(Retry(1).increment(method='GET').total, 0)
+        assert not Retry(0).is_exhausted()
+        assert Retry(-1).is_exhausted()
+        assert Retry(1).increment(method='GET').total == 0
 
     def test_disabled(self):
-        self.assertRaises(MaxRetryError, Retry(-1).increment, method='GET')
-        self.assertRaises(MaxRetryError, Retry(0).increment, method='GET')
+        with pytest.raises(MaxRetryError):
+            Retry(-1).increment(method='GET')
+        with pytest.raises(MaxRetryError):
+            Retry(0).increment(method='GET')
 
     def test_error_message(self):
         retry = Retry(total=0)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry = retry.increment(method='GET',
                                     error=ReadTimeoutError(None, "/", "read timed out"))
-            raise AssertionError("Should have raised a MaxRetryError")
-        except MaxRetryError as e:
-            assert 'Caused by redirect' not in str(e)
-            self.assertEqual(str(e.reason), 'None: read timed out')
+        assert 'Caused by redirect' not in str(e)
+        assert str(e.value.reason) == 'None: read timed out'
 
         retry = Retry(total=1)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry = retry.increment('POST', '/')
             retry = retry.increment('POST', '/')
-            raise AssertionError("Should have raised a MaxRetryError")
-        except MaxRetryError as e:
-            assert 'Caused by redirect' not in str(e)
-            self.assertTrue(isinstance(e.reason, ResponseError),
-                            "%s should be a ResponseError" % e.reason)
-            self.assertEqual(str(e.reason), ResponseError.GENERIC_ERROR)
+        assert 'Caused by redirect' not in str(e)
+        assert isinstance(e.value.reason, ResponseError)
+        assert str(e.value.reason) == ResponseError.GENERIC_ERROR
 
         retry = Retry(total=1)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             response = HTTPResponse(status=500)
             retry = retry.increment('POST', '/', response=response)
             retry = retry.increment('POST', '/', response=response)
-            raise AssertionError("Should have raised a MaxRetryError")
-        except MaxRetryError as e:
-            assert 'Caused by redirect' not in str(e)
-            msg = ResponseError.SPECIFIC_ERROR.format(status_code=500)
-            self.assertEqual(str(e.reason), msg)
+        assert 'Caused by redirect' not in str(e)
+        msg = ResponseError.SPECIFIC_ERROR.format(status_code=500)
+        assert str(e.value.reason) == msg
 
         retry = Retry(connect=1)
-        try:
+        with pytest.raises(MaxRetryError) as e:
             retry = retry.increment(error=ConnectTimeoutError('conntimeout'))
             retry = retry.increment(error=ConnectTimeoutError('conntimeout'))
-            raise AssertionError("Should have raised a MaxRetryError")
-        except MaxRetryError as e:
-            assert 'Caused by redirect' not in str(e)
-            self.assertEqual(str(e.reason), 'conntimeout')
+        assert 'Caused by redirect' not in str(e)
+        assert str(e.value.reason) == 'conntimeout'
 
     def test_history(self):
         retry = Retry(total=10, method_whitelist=frozenset(['GET', 'POST']))
-        self.assertEqual(retry.history, tuple())
+        assert retry.history == tuple()
         connection_error = ConnectTimeoutError('conntimeout')
         retry = retry.increment('GET', '/test1', None, connection_error)
         history = (RequestHistory('GET', '/test1', connection_error, None, None),)
-        self.assertEqual(retry.history, history)
+        assert retry.history == history
 
         read_error = ReadTimeoutError(None, "/test2", "read timed out")
         retry = retry.increment('POST', '/test2', None, read_error)
         history = (RequestHistory('GET', '/test1', connection_error, None, None),
                    RequestHistory('POST', '/test2', read_error, None, None))
-        self.assertEqual(retry.history, history)
+        assert retry.history == history
 
         response = HTTPResponse(status=500)
         retry = retry.increment('GET', '/test3', response, None)
         history = (RequestHistory('GET', '/test1', connection_error, None, None),
                    RequestHistory('POST', '/test2', read_error, None, None),
                    RequestHistory('GET', '/test3', None, 500, None))
-        self.assertEqual(retry.history, history)
+        assert retry.history == history
 
     def test_retry_method_not_in_whitelist(self):
         error = ReadTimeoutError(None, "/", "read timed out")
         retry = Retry()
-        self.assertRaises(ReadTimeoutError, retry.increment, method='POST', error=error)
+        with pytest.raises(ReadTimeoutError):
+            retry.increment(method='POST', error=error)


### PR DESCRIPTION
Making some incremental progress on #1160. Such lovely and clean unittest-free code!

And as a bonus, you no longer get `ResourceWarning`s emitted from `test_response.py` if all the tests succeed.