### PR TITLE
Fix dummyserver decode errors when defaults are used with Python 3

### DIFF
--- a/dummyserver/handlers.py
+++ b/dummyserver/handlers.py
@@ -142,8 +142,8 @@ class TestingApp(RequestHandler):
     def upload(self, request):
         "Confirm that the uploaded file conforms to specification"
         # FIXME: This is a huge broken mess
-        param = request.params.get('upload_param', 'myfile').decode('ascii')
-        filename = request.params.get('upload_filename', '').decode('utf-8')
+        param = request.params.get('upload_param', b'myfile').decode('ascii')
+        filename = request.params.get('upload_filename', b'').decode('utf-8')
         size = int(request.params.get('upload_size', '0'))
         files_ = request.files.get(param)
 
@@ -179,7 +179,7 @@ class TestingApp(RequestHandler):
 
     def multi_redirect(self, request):
         "Performs a redirect chain based on ``redirect_codes``"
-        codes = request.params.get('redirect_codes', '200').decode('utf-8')
+        codes = request.params.get('redirect_codes', b'200').decode('utf-8')
         head, tail = codes.split(',', 1) if "," in codes else (codes, None)
         status = "{0} {1}".format(head, responses[int(head)])
         if not tail:
@@ -281,7 +281,7 @@ class TestingApp(RequestHandler):
 
     def retry_after(self, request):
         if datetime.now() - self.application.last_req < timedelta(seconds=1):
-            status = request.params.get("status", "429 Too Many Requests")
+            status = request.params.get("status", b"429 Too Many Requests")
             return Response(
                     status=status.decode('utf-8'),
                     headers=[('Retry-After', '1')])


### PR DESCRIPTION
Fixes issue https://github.com/shazow/urllib3/issues/1258
I searched for any usage of request.params.get() followed by a decode on the value.

A better version of a small part of PR https://github.com/shazow/urllib3/pull/1257 with some extra fixes.