### PR TITLE
Pass {posargs} to py.test so arguments can be passed through tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands=
     python --version
     python -c "import struct; print(struct.calcsize('P') * 8)"
     pip install .[socks,secure]
-    py.test --cov urllib3 test
+    py.test --cov urllib3 test {posargs}
 setenv =
     PYTHONWARNINGS=always::DeprecationWarning
 passenv = CFLAGS LDFLAGS TRAVIS APPVEYOR CRYPTOGRAPHY_OSX_NO_LINK_FLAGS


### PR DESCRIPTION
From PR https://github.com/shazow/urllib3/pull/1257
Fixes issue https://github.com/shazow/urllib3/issues/1260

Allows for arguments to passed through tox to py.test so, for instance, individual tests can be run:
```
tox -e py36 -- -k 'test_poolmanager or test_connectionpool'
```