### PR TITLE
IPv6 bracket missing when IPv6 proxy is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 dev (master)
 ------------
 
+* Fixed missing brackets in ``HTTP CONNECT`` when connecting to IPv6 address via
+  IPv6 proxy. (Issue #1222)
+
 * Made the connection pool retry on ``SSLError``.  The original ``SSLError``
   is available on ``MaxRetryError.reason``. (Issue #1112)
 

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -69,6 +69,7 @@ class ConnectionPool(object):
             raise LocationValueError("No host specified.")
 
         self.host = _ipv6_host(host).lower()
+        self._proxy_host = host.lower()
         self.port = port
 
     def __str__(self):
@@ -792,9 +793,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
             set_tunnel = conn._set_tunnel
 
         if sys.version_info <= (2, 6, 4) and not self.proxy_headers:  # Python 2.6.4 and older
-            set_tunnel(self.host, self.port)
+            set_tunnel(self._proxy_host, self.port)
         else:
-            set_tunnel(self.host, self.port, self.proxy_headers)
+            set_tunnel(self._proxy_host, self.port, self.proxy_headers)
 
         conn.connect()
 


### PR DESCRIPTION
Currently, I am trying to connect to an https IPv6 host via IPv6 proxy. Here is my example:

```                                                                                                                                                                                                                                                   
import requests
url = 'https://[2620:10d:c081:b:0:0:0:26]/1/self'
r = requests.get( url, proxies={ 'http': '[2401:db00:0020:8065:beaf:0000:0019:0000]:8080', 'https': '[2401:db00:0020:8065:beaf:0000:0019:0000]:8080', }, verify=False )
print(r.content)
```

I got this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/urllib3/connectionpool.py", line 592, in urlopen
    self._prepare_proxy(conn)
  File "/usr/local/lib/python3.5/site-packages/urllib3/connectionpool.py", line 808, in _prepare_proxy
    conn.connect()
  File "/usr/local/lib/python3.5/site-packages/urllib3/connection.py", line 294, in connect
    self._tunnel()
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/http/client.py", line 832, in _tunnel
    message.strip()))
