### PR TITLE
Don't pin minor version of Python release

### DIFF
--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -18,28 +18,28 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 
     case "${TOXENV}" in
         py26)
-            pyenv install 2.6.9
-            pyenv global 2.6.9
+            pyenv install 2.6
+            pyenv global 2.6
             ;;
         py27)
-            pyenv install 2.7.14
-            pyenv global 2.7.14
+            pyenv install 2.7
+            pyenv global 2.7
             ;;
         py33)
-            pyenv install 3.3.6
-            pyenv global 3.3.6
+            pyenv install 3.3
+            pyenv global 3.3
             ;;
         py34)
-            pyenv install 3.4.7
-            pyenv global 3.4.7
+            pyenv install 3.4
+            pyenv global 3.4
             ;;
         py35)
-            pyenv install 3.5.4
-            pyenv global 3.5.4
+            pyenv install 3.5
+            pyenv global 3.5
             ;;
         py36)
-            pyenv install 3.6.3
-            pyenv global 3.6.3
+            pyenv install 3.6
+            pyenv global 3.6
             ;;
         py37)
             pyenv install 3.7-dev


### PR DESCRIPTION
Noticed we were testing against 3.6.3 instead of 3.6.4 on macOS builders and figured we'd rather have the latest release version for 3.6.x.

Another thought is if we're able to cache pyenv on macOS? My local installation of 3.6.4 under `~/.pyenv/versions/3.6.4/...` is 716KiB, well under [Travis' suggested limit of a "few hundred Megabytes"](https://docs.travis-ci.com/user/caching#How-does-the-caching-work%3F).