### PR TITLE
OSError does not take keyword arguments

### DIFF
--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -708,6 +708,7 @@ class TestUniqueSelectScenarios(BaseSelectorTestCase):
         selector = self.make_selector()
         self.assertIsInstance(selector, selectors.SelectSelector)
 
+    @skipUnless(sys.version_info < (3, 5), "We only have a custom timeout on older Python versions")
     def test_syscall_wrapper_select_timeout(self):
         # This test is to make sure that if our select call times out
         # we correctly raise an OSError.

--- a/test/test_selectors.py
+++ b/test/test_selectors.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 import errno
+import mock
 import os
 import psutil
 import select
@@ -708,7 +709,7 @@ class TestUniqueSelectScenarios(BaseSelectorTestCase):
         selector = self.make_selector()
         self.assertIsInstance(selector, selectors.SelectSelector)
 
-    @skipUnless(sys.version_info < (3, 5), "We only have a custom timeout on older Python versions")
+    @skipUnless(sys.version_info < (3, 5), "Platform uses simple _syscall_wrapper")
     def test_syscall_wrapper_select_timeout(self):
         # This test is to make sure that if our select call times out
         # we correctly raise an OSError.
@@ -736,6 +737,53 @@ class TestUniqueSelectScenarios(BaseSelectorTestCase):
             self.fail("Raised incorrect exception: " + repr(e))
         else:
             self.fail("select() didn't raise OSError, got: " + repr(result))
+
+    @skipUnless(sys.version_info < (3, 5), "Platform uses simple _syscall_wrapper")
+    def test_timeout_is_recalculated_after_interrupt(self):
+        selectors._DEFAULT_SELECTOR = None
+
+        mock_socket = mock.Mock()
+        mock_socket.fileno.return_value = 1
+
+        class InterruptingSelect(object):
+            """ Helper object that imitates a select that interrupts
+            after sleeping some time then returns a result. """
+            def __init__(self):
+                self.call_count = 0
+                self.calls = []
+
+            def select(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                self.call_count += 1
+                if self.call_count == 1:
+                    time.sleep(0.1)
+                    error = OSError()
+                    error.errno = errno.EINTR
+                    raise error
+                else:
+                    return [1], [], []
+
+        mock_select = InterruptingSelect()
+
+        patch_select_module(self, select=mock_select.select)
+
+        selector = self.make_selector()
+        selector.register(mock_socket, selectors.EVENT_READ)
+
+        result = selector.select(timeout=1.0)
+
+        # Make sure the mocked call actually completed correctly.
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0].fileobj, mock_socket)
+        self.assertEqual(result[0][1], selectors.EVENT_READ)
+
+        # There should be two calls to the mock_select.select() function
+        self.assertEqual(mock_select.call_count, 2)
+
+        # Timeout should be less in the second call.
+        # The structure of mock_select.calls is [(args, kwargs), (args, kwargs)] where
+        # args is ([r], [w], [x], timeout).
+        self.assertLess(mock_select.calls[1][0][3], mock_select.calls[0][0][3])
 
     @skipUnlessHasENOSYS
     def test_select_module_defines_does_not_implement_poll(self):

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -112,7 +112,7 @@ else:
                     if expires is not None:
                         current_time = monotonic()
                         if current_time > expires:
-                            raise OSError(errno=errno.ETIMEDOUT)
+                            raise OSError(errno.ETIMEDOUT)
                         if recalc_timeout:
                             if "timeout" in kwargs:
                                 kwargs["timeout"] = expires - current_time

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -91,8 +91,6 @@ else:
             else:
                 expires = monotonic() + timeout
 
-        args = list(args)
-
         result = _SYSCALL_SENTINEL
         while result is _SYSCALL_SENTINEL:
             try:


### PR DESCRIPTION
This PR ensures that the intended OSError is raised instead of a TypeError.