### PR TITLE
Begin testing against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,11 @@ matrix:
     - language: generic
       os: osx
       env: TOXENV=py36
+    - language: generic
+      os: osx
+      env: TOXENV=py37
   allow_failures:
   - python: pypy-5.4
   - python: 3.7-dev
+  - env: TOXENV=py37
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7-dev
+      env: TOXENV=py37
     - python: pypy-5.4
       env: TOXENV=pypy
     - language: generic
@@ -52,4 +54,5 @@ matrix:
       env: TOXENV=py36
   allow_failures:
   - python: pypy-5.4
+  - python: 3.7-dev
 sudo: false

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -44,6 +44,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         py37)
             pyenv install 3.7-dev
             pyenv global 3.7-dev
+            ;;
         pypy*)
             pyenv install "pypy-5.4.1"
             pyenv global "pypy-5.4.1"

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -41,6 +41,9 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv install 3.6.3
             pyenv global 3.6.3
             ;;
+        py37)
+            pyenv install 3.7-dev
+            pyenv global 3.7-dev
         pypy*)
             pyenv install "pypy-5.4.1"
             pyenv global "pypy-5.4.1"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8-py3, py26, py27, py34, py35, py36, pypy
+envlist = flake8-py3, py26, py27, py34, py35, py36, py37, pypy
 
 [testenv]
 deps= -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
Since Python 3.7 is starting to see alpha releases we should probably start testing against the `3.7-dev` stream in order to start catching issues.
It's marked as an `allow_failure` in Travis so that failures won't stop existing changes from being implemented.