### PR TITLE
Simplify tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,6 @@
 envlist = flake8-py3, py26, py27, py34, py35, py36, pypy
 
 [testenv]
-basepython =
-    py26: {env:TOXPY26:python2.6}
-    py27: {env:TOXPY27:python2.7}
-    py34: {env:TOXPY34:python3.4}
-    py35: {env:TOXPY35:python3.5}
-    py36: {env:TOXPY36:python3.6}
-    pypy: {env:TOXPYPY:pypy}
 deps= -r{toxinidir}/dev-requirements.txt
 commands=
     # Print out the python version and bitness


### PR DESCRIPTION
tox sets good defaults for the `basepython` value. Simply use that instead of respecifying it. Helps to slightly simplify the configuration by removing repetitive boilerplate.

For details, see tox documentation:

https://tox.readthedocs.io/en/latest/config.html#factors-and-factor-conditional-settings

> tox provides good defaults for basepython setting, so the above ini-file can be further reduced by omitting the basepython setting.