### PR TITLE
Separate collections from collections.abc

### DIFF
--- a/urllib3/_collections.py
+++ b/urllib3/_collections.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
-from collections import Mapping, MutableMapping
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    from collections import Mapping, MutableMapping
 try:
     from threading import RLock
 except ImportError:  # Platform-specific: No threads available

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -11,8 +11,13 @@ import select
 import socket
 import sys
 import time
-from collections import namedtuple, Mapping
+from collections import namedtuple
 from ..packages.six import integer_types
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 try:
     monotonic = time.monotonic


### PR DESCRIPTION
In Python 3.7, there is a warning that the abstract bases in collections.abc will no longer be accessible through the regular collections module in Python 3.8.