### PR TITLE
Use FQDN only for DNS and drop trailing dot for other operations

### DIFF
--- a/dummyserver/testcase.py
+++ b/dummyserver/testcase.py
@@ -76,6 +76,23 @@ class SocketDummyServerTestCase(unittest.TestCase):
         if hasattr(cls, 'server_thread'):
             cls.server_thread.join(0.1)
 
+    def assert_header_received(
+        self,
+        received_headers,
+        header_name,
+        expected_value=None
+    ):
+        header_name = header_name.encode('ascii')
+        if expected_value is not None:
+            expected_value = expected_value.encode('ascii')
+        header_titles = []
+        for header in received_headers:
+            key, value = header.split(b': ')
+            header_titles.append(key)
+            if key == header_name and expected_value is not None:
+                self.assertEqual(value, expected_value)
+        self.assertIn(header_name, header_titles)
+
 
 class IPV4SocketDummyServerTestCase(SocketDummyServerTestCase):
     @classmethod

--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -118,6 +118,7 @@ class TestConnectionPool(object):
         ('google.com', 'https://google.com/'),
         ('yahoo.com', 'http://google.com/'),
         ('google.com', 'https://google.net/'),
+        ('google.com', 'http://google.com./'),
     ])
     def test_not_same_host_no_port_http(self, a, b):
         with HTTPConnectionPool(a) as c:
@@ -130,6 +131,7 @@ class TestConnectionPool(object):
         ('google.com', 'http://google.com/'),
         ('yahoo.com', 'https://google.com/'),
         ('google.com', 'https://google.net/'),
+        ('google.com', 'https://google.com./'),
     ])
     def test_not_same_host_no_port_https(self, a, b):
         with HTTPSConnectionPool(a) as c:

--- a/test/test_poolmanager.py
+++ b/test/test_poolmanager.py
@@ -31,6 +31,14 @@ class TestPoolManager(object):
 
         assert conn1 == conn2
 
+        # Ensure that FQDNs are handled separately from relative domains
+        p = PoolManager(2)
+
+        conn1 = p.connection_from_url('http://localhost.:8081/foo')
+        conn2 = p.connection_from_url('http://localhost:8081/bar')
+
+        assert conn1 != conn2
+
     def test_many_urls(self):
         urls = [
             "http://localhost:8081/foo",

--- a/test/with_dummyserver/test_https.py
+++ b/test/with_dummyserver/test_https.py
@@ -65,6 +65,11 @@ class TestHTTPS(HTTPSDummyServerTestCase):
         r = self._pool.request('GET', '/')
         self.assertEqual(r.status, 200, r.data)
 
+    def test_dotted_fqdn(self):
+        pool = HTTPSConnectionPool(self.host + '.', self.port)
+        r = pool.request('GET', '/')
+        self.assertEqual(r.status, 200, r.data)
+
     def test_set_ssl_version_to_tlsv1(self):
         self._pool.ssl_version = ssl.PROTOCOL_TLSv1
         r = self._pool.request('GET', '/')

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1225,6 +1225,37 @@ class TestHeaders(SocketDummyServerTestCase):
         pool.request('GET', '/', headers=OrderedDict(expected_request_headers))
         self.assertEqual(expected_request_headers, actual_request_headers)
 
+    def test_request_host_header_ignores_fqdn_dot(self):
+
+        received_headers = []
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            buf = b''
+            while not buf.endswith(b'\r\n\r\n'):
+                buf += sock.recv(65536)
+
+            for header in buf.split(b'\r\n')[1:]:
+                if header:
+                    received_headers.append(header)
+
+            sock.send((
+                u'HTTP/1.1 204 No Content\r\n'
+                u'Content-Length: 0\r\n'
+                u'\r\n').encode('ascii'))
+
+            sock.close()
+
+        self._start_server(socket_handler)
+
+        pool = HTTPConnectionPool(self.host + '.', self.port, retries=False)
+        self.addCleanup(pool.close)
+        pool.request('GET', '/')
+        self.assert_header_received(
+            received_headers, 'Host', '%s:%s' % (self.host, self.port)
+        )
+
     def test_response_headers_are_returned_in_the_original_order(self):
         # NOTE: Probability this test gives a false negative is 1/(K!)
         K = 16


### PR DESCRIPTION
Fixes #1254.