### PR TITLE
Add Akamai as a sponsor; update sponsorship text to include time-based contributions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -243,5 +243,8 @@ In chronological order:
   * Fix ``util.selectors._fileobj_to_fd`` to accept ``long``.
   * Update appveyor tox setup to use the 64bit python.
 
+* Akamai (through Jesse Shapiro) <jshapiro@akamai.com>
+  * Ongoing maintenance
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ urllib3 is powerful and easy to use::
     >>> r.data
     'User-agent: *\nDisallow: /deny\n'
 
+
 Installing
 ----------
 
@@ -75,6 +76,7 @@ urllib3 happily accepts contributions. Please see our
 `contributing documentation <https://urllib3.readthedocs.io/en/latest/contributing.html>`_
 for some tips on getting started.
 
+
 Maintainers
 -----------
 
@@ -84,6 +86,7 @@ Maintainers
 - `@shazow <https://github.com/shazow>`_ (Andrey Petrov)
 
 👋
+
 
 Sponsorship
 -----------

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ for some tips on getting started.
 Maintainers
 -----------
 
+- `@haikuginger <https://github.com/haikuginger>`_ (Jesse Shapiro)
 - `@lukasa <https://github.com/lukasa>`_ (Cory Benfield)
 - `@sigmavirus24 <https://github.com/sigmavirus24>`_ (Ian Cordasco)
 - `@shazow <https://github.com/shazow>`_ (Andrey Petrov)
@@ -92,4 +93,5 @@ development <https://urllib3.readthedocs.io/en/latest/contributing.html#sponsors
 
 Sponsors include:
 
+- Akamai (2017-present), sponsors `@haikuginger <https://github.com/haikuginger>`_'s work on an ongoing basis
 - Hewlett Packard Enterprise (2016-2017), sponsored `@Lukasa’s <https://github.com/Lukasa>`_ work on urllib3

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -62,6 +62,10 @@ We welcome your patronage on `Bountysource <https://www.bountysource.com/teams/u
 Your contribution will go towards adding new features to urllib3 and making
 sure all functionality continues to meet our high quality standards.
 
+We also welcome sponsorship in the form of time. We greatly appreciate companies
+who encourage employees to contribute on an ongoing basis during their work hours.
+Please let us know and we'll be glad to add you to our sponsors list!
+
 
 Project Grant
 -------------


### PR DESCRIPTION
This change adds @haikuginger as a maintainer, calls Akamai out as a sponsor of @haikuginger's time, and specifically mentions allowing employee time to work on urllib3 as a form of a contribution a company can make.