### PR TITLE
Fix timeout kwarg _syscall_wrapper within selectors.py

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -49,6 +49,18 @@ def onlyPy26OrOlder(test):
     return wrapper
 
 
+def onlyPy34OrOlder(test):
+    """Skips this test unless you are on Python2.6.x or earlier."""
+
+    @functools.wraps(test)
+    def wrapper(*args, **kwargs):
+        msg = "{name} only runs on Python2.6.x or older".format(name=test.__name__)
+        if sys.version_info >= (3, 4):
+            pytest.skip(msg)
+        return test(*args, **kwargs)
+    return wrapper
+
+
 def onlyPy27OrNewer(test):
     """Skips this test unless you are on Python 2.7.x or later."""
 

--- a/urllib3/util/selectors.py
+++ b/urllib3/util/selectors.py
@@ -11,8 +11,13 @@ import select
 import socket
 import sys
 import time
-from collections import namedtuple, Mapping
+from collections import namedtuple
 from ..packages.six import integer_types
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 try:
     monotonic = time.monotonic


### PR DESCRIPTION
This PR fixes the issues with `urllib3/util/selectors.py` found in #1211 with selectors that has gone a bit stale.