### PR TITLE
Closed HTTPResponse.read_chunked() returns no chunks instead of exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ dev (master)
 
 * Lazily load `uuid` to boost performance on imports (Pull #1270)
 
+* ``read_chunked()`` on a closed response returns no chunks. (Issue #1088)
+
 * ... [Short description of non-trivial change.] (Issue #)
 
 

--- a/test/appengine/test_gae_manager.py
+++ b/test/appengine/test_gae_manager.py
@@ -106,6 +106,7 @@ class TestGAEConnectionManager(test_connectionpool.TestConnectionPool):
     test_stream_keepalive = None
     test_cleanup_on_connection_error = None
     test_read_chunked_short_circuit = None
+    test_read_chunked_on_closed_response = None
 
     # Tests that should likely be modified for appengine specific stuff
     test_timeout = None

--- a/test/appengine/test_gae_manager.py
+++ b/test/appengine/test_gae_manager.py
@@ -105,6 +105,7 @@ class TestGAEConnectionManager(test_connectionpool.TestConnectionPool):
     test_release_conn_parameter = None
     test_stream_keepalive = None
     test_cleanup_on_connection_error = None
+    test_read_chunked_short_circuit = None
 
     # Tests that should likely be modified for appengine specific stuff
     test_timeout = None

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -706,6 +706,16 @@ class TestConnectionPool(HTTPDummyServerTestCase):
         with pytest.raises(StopIteration):
             next(response.read_chunked())
 
+    def test_read_chunked_on_closed_response(self):
+        response = self.pool.request(
+            'GET',
+            '/chunked',
+            preload_content=False
+        )
+        response.close()
+        with pytest.raises(StopIteration):
+            next(response.read_chunked())
+
     def test_chunked_gzip(self):
         response = self.pool.request(
                 'GET',

--- a/test/with_dummyserver/test_connectionpool.py
+++ b/test/with_dummyserver/test_connectionpool.py
@@ -5,6 +5,7 @@ import sys
 import unittest
 import time
 import warnings
+import pytest
 
 import mock
 
@@ -694,6 +695,16 @@ class TestConnectionPool(HTTPDummyServerTestCase):
 
         self.assertEqual(self.pool.num_connections, 1)
         self.assertEqual(self.pool.num_requests, x)
+
+    def test_read_chunked_short_circuit(self):
+        response = self.pool.request(
+            'GET',
+            '/chunked',
+            preload_content=False
+        )
+        response.read()
+        with pytest.raises(StopIteration):
+            next(response.read_chunked())
 
     def test_chunked_gzip(self):
         response = self.pool.request(

--- a/urllib3/response.py
+++ b/urllib3/response.py
@@ -600,6 +600,11 @@ class HTTPResponse(io.IOBase):
         Similar to :meth:`HTTPResponse.read`, but with an additional
         parameter: ``decode_content``.
 
+        :param amt:
+            How much of the content to read. If specified, caching is skipped
+            because it doesn't make sense to cache partial content as the full
+            response.
+
         :param decode_content:
             If True, will attempt to decode the body based on the
             'content-encoding' header.
@@ -619,6 +624,11 @@ class HTTPResponse(io.IOBase):
             # Don't bother reading the body of a HEAD request.
             if self._original_response and is_response_to_head(self._original_response):
                 self._original_response.close()
+                return
+
+            # If a response is already read and closed
+            # then return immediately.
+            if self._fp.fp is None:
                 return
 
             while True:


### PR DESCRIPTION
Brings the behavior more in-line with `HTTPResponse.read()` and returns no chunks when the response object is already closed. Closes #1088.