### PR TITLE
Prevent AttributeError to be raised when pool is already None

### DIFF
--- a/test/test_connectionpool.py
+++ b/test/test_connectionpool.py
@@ -249,6 +249,23 @@ class TestConnectionPool(object):
         with pytest.raises(Empty):
             old_pool_queue.get(block=False)
 
+    def test_pool_close_twice(self):
+        pool = connection_from_url('http://google.com:80')
+
+        # Populate with some connections
+        conn1 = pool._get_conn()
+        conn2 = pool._get_conn()
+        pool._put_conn(conn1)
+        pool._put_conn(conn2)
+
+        pool.close()
+        assert pool.pool is None
+
+        try:
+            pool.close()
+        except AttributeError:
+            pytest.fail("Pool of the ConnectionPool is None and has no attribute get.")
+
     def test_pool_timeouts(self):
         with HTTPConnectionPool(host='localhost') as pool:
             conn = pool._new_conn()

--- a/urllib3/connectionpool.py
+++ b/urllib3/connectionpool.py
@@ -411,6 +411,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         """
         Close all pooled connections and disable the pool.
         """
+        if self.pool is None:
+            return
         # Disable access to the pool
         old_pool, self.pool = self.pool, None
 


### PR DESCRIPTION
Calling close() multiple times will not result into an error now.