### PR TITLE
Don't send IP address as SNI.

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -25,6 +25,7 @@ from urllib3.util.ssl_ import (
     resolve_ssl_version,
     ssl_wrap_socket,
     _const_compare_digest_backport,
+    _is_ip_address
 )
 from urllib3.exceptions import (
     LocationParseError,
@@ -575,3 +576,12 @@ class TestUtil(object):
     def test_assert_header_parsing_throws_typeerror_with_non_headers(self, headers):
         with pytest.raises(TypeError):
             assert_header_parsing(headers)
+
+    def test_is_ip_address(self):
+        assert _is_ip_address(None) is False
+        assert _is_ip_address("127.0.0.1") is True
+        assert _is_ip_address("127.0.0") is True
+        assert _is_ip_address("127.0.0") is True
+        assert _is_ip_address("fd99:f17b:37d0::100") is True
+        assert _is_ip_address("fd99:f17b:37d0:") is False
+        assert _is_ip_address("google.com") is False

--- a/urllib3/util/ssl_.py
+++ b/urllib3/util/ssl_.py
@@ -279,6 +279,23 @@ def create_urllib3_context(ssl_version=None, cert_reqs=None,
     return context
 
 
+def _is_ip_address(input_str):
+    if input_str is None:
+        return False
+
+    import socket
+    try:
+        socket.inet_aton(input_str)
+        return True
+    except socket.error:
+        try:
+            socket.inet_pton(socket.AF_INET6, input_str)
+            return True
+        except socket.error:
+            pass
+    return False
+    
+
 def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
                     ca_certs=None, server_hostname=None,
                     ssl_version=None, ciphers=None, ssl_context=None,
@@ -325,7 +342,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
 
     if certfile:
         context.load_cert_chain(certfile, keyfile)
-    if HAS_SNI:  # Platform-specific: OpenSSL with enabled SNI
+    if HAS_SNI and not _is_ip_address(server_hostname):  # Platform-specific: OpenSSL with enabled SNI
         return context.wrap_socket(sock, server_hostname=server_hostname)
 
     warnings.warn(


### PR DESCRIPTION
In RFC-6066 section-3, it was said that SNI is for host name not for IP
address. This code closes shazow/urllib3#1298 .