### PR TITLE
Use pyenv to install all versions of Python for macOS; update Python3 versions

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -22,24 +22,24 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv global 2.6.9
             ;;
         py27)
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python get-pip.py --user
+            pyenv install 2.7.14
+            pyenv global 2.7.14
             ;;
         py33)
             pyenv install 3.3.6
             pyenv global 3.3.6
             ;;
         py34)
-            pyenv install 3.4.5
-            pyenv global 3.4.5
+            pyenv install 3.4.7
+            pyenv global 3.4.7
             ;;
         py35)
-            pyenv install 3.5.2
-            pyenv global 3.5.2
+            pyenv install 3.5.4
+            pyenv global 3.5.4
             ;;
         py36)
-            pyenv install 3.6.0
-            pyenv global 3.6.0
+            pyenv install 3.6.3
+            pyenv global 3.6.3
             ;;
         pypy*)
             pyenv install "pypy-5.4.1"


### PR DESCRIPTION
Currently, our macOS tests for Python 2.7 expect a version of Python 2.7 to already be installed, and then install pip. However, for whatever reason, this currently appears to be failing. To fix this issue and avoid the same class of issue going forward (where different versions behave differently under testing), this change updates the test suite to explicitly install Python 2.7 (including pip) with pyenv, as we already do for other versions.

This change also updates the versions of Python 3 to test with macOS to their respective newest revisions.