### PR TITLE
Fix compatibility for cookiejar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ dev (master)
 * Drain and release connection before recursing on retry/redirect.  Fixes
   deadlocks with a blocking connectionpool. (Issue #1167)
 
+* Fixed compatibility for cookiejar. (Issue #1229)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/test_compatibility.py
+++ b/test/test_compatibility.py
@@ -3,6 +3,8 @@ import warnings
 import pytest
 
 from urllib3.connection import HTTPConnection
+from urllib3.response import HTTPResponse
+from urllib3.packages.six.moves import http_cookiejar, urllib
 
 
 class TestVersionCompatibility(object):
@@ -22,3 +24,17 @@ class TestVersionCompatibility(object):
             HTTPConnection('localhost', 12345, source_address='127.0.0.1')
         except TypeError as e:
             pytest.fail('HTTPConnection raised TypeError on source_adddress: %r' % e)
+
+
+class TestCookiejar(object):
+    def test_extract(self):
+        request = urllib.request.Request('http://google.com')
+        cookiejar = http_cookiejar.CookieJar()
+        response = HTTPResponse()
+
+        cookies = ["sessionhash=abcabcabcabcab; path=/; HttpOnly",
+                   "lastvisit=1348253375; expires=Sat, 21-Sep-2050 18:49:35 GMT; path=/"]
+        for c in cookies:
+            response.headers.add('set-cookie', c)
+        cookiejar.extract_cookies(response, request)
+        assert len(cookiejar) == len(cookies)

--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -247,13 +247,15 @@ class HTTPHeaderDict(MutableMapping):
         for key, value in kwargs.items():
             self.add(key, value)
 
-    def getlist(self, key):
+    def getlist(self, key, default=__marker):
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
         try:
             vals = self._container[key.lower()]
         except KeyError:
-            return []
+            if default is self.__marker:
+                return []
+            return default
         else:
             return vals[1:]
 
@@ -261,6 +263,9 @@ class HTTPHeaderDict(MutableMapping):
     getheaders = getlist
     getallmatchingheaders = getlist
     iget = getlist
+
+    # Backwards compatibility for http.cookiejar
+    get_all = getlist
 
     def __repr__(self):
         return "%s(%s)" % (type(self).__name__, dict(self.itermerged()))

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -474,6 +474,10 @@ class HTTPResponse(io.IOBase):
     def getheader(self, name, default=None):
         return self.headers.get(name, default)
 
+    # Backwards compatibility for http.cookiejar
+    def info(self):
+        return self.headers
+
     # Overrides from io.IOBase
     def close(self):
         if not self.closed:


### PR DESCRIPTION
py3 cookiejar expects `get_all()` from header objects and `info()` from response objects. This PR adds the necessary compatibility methods and a test for that in `test_compatibility`. `getlist()` needs to get a default argument, to serve as a dropin for the required `get_all()`. I opted for extending `getlist` instead of reinventing the wheel by creating a separate `get_all`, not sure if you agree here.