### PR TITLE
Fix docstring in HTTPResponse

### DIFF
--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -113,9 +113,8 @@ class HTTPResponse(io.IOBase):
         If True, the response's body will be preloaded during construction.
 
     :param decode_content:
-        If True, attempts to decode specific content-encoding's based on headers
-        (like 'gzip' and 'deflate') will be skipped and raw data will be used
-        instead.
+        If True, will attempt to decode the body based on the
+        'content-encoding' header.
 
     :param original_response:
         When this HTTPResponse wrapper is generated from an httplib.HTTPResponse


### PR DESCRIPTION
In the HTTPResponse class, the previous `decode_content` docstring mentioned True, but actually described the False case.