### PR TITLE
Fix uses of deprecated assertEquals() to use assertEqual() instead

### DIFF
--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -1000,7 +1000,7 @@ class TestRetryPoolSize(HTTPDummyServerTestCase):
 
     def test_pool_size_retry(self):
         self.pool.urlopen('GET', '/not_found', preload_content=False)
-        self.assertEquals(self.pool.num_connections, 1)
+        assert self.pool.num_connections == 1
 
 
 class TestRedirectPoolSize(HTTPDummyServerTestCase):
@@ -1017,7 +1017,7 @@ class TestRedirectPoolSize(HTTPDummyServerTestCase):
 
     def test_pool_size_redirect(self):
         self.pool.urlopen('GET', '/redirect', preload_content=False)
-        self.assertEquals(self.pool.num_connections, 1)
+        assert self.pool.num_connections == 1
 
 
 if __name__ == '__main__':

--- a/test/with_dummyserver/test_socketlevel.py
+++ b/test/with_dummyserver/test_socketlevel.py
@@ -1468,4 +1468,4 @@ class TestRetryPoolSizeDrainFail(SocketDummyServerTestCase):
         self.addCleanup(pool.close)
 
         pool.urlopen('GET', '/not_found', preload_content=False)
-        self.assertEquals(pool.num_connections, 1)
+        assert pool.num_connections == 1


### PR DESCRIPTION
When running tests with Python warnings enabled, fixes warnings of the form:

```
DeprecationWarning: Please use assertEqual instead.
```

For a full list of deprecated test functions, see:

https://docs.python.org/3/library/unittest.html#deprecated-aliases