OSError: Tunnel connection failed: 400 Bad Request

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/requests/adapters.py", line 439, in send
    timeout=timeout
  File "/usr/local/lib/python3.5/site-packages/urllib3/connectionpool.py", line 647, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/local/lib/python3.5/site-packages/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='2620:10d:c081:b:0:0:0:26', port=443): Max retries exceeded with url: /1/self (Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 400 Bad Request',)))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test2.py", line 4, in <module>
    r = requests.get( url, proxies={ 'http': '[2401:db00:0020:8065:beaf:0000:0019:0000]:8080', 'https': '[2401:db00:0020:8065:beaf:0000:0019:0000]:8080', }, verify=False )
  File "/usr/local/lib/python3.5/site-packages/requests/api.py", line 72, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/requests/sessions.py", line 502, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.5/site-packages/requests/sessions.py", line 612, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/requests/adapters.py", line 501, in send
    raise ProxyError(e, request=request)
requests.exceptions.ProxyError: HTTPSConnectionPool(host='2620:10d:c081:b:0:0:0:26', port=443): Max retries exceeded with url: /1/self (Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 400 Bad Request',)))
```

Digging through the logs and pcap, I found that the brackets are missing in `CONNECT`. Here is the output of tshark:

```
Capturing on 'utun1'
  1   0.000000 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59366 → 8080 [SYN] Seq=0 Win=65535 Len=0 MSS=1340 WS=32 TSval=1044073862 TSecr=0 SACK_PERM=1
  2   0.042774 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59366 [SYN, ACK] Seq=0 Ack=1 Win=28560 Len=0 MSS=1340 SACK_PERM=1 TSval=157458772 TSecr=1044073862 WS=256
  3   0.042892 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59366 → 8080 [ACK] Seq=1 Ack=1 Win=131456 Len=0 TSval=1044073904 TSecr=157458772
  4   0.043007 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  [TCP segment of a reassembled PDU]
  5   0.086576 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59366 [ACK] Seq=1 Ack=48 Win=28672 Len=0 TSval=157458815 TSecr=1044073904
  6   0.086665 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 HTTP  CONNECT 2620:10d:c081:b:0:0:0:26:443 HTTP/1.0
  7   0.086733 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 HTTP  HTTP/1.1 400 Bad Request
  8   0.086894 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59366 [FIN, ACK] Seq=129 Ack=48 Win=28672 Len=0 TSval=157458816 TSecr=1044073904
  9   0.086963 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59366 → 8080 [ACK] Seq=50 Ack=129 Win=131328 Len=0 TSval=1044073947 TSecr=157458815
 10   0.087166 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59366 → 8080 [ACK] Seq=50 Ack=130 Win=131328 Len=0 TSval=1044073947 TSecr=157458816
 11   0.101217 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59366 → 8080 [FIN, ACK] Seq=50 Ack=130 Win=131328 Len=0 TSval=1044073961 TSecr=157458816
 12   0.137349 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59366 [RST] Seq=130 Win=0 Len=0
```

Notice, packet 6, we have `CONNECT 2620:10d:c081:b:0:0:0:26:443`. This is invalid.

The diff should fix this by adding brackets if there is none. 

here is the tshark output of the same script:

```
Capturing on 'utun1'
  1   0.000000 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [SYN] Seq=0 Win=65535 Len=0 MSS=1340 WS=32 TSval=1044108399 TSecr=0 SACK_PERM=1
  2   0.044588 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [SYN, ACK] Seq=0 Ack=1 Win=28560 Len=0 MSS=1340 SACK_PERM=1 TSval=157493678 TSecr=1044108399 WS=256
  3   0.044698 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=1 Ack=1 Win=131456 Len=0 TSval=1044108443 TSecr=157493678
  4   0.044815 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  [TCP segment of a reassembled PDU]
  5   0.098407 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [ACK] Seq=1 Ack=50 Win=28672 Len=0 TSval=157493733 TSecr=1044108443
  6   0.098495 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 HTTP  CONNECT [2620:10d:c081:b:0:0:0:26]:443 HTTP/1.0
  7   0.140417 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [ACK] Seq=1 Ack=52 Win=28672 Len=0 TSval=157493774 TSecr=1044108495
  8   0.140502 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 HTTP  HTTP/1.0 200 Connection established
  9   0.140591 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=52 Ack=270 Win=131200 Len=0 TSval=1044108534 TSecr=157493775
 10   0.151764 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [PSH, ACK] Seq=52 Ack=270 Win=131200 Len=517 TSval=1044108545 TSecr=157493775
 11   0.213243 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [ACK] Seq=270 Ack=569 Win=29696 Len=1328 TSval=157493846 TSecr=1044108545
 12   0.213388 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [ACK] Seq=1598 Ack=569 Win=29696 Len=1328 TSval=157493846 TSecr=1044108545
 13   0.213448 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=569 Ack=2926 Win=129728 Len=0 TSval=1044108605 TSecr=157493846
 14   0.213581 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [PSH, ACK] Seq=2926 Ack=569 Win=29696 Len=314 TSval=157493846 TSecr=1044108545
 15   0.213642 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=569 Ack=3240 Win=130464 Len=0 TSval=1044108605 TSecr=157493846
 16   0.214640 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [PSH, ACK] Seq=569 Ack=3240 Win=131072 Len=126 TSval=1044108606 TSecr=157493846
 17   0.258051 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [PSH, ACK] Seq=3240 Ack=695 Win=29696 Len=274 TSval=157493891 TSecr=1044108606
 18   0.258116 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=695 Ack=3514 Win=130784 Len=0 TSval=1044108648 TSecr=157493891
 19   0.258905 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [PSH, ACK] Seq=695 Ack=3514 Win=131072 Len=194 TSval=1044108648 TSecr=157493891
 20   0.304204 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [PSH, ACK] Seq=3514 Ack=889 Win=30720 Len=538 TSval=157493937 TSecr=1044108648
 21   0.304297 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=889 Ack=4052 Win=130528 Len=0 TSval=1044108693 TSecr=157493937
 22   0.307226 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [FIN, ACK] Seq=889 Ack=4052 Win=131072 Len=0 TSval=1044108695 TSecr=157493937
 23   0.350246 2401:db00:20:8065:beaf:0:19:0 -> 2620:10d:c081:1133::11b2 TCP  8080 → 59414 [FIN, ACK] Seq=4052 Ack=890 Win=30720 Len=0 TSval=157493983 TSecr=1044108695
 24   0.350318 2620:10d:c081:1133::11b2 -> 2401:db00:20:8065:beaf:0:19:0 TCP  59414 → 8080 [ACK] Seq=890 Ack=4053 Win=131072 Len=0 TSval=1044108736 TSecr=157493983
```