### PR TITLE
Move RECENT_DATE to 2017-06-30

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -246,5 +246,8 @@ In chronological order:
 * Akamai (through Jesse Shapiro) <jshapiro@akamai.com>
   * Ongoing maintenance
 
+* Dominique Leuenberger <dimstar@opensuse.org>
+  * Minor fixes in the test suite
+
 * [Your name or handle] <[email or website]>
   * [Brief summary of your changes]

--- a/urllib3/connection.py
+++ b/urllib3/connection.py
@@ -56,10 +56,11 @@ port_by_scheme = {
     'https': 443,
 }
 
-# When updating RECENT_DATE, move it to
-# within two years of the current date, and no
-# earlier than 6 months ago.
-RECENT_DATE = datetime.date(2016, 1, 1)
+# When updating RECENT_DATE, move it to within two years of the current date,
+# and not less than 6 months ago.
+# Example: if Today is 2018-01-01, then RECENT_DATE should be any date on or
+# after 2016-01-01 (today - 2 years) AND before 2017-07-01 (today - 6 months)
+RECENT_DATE = datetime.date(2017, 6, 30)
 
 
 class DummyConnection(object):


### PR DESCRIPTION
The test suite expects the current date to be no more than two years in the future
of RECENT_DATE, which just serves as a reference point.

Also clarify the comment about how to update RECENT_DATE

Fixes #1303