### PR TITLE
Add support for DNS hijacking

### DIFF
--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -370,6 +370,25 @@ class TestPoolManager(unittest.TestCase):
             override_pool.conn_kw['socket_options'], override_opts
         )
 
+    def test_hijacked_resolver_sets_correct_host(self):
+        hijacked_manager = PoolManager(hijacked_dns_resolver={'example.com': '127.0.0.1'})
+        hijacked_pool = hijacked_manager.connection_from_url('http://example.com/')
+
+        self.assertEqual(hijacked_pool.host, '127.0.0.1')
+        self.assertEqual(hijacked_pool.port, 80)
+
+    def test_hijacked_resolver_is_bypassed_with_missing_host(self):
+        hijacked_manager = PoolManager(hijacked_dns_resolver={'example': '127.0.0.1'})
+        hijacked_pool = hijacked_manager.connection_from_url('http://example.com/')
+
+        self.assertEqual(hijacked_pool.host, 'example.com')
+
+    def test_hijacked_resolver_is_bypassed_if_is_not_a_dict(self):
+        hijacked_manager = PoolManager(hijacked_dns_resolver=[('example.com', '127.0.0.1')])
+        hijacked_pool = hijacked_manager.connection_from_url('http://example.com/')
+
+        self.assertEqual(hijacked_pool.host, 'example.com')
+
     def test_merge_pool_kwargs(self):
         """Assert _merge_pool_kwargs works in the happy case"""
         p = PoolManager(strict=True)

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -371,23 +371,39 @@ class TestPoolManager(unittest.TestCase):
         )
 
     def test_hijacked_resolver_sets_correct_host(self):
-        hijacked_manager = PoolManager(hijacked_dns_resolver={'example.com': '127.0.0.1'})
+        hijacked_manager = PoolManager(hijacked_dns_resolver={
+            'example.com': '127.0.0.2',
+            'example.com:443': '127.0.0.1'
+        })
         hijacked_pool = hijacked_manager.connection_from_url('http://example.com/')
 
-        self.assertEqual(hijacked_pool.host, '127.0.0.1')
+        self.assertEqual(hijacked_pool.host, '127.0.0.2')
         self.assertEqual(hijacked_pool.port, 80)
 
     def test_hijacked_resolver_is_bypassed_with_missing_host(self):
-        hijacked_manager = PoolManager(hijacked_dns_resolver={'example': '127.0.0.1'})
-        hijacked_pool = hijacked_manager.connection_from_url('http://example.com/')
+        hijacked_manager = PoolManager(hijacked_dns_resolver={
+            'example.com': '127.0.0.2',
+            'example.com:443': '127.0.0.1'
+        })
+        hijacked_pool = hijacked_manager.connection_from_url('http://example.net/')
 
-        self.assertEqual(hijacked_pool.host, 'example.com')
+        self.assertEqual(hijacked_pool.host, 'example.net')
 
     def test_hijacked_resolver_is_bypassed_if_is_not_a_dict(self):
         hijacked_manager = PoolManager(hijacked_dns_resolver=[('example.com', '127.0.0.1')])
         hijacked_pool = hijacked_manager.connection_from_url('http://example.com/')
 
         self.assertEqual(hijacked_pool.host, 'example.com')
+
+    def test_hijacked_resolver_sets_correct_host_and_port(self):
+        hijacked_manager = PoolManager(hijacked_dns_resolver={
+            'example.com': '127.0.0.2',
+            'example.com:443': '127.0.0.1'
+        })
+        hijacked_pool = hijacked_manager.connection_from_url('https://example.com:443/')
+
+        self.assertEqual(hijacked_pool.host, '127.0.0.1')
+        self.assertEqual(hijacked_pool.port, 443)
 
     def test_merge_pool_kwargs(self):
         """Assert _merge_pool_kwargs works in the happy case"""

--- a/urllib3/poolmanager.py
+++ b/urllib3/poolmanager.py
@@ -131,6 +131,10 @@ class PoolManager(RequestMethods):
         Headers to include with all requests, unless other headers are given
         explicitly.
 
+    :param hijacked_dns_resolver:
+        A dict used in order to bypass the DNS resolver. It should contain
+        pairs of host and an ip used to make the connection.
+
     :param \\**connection_pool_kw:
         Additional parameters are used to create fresh
         :class:`urllib3.connectionpool.ConnectionPool` instances.
@@ -148,8 +152,14 @@ class PoolManager(RequestMethods):
 
     proxy = None
 
-    def __init__(self, num_pools=10, headers=None, **connection_pool_kw):
+    def __init__(self, num_pools=10, headers=None, hijacked_dns_resolver=None,
+                 **connection_pool_kw):
         RequestMethods.__init__(self, headers)
+
+        self.hijacked_dns_resolver = hijacked_dns_resolver or {}
+        if not isinstance(self.hijacked_dns_resolver, dict):
+            log.info('hijacked_dns_resolver needs to be a dict')
+
         self.connection_pool_kw = connection_pool_kw
         self.pools = RecentlyUsedContainer(num_pools,
                                            dispose_func=lambda p: p.close())
@@ -216,6 +226,10 @@ class PoolManager(RequestMethods):
 
         if not host:
             raise LocationValueError("No host specified.")
+
+        if (isinstance(self.hijacked_dns_resolver, dict) and
+                host in self.hijacked_dns_resolver):
+            host = self.hijacked_dns_resolver[host]
 
         request_context = self._merge_pool_kwargs(pool_kwargs)
         request_context['scheme'] = scheme or 'http'


### PR DESCRIPTION
This is more of a naive approach and maybe the API is too intrusive, but we can change that.

First I started by comparing the hosts, without support for ports (as `curl` have in its `--resolve` argument).
In that implementation it made sense to use `hijack_dns_resolver`, since it map a host to a custom ip.

Since I've added support for ports, maybe `hijack_dns_resolver` is not the good, but I liked the name so I kept it. I'm open to change it (maybe `hijack_resolver` or just `resolver` is better).