### PR TITLE
lazily load uuid lib only where needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ dev (master)
 
 * Add the port to the connectionpool connect print (Pull #1251)
 
+* Lazily load `uuid` to boost performance on imports (Pull #1270)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/urllib3/filepost.py
+++ b/urllib3/filepost.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import codecs
 
-from uuid import uuid4
 from io import BytesIO
 
 from .packages import six
@@ -14,7 +13,15 @@ writer = codecs.lookup('utf-8')[3]
 def choose_boundary():
     """
     Our embarrassingly-simple replacement for mimetools.choose_boundary.
+
+    We are lazily loading uuid here, because we don't want its issues
+
+    https://bugs.python.org/issue5885
+    https://bugs.python.org/issue11063
+
+    to affect our entire library.
     """
+    from uuid import uuid4
     return uuid4().hex
 
 


### PR DESCRIPTION
This should address issues such as https://github.com/requests/requests/issues/3213 in downstream libraries.