### PR TITLE
Use vendored version of ``six`` in pyopenssl.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ dev (master)
 
 * Fixed compatibility for cookiejar. (Issue #1229)
 
+* pyopenssl: Use vendored version of ``six``.
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ dev (master)
 
 * Fixed compatibility for cookiejar. (Issue #1229)
 
-* pyopenssl: Use vendored version of ``six``.
+* pyopenssl: Use vendored version of ``six``. (Issue #1231)
 
 * ... [Short description of non-trivial change.] (Issue #)
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -230,5 +230,8 @@ In chronological order:
 * Tuukka Mustonen <tuukka.mustonen@gmail.com>
   * Add counter for status_forcelist retries.
 
+* Erik Rose <erik@mozilla.com>
+  * Bugfix to pyopenssl vendoring
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/contrib/pyopenssl.py
+++ b/urllib3/contrib/pyopenssl.py
@@ -59,7 +59,7 @@ except ImportError:  # Platform-specific: Python 3
 
 import logging
 import ssl
-import six
+from ..packages import six
 import sys
 
 from .. import util


### PR DESCRIPTION
Fixes import errors like https://github.com/certbot/certbot/issues/4886 when importing `requests`. Everywhere else in `contrib` vendors properly; it looks like we just missed a spot.

If this looks good, could we please have a 1.21.2 release soon so Let's Encrypt doesn't have to work around this in a zillion OS packages? I expect this problem is widespread, since any import of `requests` without a suitable `six` also installed could trigger it. [pip may even be hitting it](https://github.com/certbot/certbot/issues/2902), though I haven't dug into that deeply. Many thanks!