### PR TITLE
fix failing tests on windows python (64 bits) 2.7 and 2.6 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,17 @@ env:
     - PYTHONWARNINGS=always::DeprecationWarning
   matrix:
     - TOXENV=flake8-py3
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=py34
     - TOXENV=gae
     - TOXENV=docs
 # https://github.com/travis-ci/travis-ci/issues/4794
 matrix:
   include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 dev (master)
 ------------
 
+* Fix ``util.selectors._fileobj_to_fd`` to accept ``long`` (Issue #1247).
+
 * Dropped Python 3.3 support. (Pull #1242)
 
 * Put the connection back in the pool when calling stream() or read_chunked() on

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -239,5 +239,9 @@ In chronological order:
 * Mike Miller <github@mikeage.net>
   * Logging improvements to include the HTTP(S) port when opening a new connection
 
+* Ioannis Tziakos <mail@itziakos.gr>
+  * Fix ``util.selectors._fileobj_to_fd`` to accept ``long``.
+  * Update appveyor tox setup to use the 64bit python.
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,44 @@
 # AppVeyor.yml from https://github.com/ogrisel/python-appveyor-demo
 # License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
 
+skip_branch_with_pr: true
 build: off
 
 environment:
+
   matrix:
-    - PYTHON: "C:\\Python266-x64"
-      PYTHON_VERSION: "2.6.6"
+    - PYTHON: "C:\\Python26-x64"
+      PYTHON_VERSION: "2.6.x"
       PYTHON_ARCH: "64"
       TOXENV: "py26"
+      TOXPY26: "%PYTHON%\\python.exe"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       TOXENV: "py27"
+      TOXPY27: "%PYTHON%\\python.exe"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
       TOXENV: "py34"
+      TOXPY34: "%PYTHON%\\python.exe"
 
     - PYTHON: "C:\\Python35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
       TOXENV: "py35"
+      TOXPY35: "%PYTHON%\\python.exe"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       TOXENV: "py36"
+      TOXPY36: "%PYTHON%\\python.exe"
+
+cache:
+  - C:\Users\appveyor\AppData\Local\pip\Cache
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when
@@ -38,23 +48,21 @@ install:
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
 
   # Check that we have the expected version and architecture for Python
-  - "python --version"
-  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - python --version
+  - python -c "import struct; print(struct.calcsize('P') * 8)"
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
-  - "pip install tox"
-
-  - "python setup.py install"
+  - pip install --disable-pip-version-check --user --upgrade pip wheel
+  - pip install tox virtualenv
 
 test_script:
-  - "tox"
+  - tox
 
 on_success:
-  - ".tox\\%TOXENV%\\Scripts\\activate"
-  - "pip install codecov"
-  - "codecov --env PLATFORM,TOXENV"
+  - .tox/%TOXENV%/Scripts/activate.bat
+  - pip install codecov
+  - codecov --env PLATFORM,TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,19 @@
 envlist = flake8-py3, py26, py27, py34, py35, py36, pypy
 
 [testenv]
+basepython =
+    py26: {env:TOXPY26:python2.6}
+    py27: {env:TOXPY27:python2.7}
+    py34: {env:TOXPY34:python3.4}
+    py35: {env:TOXPY35:python3.5}
+    py36: {env:TOXPY36:python3.6}
+    pypy: {env:TOXPYPY:pypy}
 deps= -r{toxinidir}/dev-requirements.txt
 commands=
+    # Print out the python version and bitness
+    pip --version
+    python --version
+    python -c "import struct; print(struct.calcsize('P') * 8)"
     pip install .[socks,secure]
     py.test --cov urllib3 test
 setenv =

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -12,11 +12,13 @@ import socket
 import sys
 import time
 from collections import namedtuple, Mapping
+from ..packages.six import integer_types
 
 try:
     monotonic = time.monotonic
 except (AttributeError, ImportError):  # Python 3.3<
     monotonic = time.time
+
 
 EVENT_READ = (1 << 0)
 EVENT_WRITE = (1 << 1)
@@ -41,7 +43,7 @@ class SelectorError(Exception):
 def _fileobj_to_fd(fileobj):
     """ Return a file descriptor from a file object. If
     given an integer will simply return that integer back. """
-    if isinstance(fileobj, int):
+    if isinstance(fileobj, integer_types):
         fd = fileobj
     else:
         try:


### PR DESCRIPTION
This PR updates the selectors code to better support python 2.6 and 2.7 (64bit). fixes #1247 


in more detail:

- Update tox.ini and appveyor.yml to use the python defined by the TOXPY** environment variable (when defined).
- Update the `util.selectors._fileobj_to_fd` to accept a `long` value. 
- Various appveyor improvements:
   - (speedup) No need to install python 2.6.6, appveyor already has the desired version.
   - (speedup) Cache wheels 
   - (speedup) No need to install urllib on parent python.
   - Do not run test builds on a branch when it is part of a pull request.
