### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ max-line-length=99
 universal = 1
 
 [metadata]
+license_file = LICENSE.txt
 provides-extra =
     secure
     socks


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file