### PR TITLE
Add port to connection open print if it's non standard (not 80 or 443)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ dev (master)
 * Fixed pyOpenSSL-specific ssl client authentication issue when clients
   attempted to auth via certificate + chain (Issue #1060)
 
+* Add the port to the connectionpool connect print (Pull #1251)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -236,5 +236,8 @@ In chronological order:
 * Wolfgang Richter <wolfgang.richter@gmail.com>
   * Bugfix related to loading full certificate chains with PyOpenSSL backend.
 
+* Mike Miller <github@mikeage.net>
+  * Logging improvements to include the HTTP(S) port when opening a new connection
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -204,8 +204,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`HTTPConnection`.
         """
         self.num_connections += 1
-        log.debug("Starting new HTTP connection (%d): %s",
-                  self.num_connections, self.host)
+        log.debug("Starting new HTTP connection (%d): %s%s",
+                  self.num_connections, self.host,
+                  ":%s" % self.port if (self.port and self.port != 80) else "")
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
                                   timeout=self.timeout.connect_timeout,
@@ -820,8 +821,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.debug("Starting new HTTPS connection (%d): %s",
-                  self.num_connections, self.host)
+        log.debug("Starting new HTTPS connection (%d): %s%s",
+                  self.num_connections, self.host,
+                  ":%s" % self.port if (self.port and self.port != 443) else "")
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:
             raise SSLError("Can't connect to HTTPS URL because the SSL "

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -205,8 +205,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         """
         self.num_connections += 1
         log.debug("Starting new HTTP connection (%d): %s:%s",
-                  self.num_connections, self.host,
-                  self.port if self.port else "80")
+                  self.num_connections, self.host, self.port or "80")
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
                                   timeout=self.timeout.connect_timeout,
@@ -822,8 +821,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         """
         self.num_connections += 1
         log.debug("Starting new HTTPS connection (%d): %s:%s",
-                  self.num_connections, self.host,
-                  self.port if self.port else "443")
+                  self.num_connections, self.host, self.port or "443")
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:
             raise SSLError("Can't connect to HTTPS URL because the SSL "

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -204,9 +204,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`HTTPConnection`.
         """
         self.num_connections += 1
-        log.debug("Starting new HTTP connection (%d): %s%s",
+        log.debug("Starting new HTTP connection (%d): %s:%s",
                   self.num_connections, self.host,
-                  ":%s" % self.port if (self.port and self.port != 80) else "")
+                  self.port if self.port else "80")
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
                                   timeout=self.timeout.connect_timeout,
@@ -821,9 +821,9 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.debug("Starting new HTTPS connection (%d): %s%s",
+        log.debug("Starting new HTTPS connection (%d): %s:%s",
                   self.num_connections, self.host,
-                  ":%s" % self.port if (self.port and self.port != 443) else "")
+                  self.port if self.port else "443")
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:
             raise SSLError("Can't connect to HTTPS URL because the SSL "


### PR DESCRIPTION
I do quite a lot of work with HTTP tunnels, and so the URL / IP I connect to is almost never enough to identify which endpoint I'm actually trying to reach. This commit adds the port, if it's not standard (80 for HTTP, 443 for HTTPS)