### PR TITLE
Release connection on chunked HEAD response.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 dev (master)
 ------------
 
+* Put the connection back in the pool when calling stream() or read_chunked() on
+  a chunked HEAD response. (Issue #1234)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -588,12 +588,12 @@ class HTTPResponse(io.IOBase):
                 "Body should be httplib.HTTPResponse like. "
                 "It should have have an fp attribute which returns raw chunks.")
 
-        # Don't bother reading the body of a HEAD request.
-        if self._original_response and is_response_to_head(self._original_response):
-            self._original_response.close()
-            return
-
         with self._error_catcher():
+            # Don't bother reading the body of a HEAD request.
+            if self._original_response and is_response_to_head(self._original_response):
+                self._original_response.close()
+                return
+
             while True:
                 self._update_chunk_length()
                 if self.chunk_left == 0:


### PR DESCRIPTION
AWS S3 servers set "Transfer-Encoding: chunked" even for a HEAD
response, which results in urllib3 not returning the connection to the
pool after calling stream() or read_chunked().

The patch moves the HEAD request check into the error_catcher context
manager, which ensures to release the connection to the pool upon
completion.

Fixes #1234