### PR TITLE
Add 'other' counter

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -228,7 +228,7 @@ In chronological order:
   * Stop buffering entire deflate-encoded responses.
 
 * Tuukka Mustonen <tuukka.mustonen@gmail.com>
-  * Add counter for status_forcelist retries.
+  * Add 'status' and 'other' counters.
 
 * Erik Rose <erik@mozilla.com>
   * Bugfix to pyopenssl vendoring


### PR DESCRIPTION
Similar to https://github.com/shazow/urllib3/issues/1147, would you be willing to merge this?

Honestly, I'm no longer sure this makes sense. My original goal was to retry different sorts of errors (read, connect, status) once each, the idea being something like: "it's not worth retrying connect timeout multiple times - if it doesn't answer right away, it probably doesn't answer after 5 retries..." but at the same time "let's allow retrying _different_ types or errors on the same go, because maybe proxy just disconnected us, and after re-initializing connection it might throw timeout, that we can also retry once"...

And actually, `ProxyError` (for example) doesn't fall into any category currently, so `other` counter would catch that. However, there are gazillions of potential exceptions in `requests.exceptions`, and this will regard all of them as one, so my idea doesn't quite realize here. Thus, I wonder if this makes any sense...

In the end, it doesn't really do any harm if I just `Retry(3)`... maybe not perfect, but it works and is more flexible...