### PR TITLE
Provide _original_response in AppEngine adapter

### DIFF
--- a/test/test_response.py
+++ b/test/test_response.py
@@ -216,10 +216,12 @@ class TestResponse(object):
                 assert not resp.closed
                 assert not resp._fp.isclosed()
                 assert not is_fp_closed(resp._fp)
+                assert not resp.isclosed()
                 resp.read()
                 assert resp.closed
                 assert resp._fp.isclosed()
                 assert is_fp_closed(resp._fp)
+                assert resp.isclosed()
         finally:
             hlr.close()
 

--- a/urllib3/contrib/appengine.py
+++ b/urllib3/contrib/appengine.py
@@ -236,12 +236,21 @@ class AppEngineManager(RequestMethods):
             encodings.remove('chunked')
             urlfetch_resp.headers['transfer-encoding'] = ','.join(encodings)
 
-        return HTTPResponse(
+        original_response = HTTPResponse(
             # In order for decoding to work, we must present the content as
             # a file-like object.
             body=BytesIO(urlfetch_resp.content),
+            msg=urlfetch_resp.header_msg,
             headers=urlfetch_resp.headers,
             status=urlfetch_resp.status_code,
+            **response_kw
+        )
+
+        return HTTPResponse(
+            body=BytesIO(urlfetch_resp.content),
+            headers=urlfetch_resp.headers,
+            status=urlfetch_resp.status_code,
+            original_response=original_response,
             **response_kw
         )
 

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -112,7 +112,7 @@ class HTTPResponse(io.IOBase):
 
     def __init__(self, body='', headers=None, status=0, version=0, reason=None,
                  strict=0, preload_content=True, decode_content=True,
-                 original_response=None, pool=None, connection=None,
+                 original_response=None, pool=None, connection=None, msg=None,
                  retries=None, enforce_content_length=False, request_method=None):
 
         if isinstance(headers, HTTPHeaderDict):
@@ -132,6 +132,7 @@ class HTTPResponse(io.IOBase):
         self._fp = None
         self._original_response = original_response
         self._fp_bytes_read = 0
+        self.msg = msg
 
         if body and isinstance(body, (basestring, binary_type)):
             self._body = body
@@ -190,6 +191,9 @@ class HTTPResponse(io.IOBase):
     @property
     def connection(self):
         return self._connection
+
+    def isclosed(self):
+        return is_fp_closed(self._fp)
 
     def tell(self):
         """


### PR DESCRIPTION
_original_response is missing from the AppEngine adapter this breaks many flows like cookie parsing. This is an attempt to fix this issue.